### PR TITLE
feat: enum 정의 및 글로벌 예외처리 추가

### DIFF
--- a/server/src/main/java/com/settleops/global/enums/Action.java
+++ b/server/src/main/java/com/settleops/global/enums/Action.java
@@ -1,0 +1,39 @@
+package com.settleops.global.enums;
+
+/**
+ * 시스템 전역 Action 표준 ENUM (Freeze 대상)<br>
+ *<br>
+ * - 로그, 이벤트, 감사(Audit), 배치 결과 기록에서 공통 사용<br>
+ * - 문서/코드/로그 문자열은 반드시 이 ENUM 이름과 100% 동일해야 함<br>
+ * - 대소문자 및 언더스코어 포함 변경 금지<br>
+ *<br>
+ * B 파트 표준 오너 관리 대상
+ */
+public enum Action {
+
+    // ===================== PAYMENT =====================
+    PAYMENT_CREATED,        // 결제 생성
+    PAYMENT_CAPTURED,       // 결제 캡처(승인 완료)
+    PAYMENT_CONFIRMED,      // 결제 확정
+
+    // ===================== BATCH =====================
+    BATCH_RUN_TRIGGERED,    // 배치 실행 트리거 발생
+    BATCH_RUN_SKIPPED,      // 배치 실행 스킵
+    BATCH_RUN_COMPLETED,    // 배치 실행 완료
+
+    // ===================== SETTLEMENT =====================
+    SETTLEMENT_CREATED,         // 정산 생성
+    SETTLEMENT_STATUS_CHANGED,  // 정산 상태 변경
+    SETTLEMENT_PAY_REQUESTED,   // 지급 요청
+    SETTLEMENT_PAY_APPROVED,    // 지급 승인
+
+    // ===================== HOLD =====================
+    HOLD_REQUESTED,     // 홀드 요청
+    HOLD_APPROVED,      // 홀드 승인
+    HOLD_RELEASED,      // 홀드 해제
+
+    // ===================== REFUND =====================
+    REFUND_REQUESTED,   // 환불 요청
+    REFUND_APPROVED,    // 환불 승인
+    REFUND_REJECTED     // 환불 거절
+}

--- a/server/src/main/java/com/settleops/global/enums/ReasonCode.java
+++ b/server/src/main/java/com/settleops/global/enums/ReasonCode.java
@@ -1,0 +1,47 @@
+package com.settleops.global.enums;
+
+/**
+ * MVP 고정 ReasonCode 목록 (LOCKED)
+ *
+ * - 409 Conflict 응답의 reason 코드로 사용
+ * - 문서 / 로그 / 예외 응답과 동일 문자열 유지 (SoT)
+ * - BUYER_MISMATCH는 403 전용이므로 본 ENUM에 포함하지 않음
+ */
+public enum ReasonCode {
+
+    /** 결제가 capture 되지 않은 상태 */
+    PAYMENT_NOT_CAPTURED,
+
+    /** 이미 환불이 존재하는 경우 */
+    REFUND_ALREADY_EXISTS,
+
+    /** Hold가 활성 상태 */
+    HOLD_ACTIVE,
+
+    /** Hold가 비활성 상태 */
+    HOLD_NOT_ACTIVE,
+
+    /** 환불 가능 금액이 부족함 */
+    INSUFFICIENT_REFUNDABLE,
+
+    /** 배치 실행 실패 */
+    BATCH_FAILED,
+
+    /** 정산이 아직 지급 가능 상태가 아님 */
+    SETTLEMENT_NOT_READY,
+
+    /** 지급 요청이 선행되어야 함 */
+    PAY_REQUESTED_REQUIRED,
+
+    /** 동일 승인자는 승인 불가 (이중 승인 방지) */
+    SAME_APPROVER_NOT_ALLOWED,
+
+    /** 이미 지급 완료된 상태 */
+    PAID_ALREADY,
+
+    /** 현재 처리 진행 중 */
+    IN_PROGRESS,
+
+    /** 환불 차감 정산이 아직 반영 대기 상태 */
+    REFUND_ADJUSTMENT_PENDING
+}

