### PR TITLE
feat: add audit trace query API skeleton

### DIFF
--- a/server/src/main/java/com/settleops/domain/admin/trace/controller/AuditTraceController.java
+++ b/server/src/main/java/com/settleops/domain/admin/trace/controller/AuditTraceController.java
@@ -1,0 +1,40 @@
+package com.settleops.domain.admin.trace.controller;
+
+import com.settleops.domain.admin.trace.dto.AuditTraceResponseDto;
+import com.settleops.domain.admin.trace.dto.AuditTraceSearchRequestDto;
+import com.settleops.domain.admin.trace.service.AuditTraceService;
+import com.settleops.global.audit.EntityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AuditTraceController {
+    private final AuditTraceService auditTraceService;
+
+    @GetMapping("/audit-logs")
+    public AuditTraceResponseDto search(
+            @RequestParam(required = false) String requestId,
+            @RequestParam(required = false) String merchantId,
+            @RequestParam(required = false) EntityType entityType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)  LocalDateTime to,
+            @PageableDefault(size = 20) Pageable pageable
+    ){
+
+        AuditTraceSearchRequestDto rq = new AuditTraceSearchRequestDto(requestId,merchantId,entityType,from,to);
+
+        return auditTraceService.searchAuditTraces(rq,pageable);
+
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceResponseDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceResponseDto.java
@@ -1,0 +1,18 @@
+package com.settleops.domain.admin.trace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AuditTraceResponseDto {
+    // requestId 검색일 때만 세팅, merchantId 검색은 null
+    private final String requestId ;
+    private final List<AuditTraceRowDto> items;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+}

--- a/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceRowDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceRowDto.java
@@ -1,0 +1,56 @@
+package com.settleops.domain.admin.trace.dto;
+
+import com.settleops.global.audit.ActorType;
+import com.settleops.global.audit.AuditLog;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.enums.Action;
+import com.settleops.global.error.BadRequestException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuditTraceRowDto {
+
+//    3.  DTO 매핑(A1 6컬럼 중심)
+//    엔티티(AuditLog)를 그대로 반환 금지
+//    응답 필드 고정: (occurredAt,actorType/actorId, action,entityType, entityId, statusBeforeAfter, metaJson 등)
+    private LocalDateTime occurredAt;
+    private ActorType actorType;
+    private String actorId;
+    private Action action;
+    private EntityType entityType;
+    private String entityId;
+    private String statusBefore;
+    private String statusAfter;
+    private String metaJson;
+
+    // 확장 필드(기본은 숨김 처리 가능)
+    private Long auditId;
+    private String merchantId;
+
+    public static AuditTraceRowDto from(AuditLog log) {
+        if (log == null) throw new BadRequestException("요청 값이 올바르지 않습니다.");
+
+        return new AuditTraceRowDto(
+                log.getOccurredAt(),
+                log.getActorType(),
+                log.getActorId(),
+                log.getAction(),
+                log.getEntityType(),
+                log.getEntityId(),
+                log.getStatusBefore(),
+                log.getStatusAfter(),
+
+                // metaJson은 DDL/PrePersist 상 NOT NULL이지만, 방어적으로 한 번 더 처리
+                (log.getMetaJson() == null || log.getMetaJson().isBlank()) ? "{}" : log.getMetaJson(),
+                log.getAuditId(),
+                log.getMerchantId()
+        );
+    }
+
+
+}

--- a/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceSearchRequestDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/trace/dto/AuditTraceSearchRequestDto.java
@@ -1,0 +1,18 @@
+package com.settleops.domain.admin.trace.dto;
+
+import com.settleops.global.audit.EntityType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AuditTraceSearchRequestDto {
+    private String requestId;
+    private String merchantId;
+    private EntityType entityType;
+    private LocalDateTime from;
+    private LocalDateTime to;
+
+}

--- a/server/src/main/java/com/settleops/domain/admin/trace/service/AuditTraceService.java
+++ b/server/src/main/java/com/settleops/domain/admin/trace/service/AuditTraceService.java
@@ -1,0 +1,82 @@
+package com.settleops.domain.admin.trace.service;
+
+import com.settleops.domain.admin.trace.dto.AuditTraceResponseDto;
+import com.settleops.domain.admin.trace.dto.AuditTraceRowDto;
+import com.settleops.domain.admin.trace.dto.AuditTraceSearchRequestDto;
+import com.settleops.global.audit.AuditLog;
+import com.settleops.global.audit.AuditTraceQueryService;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuditTraceService {
+    private final AuditTraceQueryService auditTraceQueryService;
+
+    public AuditTraceResponseDto searchAuditTraces(AuditTraceSearchRequestDto rq, Pageable pageable) {
+        if (rq == null) throw new BadRequestException("요청 값이 올바르지 않습니다.");
+
+        String requestId = rq.getRequestId();
+        String merchantId = rq.getMerchantId();
+        EntityType entityType = rq.getEntityType();
+        LocalDateTime from = rq.getFrom();
+        LocalDateTime to = rq.getTo();
+        LocalDateTime now = LocalDateTime.now();
+
+        boolean hasRequestId = requestId != null && !requestId.isBlank();
+        boolean hasMerchantId = merchantId != null && !merchantId.isBlank();
+        boolean hasEntityType = entityType != null;
+
+        if (!hasRequestId && !hasMerchantId) {
+            throw new BadRequestException("requestId 또는 merchantId는 필수입니다.");
+        }
+
+        Page<AuditLog> pageResult = null;
+
+        if (hasRequestId) {
+            if (hasEntityType) {
+                pageResult = auditTraceQueryService.findByRequestIdAndEntityType(requestId, entityType, pageable);
+            } else {
+                pageResult = auditTraceQueryService.findByRequestId(requestId, pageable);
+            }
+        } else if (hasMerchantId) {
+            if (to == null && from == null) {
+                to = now;
+                from = to.minusDays(7);
+            }
+            if (from == null || to == null)
+                throw new BadRequestException("merchantId 검색은 from/to를 함께 보내야 합니다.");
+            if (!to.isAfter(from)) throw new BadRequestException("to는 from 이후여야 합니다.");
+
+            if (hasEntityType) {
+                pageResult = auditTraceQueryService.findByMerchantInRangeAndEntityType(merchantId, entityType, from, to, pageable);
+            } else {
+                pageResult = auditTraceQueryService.findByMerchantInRange(merchantId, from, to, pageable);
+            }
+        }
+        if (pageResult == null) throw new IllegalStateException("pageResult is null");
+
+        int page = pageResult.getNumber();
+        int size = pageResult.getSize();
+        long totalElements = pageResult.getTotalElements();
+        int totalPages = pageResult.getTotalPages();
+
+        List<AuditTraceRowDto> items = pageResult.getContent().stream().map(AuditTraceRowDto::from).toList();
+
+        return new AuditTraceResponseDto(
+                hasRequestId ? requestId : null,
+                items,
+                page,
+                size,
+                totalElements,
+                totalPages
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/global/audit/AuditLogQuery.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogQuery.java
@@ -1,0 +1,21 @@
+package com.settleops.global.audit;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+
+// AuditLog 조회(Trace/A1)를 위해 requestId·merchantId 기준 페이징 검색을 제공하는 조회 전용(Query) 인터페이스
+
+public interface AuditLogQuery {
+    Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, Pageable pageable);
+
+    Page<AuditLog> findByRequestIdAndEntityTypeOrderByOccurredAtDesc(
+            String requestId, EntityType entityType, Pageable pageable);
+
+    Page<AuditLog> findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(
+            String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable);
+
+    Page<AuditLog> findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(
+            String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable);
+}

--- a/server/src/main/java/com/settleops/global/audit/AuditLogRepository.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogRepository.java
@@ -2,5 +2,5 @@ package com.settleops.global.audit;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+interface AuditLogRepository extends JpaRepository<AuditLog, Long>,AuditLogQuery {
 }

--- a/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
@@ -1,0 +1,73 @@
+package com.settleops.global.audit;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.querydsl.core.types.dsl.Expressions.allOf;
+import static com.settleops.global.audit.QAuditLog.auditLog;
+
+//AuditLog를 requestId/merchantId(+entityType/+기간) 조건으로 occurredAt DESC 정렬 + 페이징해서 조회하는 QueryDSL 구현체.
+
+@Repository
+@RequiredArgsConstructor
+public class AuditLogRepositoryImpl implements  AuditLogQuery{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, Pageable pageable) {
+
+        return page(auditLog.requestId.eq(requestId), null,null,pageable);
+    }
+
+    @Override
+    public Page<AuditLog> findByRequestIdAndEntityTypeOrderByOccurredAtDesc(String requestId, EntityType entityType, Pageable pageable) {
+        return page(auditLog.requestId.eq(requestId),auditLog.entityType.eq(entityType),null,pageable);
+    }
+
+    @Override
+    public Page<AuditLog> findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        return page(auditLog.merchantId.eq(merchantId),null,auditLog.occurredAt.between(from, to),pageable);
+    }
+
+    @Override
+    public Page<AuditLog> findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable) {
+        return page(auditLog.merchantId.eq(merchantId),auditLog.entityType.eq(entityType),auditLog.occurredAt.between(from, to),pageable);
+    }
+
+    // occurredAt DESC 고정 + pageable offset/limit 적용 + countQuery로 Page 구성
+
+    private Page<AuditLog> page(BooleanExpression keyCond,
+                                BooleanExpression entityTypeCond,
+                                BooleanExpression rangeCond,
+                                Pageable pageable) {
+
+        // Expressions.allOf는 null-safe
+        BooleanExpression whereCond = allOf(keyCond, entityTypeCond, rangeCond);
+
+        List<AuditLog> content = jpaQueryFactory
+                .selectFrom(auditLog)
+                .where(whereCond)
+                .orderBy(auditLog.occurredAt.desc(), auditLog.auditId.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        var countQuery = jpaQueryFactory
+                .select(auditLog.count())
+                .from(auditLog)
+                .where(whereCond);
+
+        // countQuery는 "필요할 때만" 실행되도록 lazy 처리
+        return PageableExecutionUtils.getPage(content,pageable,() -> Optional.ofNullable(countQuery.fetchOne()).orElse(0L));
+
+    }
+}

--- a/server/src/main/java/com/settleops/global/audit/AuditLogger.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogger.java
@@ -1,5 +1,6 @@
 package com.settleops.global.audit;
 
+import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,17 +15,17 @@ public class AuditLogger {
     @Transactional
     public void log(AuditLogCommand cmd) {
 
-        if (cmd == null) throw new IllegalArgumentException("auditLogCommand is null");
+        if (cmd == null) throw new BadRequestException("auditLogCommand is null");
 
         if (cmd.getRequestId() == null || cmd.getRequestId().isBlank()) {
-            throw new IllegalArgumentException("requestId is null/blank");
+            throw new BadRequestException("requestId is null/blank");
         }
 
-        if (cmd.getAction() == null) throw new IllegalArgumentException("action is null");
-        if (cmd.getActorType() == null) throw new IllegalArgumentException("actorType is null");
-        if (cmd.getActorId() == null) throw new IllegalArgumentException("actorId is null");
-        if (cmd.getEntityType() == null) throw new IllegalArgumentException("entityType is null");
-        if (cmd.getEntityId() == null) throw new IllegalArgumentException("entityId is null");
+        if (cmd.getAction() == null) throw new BadRequestException("action is null");
+        if (cmd.getActorType() == null) throw new BadRequestException("actorType is null");
+        if (cmd.getActorId() == null) throw new BadRequestException("actorId is null");
+        if (cmd.getEntityType() == null) throw new BadRequestException("entityType is null");
+        if (cmd.getEntityId() == null) throw new BadRequestException("entityId is null");
 
         AuditLog auditLog = AuditLog.builder()
                 .requestId(cmd.getRequestId())

--- a/server/src/main/java/com/settleops/global/audit/AuditTraceQueryService.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditTraceQueryService.java
@@ -1,0 +1,31 @@
+package com.settleops.global.audit;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuditTraceQueryService {
+    private final AuditLogRepository auditLogRepository;
+
+    public Page<AuditLog> findByRequestId(String requestId, Pageable pageable){
+      return auditLogRepository.findByRequestIdOrderByOccurredAtDesc(requestId,pageable) ;
+    }
+
+    public Page<AuditLog> findByRequestIdAndEntityType(String requestId, EntityType entityType, Pageable pageable){
+        return auditLogRepository.findByRequestIdAndEntityTypeOrderByOccurredAtDesc(requestId,entityType,pageable);
+    }
+    public Page<AuditLog> findByMerchantInRange(String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable){
+        return auditLogRepository.findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,from,to,pageable);
+    }
+    public Page<AuditLog> findByMerchantInRangeAndEntityType(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable){
+        return auditLogRepository.findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,entityType,from,to,pageable);
+    }
+
+}

--- a/server/src/main/java/com/settleops/global/config/QuerydslConfig.java
+++ b/server/src/main/java/com/settleops/global/config/QuerydslConfig.java
@@ -1,0 +1,15 @@
+package com.settleops.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/server/src/main/java/com/settleops/global/error/BadRequestException.java
+++ b/server/src/main/java/com/settleops/global/error/BadRequestException.java
@@ -1,0 +1,14 @@
+package com.settleops.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BusinessException {
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, message);
+    }
+
+    @Override
+    public ErrorResponse toErrorResponse() {
+        return ErrorResponse.ofBadRequest(getMessage());
+    }
+}


### PR DESCRIPTION
## What
- Implement audit trace query API: `GET /api/admin/audit-logs`
- Add QueryDSL query layer for paging + sorting (occurredAt DESC)

## Why
- Provide minimal MVP for A1 Trace UI data source (requestId/merchantId 기반 조회)

## How to test
- `curl "http://localhost:8080/api/admin/audit-logs?requestId=REQ-TEST&page=0&size=20"`
  - (Expected 401 if security/auth not wired yet)
- After auth is ready, verify 200 + paged response format