--- a/server/src/main/java/com/settleops/global/error/BusinessException.java
+++ b/server/src/main/java/com/settleops/global/error/BusinessException.java
@@ -1,0 +1,23 @@
+package com.settleops.global.error;
+
+import com.settleops.global.enums.ReasonCode;
+import org.springframework.http.HttpStatus;
+
+/** 최상위 비즈니스 추상 클래스 */
+public abstract class BusinessException extends RuntimeException{
+
+    private final HttpStatus status;
+
+    protected BusinessException(HttpStatus status, String message) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    // 에러 응답 변환 추상 메서드 (자식 구현)
+    public abstract ErrorResponse toErrorResponse();
+
+}

--- a/server/src/main/java/com/settleops/global/error/ConflictException.java
+++ b/server/src/main/java/com/settleops/global/error/ConflictException.java
@@ -1,0 +1,23 @@
+package com.settleops.global.error;
+
+import com.settleops.global.enums.ReasonCode;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 409 Conflict 전용 예외 <br>
+ * (ReasonCode 강제)
+ * */
+public class ConflictException extends BusinessException {
+    private final ReasonCode reasonCode;
+
+    public ConflictException(ReasonCode reasonCode, String message) {
+        super(HttpStatus.CONFLICT, message);
+        this.reasonCode = reasonCode;
+    }
+
+    @Override
+    public ErrorResponse toErrorResponse() {
+        // 기획서 409 포맷: code는 RULE_VIOLATION, reason은 필수
+        return ErrorResponse.ofRuleViolation(reasonCode, getMessage());
+    }
+}

--- a/server/src/main/java/com/settleops/global/error/ErrorResponse.java
+++ b/server/src/main/java/com/settleops/global/error/ErrorResponse.java
@@ -1,0 +1,57 @@
+package com.settleops.global.error;
+
+import com.settleops.global.enums.ReasonCode;
+import org.slf4j.MDC;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+/**
+ * 전역 에러 응답 표준 DTO (GlobalExceptionHandler 전용)
+ *
+ * <p>[HTTP 정책]</p>
+ * <p>409 Conflict → ReasonCode 필수 (reason != null)</p>
+ * <p>403 Forbidden → reason 사용 금지 (null 고정, BUYER_MISMATCH는 message로 처리)</p>
+ * <p>400 Bad Request → Validation 전용</p>
+ *
+ * <p>[규칙]</p>
+ * <p>- code는 정책상 고정 문자열 사용 (예: RULE_VIOLATION)</p>
+ * <p>- reason은 반드시 ReasonCode.name() 사용</p>
+ * <p>- 문자열 하드코딩 금지</p>
+ */
+
+public record ErrorResponse(
+        String code,          // RULE_VIOLATION 등
+        String reason,        // ReasonCode.name() (409 전용)
+        String message,        // 사용자 메시지
+        String requestId
+) {
+
+    private static final String RULE_VIOLATION = "RULE_VIOLATION";
+    private static final String FORBIDDEN = "FORBIDDEN";
+    private static final String BAD_REQUEST = "BAD_REQUEST";
+    private static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+
+    // 공통으로 requestId를 가져오는 프라이빗 메서드
+    private static String getTraceId() {
+        return MDC.get("requestId"); // RequestIdFilter에서 넣어준 키값 사용
+    }
+    // 기획서 0-2 정책: 409 Conflict 전용 정적 팩토리 메서드
+    public static ErrorResponse ofRuleViolation(ReasonCode reason, String message) {
+        return new ErrorResponse(RULE_VIOLATION, reason.name(), message, getTraceId());
+    }
+
+    // 403 Forbidden용 (reason은 무조건 null)
+    public static ErrorResponse ofForbidden(String message) {
+        return new ErrorResponse(FORBIDDEN, null, message, getTraceId());
+    }
+
+    // 400 Bad Request 또는 기타 4xx용
+    public static ErrorResponse ofBadRequest(String message) {
+        return new ErrorResponse(BAD_REQUEST, null, message, getTraceId());
+    }
+
+    // 500 Internal Server Error용
+    public static ErrorResponse ofInternalError(String message) {
+        return new ErrorResponse(INTERNAL_SERVER_ERROR, null, message, getTraceId());
+    }
+}

--- a/server/src/main/java/com/settleops/global/error/ForbiddenException.java
+++ b/server/src/main/java/com/settleops/global/error/ForbiddenException.java
@@ -1,0 +1,18 @@
+package com.settleops.global.error;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Forbidden 전용 예외
+ * */
+public class ForbiddenException extends BusinessException {
+    public ForbiddenException(String message) {
+        super(HttpStatus.FORBIDDEN, message);
+    }
+
+    @Override
+    public ErrorResponse toErrorResponse() {
+        // 기획서 403 정책: reason 사용 금지 (null 고정)
+        return ErrorResponse.ofForbidden(getMessage());
+    }
+}

--- a/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.settleops.global.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * [LOCKED] 비즈니스 예외 처리 (403, 409 등)
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+        return ResponseEntity.status(e.getStatus()).body(e.toErrorResponse());
+    }
+
+    /**
+     * [LOCKED] 400 Bad Request (@Valid 검증 실패)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.ofBadRequest(errorMessage));
+    }
+
+    /**
+     * [LOCKED] 기타 모든 예외 (500 Internal Server Error)
+     * 예기치 못한 시스템 에러 발생 시에도 requestId를 응답 바디에 포함하여 추적 가능하게 함
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternalServerError(Exception e) {
+        // 보안상 시스템 에러 메시지는 구체적으로 노출하지 않고 로그로만 남김
+        // ErrorResponse.ofBadRequest를 재활용하거나 범용 메서드를 사용
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.ofInternalError("시스템 오류가 발생했습니다. 관리자에게 문의하세요."));
+    }
+}

--- a/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
+++ b/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
@@ -55,11 +55,11 @@ public class RequestIdFilter extends OncePerRequestFilter {
 
 
         try {
-            log.info("[{}] >>> {} {}", requestId, request.getMethod(), fullUri);
+            log.info(">>> {} {}", request.getMethod(), fullUri);
             filterChain.doFilter(request, response);
         } finally {
             long duration = System.currentTimeMillis() - startTime;
-            log.info("[{}] <<< {}ms status={}", requestId, duration, response.getStatus());
+            log.info("<<< {}ms status={}", duration, response.getStatus());
 
             // 5. MDC 정리
             MDC.remove(REQUEST_ID);

--- a/server/src/test/java/com/settleops/global/error/GlobalExceptionHandlerTest.java
+++ b/server/src/test/java/com/settleops/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,88 @@
+package com.settleops.global.error;
+
+import com.settleops.global.enums.ReasonCode;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandlerTest.TestController.class)
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        MDC.put("requestId", "test-request-id"); // 테스트용 requestId
+    }
+
+    @AfterEach
+    void tearDown() {
+        MDC.clear(); // 테스트 끝난 후 반드시 clear
+    }
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/test/409")
+        public String conflict() {
+            throw new ConflictException(
+                    ReasonCode.PAYMENT_NOT_CAPTURED,
+                    "결제 상태가 올바르지 않습니다."
+            );
+        }
+
+        @GetMapping("/test/403")
+        public String forbidden() {
+            throw new ForbiddenException("권한이 없습니다.");
+        }
+
+        @GetMapping("/test/500")
+        public String serverError() {
+            throw new RuntimeException("강제 500");
+        }
+    }
+
+    @Test
+    void should_return_409_rule_violation_format() throws Exception {
+        mockMvc.perform(get("/test/409"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("RULE_VIOLATION"))
+                .andExpect(jsonPath("$.reason").value("PAYMENT_NOT_CAPTURED"))
+                .andExpect(jsonPath("$.requestId").value("test-request-id"));
+    }
+
+    @Test
+    void should_return_403_forbidden_format() throws Exception {
+        mockMvc.perform(get("/test/403"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.reason").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.requestId").value("test-request-id"));
+    }
+
+    @Test
+    void should_return_500_internal_error_format() throws Exception {
+        mockMvc.perform(get("/test/500"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.reason").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.message")
+                        .value("시스템 오류가 발생했습니다. 관리자에게 문의하세요."))
+                .andExpect(jsonPath("$.requestId").value("test-request-id"));
+    }
+}


### PR DESCRIPTION
- Enum (Action, ReasonCode)
- ConflictException, ForbiddenException 등 커스텀 예외 처리
- MockMvc 기반 테스트 추가
  - 409 (RULE_VIOLATION)
  - 403 (FORBIDDEN)
  - 500 (INTERNAL_SERVER_ERROR)
- GlobalExceptionHandler를 통해 모든 컨트롤러 예외를 통합 처리