### PR TITLE
Feat/payment entity setup

### DIFF
--- a/server/src/main/java/com/settleops/domain/order/application/OrderService.java
+++ b/server/src/main/java/com/settleops/domain/order/application/OrderService.java
@@ -1,0 +1,34 @@
+package com.settleops.domain.order.application;
+
+import com.settleops.domain.order.domain.Orders;
+import com.settleops.domain.order.infra.OrdersRepository;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    final private OrdersRepository ordersRepository;
+
+    @Transactional(readOnly = true)
+    public Orders getByOrderId(String orderId) {
+
+        if (orderId == null || orderId.isBlank()) {
+            throw new BadRequestException("orderId는 필수입니다.");
+        }
+
+        return ordersRepository.findByOrderId(orderId)
+                .orElseThrow(() ->
+                        new BadRequestException("존재하지 않는 orderId 입니다.")
+                );
+    }
+
+    @Transactional
+    public Orders markPaid(Orders order) {
+        order.markPaid();   // 엔티티 내부 상태 변경
+        return order;       // 별도 save 필요 없음 (영속 상태라면)
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/domain/OrderStatus.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.settleops.domain.order.domain;
+
+public enum OrderStatus {
+    CREATED,
+    PAID
+}

--- a/server/src/main/java/com/settleops/domain/order/domain/Orders.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/Orders.java
@@ -1,0 +1,85 @@
+package com.settleops.domain.order.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "orders",
+        indexes = {
+                @Index(name = "idx_order_merchant", columnList = "merchant_id"),
+                @Index(name = "idx_order_buyer", columnList = "buyer_id"),
+                @Index(name = "idx_order_status", columnList = "status")
+        }
+)
+public class Orders {
+
+    @Id
+    @Column(name = "order_id", columnDefinition = "char(36)", nullable = false, updatable = false)
+    private String orderId;   // 서버 발급 불변 ID (UUIDv7/ULID 권장)
+
+    @Column(name = "merchant_id", length = 64, nullable = false)
+    private String merchantId;
+
+    @Column(name = "buyer_id", length = 64, nullable = false)
+    private String buyerId;
+
+    @Column(name = "item_name", length = 255, nullable = false)
+    private String itemName;
+
+    // KRW 정수 고정 (long / BIGINT)
+    @Column(name = "amount", nullable = false)
+    private long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private OrderStatus status; // CREATED | PAID (MVP 2상태 LOCKED)
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "datetime(6)")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "datetime(6)")
+    private LocalDateTime updatedAt;
+
+    /* =========================
+       생성/상태전이 메서드 (SoT 변경은 Service에서만 호출)
+       ========================= */
+
+    public static Orders create(String merchantId,
+                                String buyerId,
+                                String itemName,
+                                long amount) {
+
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+
+        Orders orders = new Orders();
+        orders.orderId = UUID.randomUUID().toString(); // ULID/UUIDv7 교체 가능
+        orders.merchantId = merchantId;
+        orders.buyerId = buyerId;
+        orders.itemName = itemName;
+        orders.amount = amount;
+        orders.status = OrderStatus.CREATED;
+        orders.createdAt = LocalDateTime.now();
+        orders.updatedAt = LocalDateTime.now();
+        return orders;
+    }
+
+    public void markPaid() {
+        if (this.status == OrderStatus.PAID) {
+            return; // no-op (멱등 안전)
+        }
+        this.status = OrderStatus.PAID;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/infra/OrdersRepository.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/OrdersRepository.java
@@ -1,0 +1,10 @@
+package com.settleops.domain.order.infra;
+
+import com.settleops.domain.order.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrdersRepository extends JpaRepository<Orders, String> {
+    public Optional<Orders> findByOrderId(String orderId);
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
@@ -1,0 +1,38 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.PayResponseDTO;
+import com.settleops.domain.payment.application.PayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/consumer/orders")
+public class ConsumerPayController {
+
+    private final PayService payService;
+
+    /** 주문 상세 조회 */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<?> getOrderDetail( // <OrderDetailResponseDTO>
+            @PathVariable String orderId
+    ){
+        // payService.findOrderDetail();
+        return null;
+    }
+
+    /** 결제하기 */
+    @PostMapping("/{orderId}/pay")
+    public ResponseEntity<PayResponseDTO> pay(
+            @PathVariable String orderId,
+            @RequestHeader("X-Idempotency-Key") String idempotencyKey
+    ) {
+        PayResponseDTO response =
+                payService.pay(orderId, idempotencyKey);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
@@ -1,0 +1,20 @@
+package com.settleops.domain.payment.api.dto;
+
+import com.settleops.domain.payment.domain.Payment;
+
+import java.time.LocalDateTime;
+
+
+public record PayResponseDTO(
+        String paymentId,
+        String status,
+        LocalDateTime capturedAt
+) {
+    public static PayResponseDTO from(Payment payment) {
+        return new PayResponseDTO(
+                payment.getPaymentId(),
+                payment.getStatus().name(), // status = PaymentStatus enum
+                payment.getUpdatedAt() // 추후 변경 예정 PAYMENT_CAPTURED event의 occurred_at을 조회
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -1,0 +1,131 @@
+package com.settleops.domain.payment.application;
+
+import com.settleops.domain.order.application.OrderService;
+import com.settleops.domain.order.domain.OrderStatus;
+import com.settleops.domain.order.domain.Orders;
+import com.settleops.domain.payment.api.dto.PayResponseDTO;
+import com.settleops.domain.payment.domain.IdempotencyRecord;
+import com.settleops.domain.payment.domain.Payment;
+import com.settleops.domain.payment.domain.PaymentEvent;
+import com.settleops.domain.payment.domain.PaymentStatus;
+import com.settleops.domain.payment.infra.IdempotencyRecordRepository;
+import com.settleops.domain.payment.infra.PaymentEventRepository;
+import com.settleops.domain.payment.infra.PaymentRepository;
+import com.settleops.global.enums.Action;
+import com.settleops.global.enums.IdempotencyTargetType;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PayService {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentEventRepository paymentEventRepository;
+    private final IdempotencyRecordRepository idempotencyRecordRepository;
+    private final OrderService orderService;
+
+    /**
+    * <p>1. `X-Idempotency-Key` 헤더가 들어왔는지 확인 (없으면 400).</p>
+    * <p>2. DB에서 `(orderId, idempotencyKey)` 조합으로 이미 성공한 기록이 있는지 조회.</p>
+    * <p>3. 있다면 실제 결제 로직을 타지 않고 **기존 결과 반환 (no-op 200)**.</p>
+    * <p>4. 없다면 결제 처리 후 `payment_event`에 기록. </p>
+    */
+    @Transactional
+    public PayResponseDTO pay(String orderId, String idempotencyKey) {
+
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new BadRequestException("X-Idempotency-Key는 필수입니다.");
+        }
+
+        Optional<IdempotencyRecord> recordOpt = idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(
+                IdempotencyTargetType.PAY_ORDER,
+                orderId,
+                idempotencyKey
+        );
+
+// ------ 0) 이미 처리된 요청인 경우
+        if(recordOpt.isPresent()) {
+            IdempotencyRecord idempotencyRecord = recordOpt.get();
+            Payment payment = paymentRepository.findById( // find by ~~~ 설정필요!
+                        idempotencyRecord.getPaymentId()
+                    ).orElseThrow(()->(new IllegalStateException("결제정보를 찾을 수 없습니다."))); // 데이터 정합성방어용 코드
+            // 기존 응답 재반환 no-op 200 *** 캡쳐시간 타 테이블에서 조회 필요
+            return PayResponseDTO.from(payment);
+        }
+
+// ------ 1) 신규 결제 처리
+        Orders orders = orderService.getByOrderId(orderId);
+        if (orders.getStatus() == OrderStatus.PAID) { // 기존데이터 충돌 방지용
+            // 1-1. 기존 payment 조회 (1:1 전제)
+            Payment payment = paymentRepository.findByOrderId(orderId)
+                    .orElseThrow(() ->
+                            new IllegalStateException("PAID 상태인데 payment가 없습니다. 데이터 정합성 오류")
+                    );
+            // 1-2. idempotency_record 복구 저장 (동시성 대비 try-catch)
+            try {
+                IdempotencyRecord record = IdempotencyRecord.create(
+                        IdempotencyTargetType.PAY_ORDER,
+                        orderId,
+                        idempotencyKey,
+                        payment.getPaymentId(),
+                        200
+                );
+                idempotencyRecordRepository.save(record);
+            } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                // UNIQUE 충돌 → 이미 다른 요청이 먼저 저장한 것
+                // 아무것도 하지 않음
+            }
+            log.warn("Idempotency 복구 발생 - orderId={}", orderId);
+            // 1-3. 기존 결과 반환 (no-op 200)
+            return PayResponseDTO.from(payment);
+        }
+
+        Payment payment = Payment.create(
+                orders.getOrderId(),
+                orders.getMerchantId(),
+                orders.getBuyerId(),
+                orders.getAmount()
+        );
+
+        paymentRepository.save(payment);
+
+        // 1) PAYMENT_CREATED event (before=null, after=CREATED)
+        paymentEventRepository.save(
+                PaymentEvent.created(payment.getPaymentId()) // 내부에서 requestId(MDC) 주입
+        );
+        payment.capture(); // status=CAPTURED
+
+        // 2) PAYMENT_CAPTURED event (before=CREATED, after=CAPTURED)
+        paymentEventRepository.save(
+                PaymentEvent.captured(payment.getPaymentId())
+        );
+
+        // payment 상태 저장 반영
+        paymentRepository.save(payment);
+
+        // order 상태 전이 (OrderService에게 위임)
+        orderService.markPaid(orders);
+
+
+// ------ 2. idempotency_record 저장
+        IdempotencyRecord record = IdempotencyRecord.create(
+                IdempotencyTargetType.PAY_ORDER,
+                orderId,
+                idempotencyKey,
+                payment.getPaymentId(),
+                200
+        );
+        idempotencyRecordRepository.save(record);
+
+        return PayResponseDTO.from(payment);
+    }
+
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
@@ -1,0 +1,97 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.global.enums.IdempotencyTargetType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.slf4j.MDC;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "idempotency_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_idempotency",
+                        columnNames = {"target_type", "target_id", "idempotency_key"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_idem_target", columnList = "target_type, target_id"),
+                @Index(name = "idx_idem_request_id", columnList = "request_id"),
+                @Index(name = "idx_idem_created_at", columnList = "created_at")
+        }
+)
+public class IdempotencyRecord {
+
+        private final static String MDC_KEY = "requestId";
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "idempotency_id")
+        private Long idempotencyId;
+
+        @Enumerated(EnumType.STRING)
+        @Column(name = "target_type", length = 32, nullable = false)
+        private IdempotencyTargetType targetType;// 고정: PAY_ORDER
+
+        @Column(name = "target_id", length = 64, nullable = false)
+        private String targetId;   // orderId
+
+        @Column(name = "idempotency_key", length = 128, nullable = false)
+        private String idempotencyKey; // X-Idempotency-Key
+
+        @Column(name = "payment_id", columnDefinition = "char(36)")
+        private String paymentId; // 성공 시 생성된 paymentId
+
+        @Column(name = "response_status", nullable = false)
+        private Integer responseStatus; // 최초 처리 HTTP 상태코드 (예: 200)
+
+        @Column(name = "request_id", columnDefinition = "char(36)", nullable = false)
+        private String requestId; // X-Request-Id (E2E 재현용)
+
+        @Column(name = "created_at", nullable = false, updatable = false,
+                columnDefinition = "datetime(3)")
+        private LocalDateTime createdAt;
+
+
+        public static IdempotencyRecord create(
+                IdempotencyTargetType targetType,
+                String orderId,
+                String idempotencyKey,
+                String paymentId,
+                int responseStatus
+        ) {
+                if (targetType == null) {
+                        throw new IllegalArgumentException("targetType은 필수입니다.");
+                }
+                if (orderId == null || orderId.isBlank()) {
+                        throw new IllegalArgumentException("orderId는 필수입니다.");
+                }
+                if (idempotencyKey == null || idempotencyKey.isBlank()) {
+                        throw new IllegalArgumentException("idempotencyKey는 필수입니다.");
+                }
+                if (paymentId == null || paymentId.isBlank()) {
+                        throw new IllegalArgumentException("paymentId는 필수입니다.");
+                }
+
+                String requestId = MDC.get(MDC_KEY);
+                if (requestId == null || requestId.isBlank()) {
+                        throw new IllegalStateException("requestId가 존재하지 않습니다. Filter 설정을 확인하세요.");
+                }
+
+                IdempotencyRecord record = new IdempotencyRecord();
+                record.targetType = targetType;
+                record.targetId = orderId;
+                record.idempotencyKey = idempotencyKey;
+                record.paymentId = paymentId;
+                record.responseStatus = responseStatus;
+                record.requestId = requestId;
+                record.createdAt = LocalDateTime.now();
+
+                return record;
+        }
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -1,0 +1,107 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.domain.order.domain.OrderStatus;
+import com.settleops.global.enums.Action;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/*
+* mysql> desc payment;
+    +------------------+-------------+------+-----+---------+-------+
+    | Field            | Type        | Null | Key | Default | Extra |
+    +------------------+-------------+------+-----+---------+-------+
+    | payment_id       | char(36)    | NO   | PRI | NULL    |       |
+    | order_id         | varchar(64) | NO   | MUL | NULL    |       |
+    | merchant_id      | varchar(32) | NO   | MUL | NULL    |       |
+    | buyer_id         | varchar(32) | NO   | MUL | NULL    |       |
+    | currency         | char(3)     | NO   |     | KRW     |       |
+    | requested_amount | bigint      | NO   |     | NULL    |       |
+    | captured_amount  | bigint      | NO   |     | 0       |       |
+    | status           | varchar(32) | NO   | MUL | NULL    |       |
+    | created_at       | datetime(6) | NO   | MUL | NULL    |       |
+    | updated_at       | datetime(6) | NO   |     | NULL    |       |
+    +------------------+-------------+------+-----+---------+-------+
+* */
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "payment",
+        indexes = {
+                @Index(name = "idx_payment_status", columnList = "status"),
+                @Index(name = "idx_payment_created_at", columnList = "created_at"),
+                @Index(name = "idx_payment_order_id", columnList = "order_id"),
+                @Index(name = "idx_payment_merchant_id", columnList = "merchant_id"),
+                @Index(name = "idx_payment_buyer_id", columnList = "buyer_id")
+        }
+)
+public class Payment {
+
+    @Id
+    @Column(name = "payment_id", columnDefinition = "char(36)", nullable = false)
+    private String paymentId;
+
+    @Column(name = "order_id", columnDefinition = "char(36)", nullable = false)
+    private String orderId;
+
+    @Column(name = "merchant_id", length = 32, nullable = false)
+    private String merchantId;
+
+    @Column(name = "buyer_id", length = 32, nullable = false)
+    private String buyerId;
+
+    @Column(name = "currency", columnDefinition = "char(3)", nullable = false)
+    private String currency;
+
+    @Column(name = "requested_amount", nullable = false)
+    private Long requestedAmount;
+
+    @Column(name = "captured_amount", nullable = false)
+    private Long capturedAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 32, nullable = false)
+    private PaymentStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Payment create(
+            String orderId,
+            String merchantId,
+            String buyerId,
+            Long amount
+    ) {
+        Payment payment = new Payment();
+
+        payment.paymentId = UUID.randomUUID().toString();
+        payment.orderId = orderId;
+        payment.merchantId = merchantId;
+        payment.buyerId = buyerId;
+        payment.currency = "KRW";
+        payment.requestedAmount = amount;
+        payment.capturedAmount = 0L;
+        payment.status = PaymentStatus.CREATED;
+        payment.createdAt = LocalDateTime.now();
+
+        return payment;
+    }
+
+
+    public void capture() {
+        if (this.status == PaymentStatus.CAPTURED) {
+            return; // no-op (멱등 안전)
+        }
+        this.status = PaymentStatus.CAPTURED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
@@ -1,0 +1,130 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.global.enums.Action;
+import jakarta.persistence.*;
+import org.slf4j.MDC;
+
+import java.time.LocalDateTime;
+
+// mysql> desc payment_event;
+// +------------------+-------------+------+-----+----------------------+-------------------+
+// | Field            | Type        | Null | Key | Default              | Extra             |
+// +------------------+-------------+------+-----+----------------------+-------------------+
+// | payment_event_id | bigint      | NO   | PRI | NULL                 | auto_increment    |
+// | payment_id       | char(36)    | NO   | MUL | NULL                 |                   |
+// | event_type       | varchar(32) | NO   | MUL | NULL                 |                   |
+// | status_before    | varchar(64) | YES  |     | NULL                 |                   |
+// | status_after     | varchar(64) | YES  |     | NULL                 |                   |
+// | request_id       | char(36)    | NO   | MUL | NULL                 |                   |
+// | occurred_at      | datetime(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED |
+// +------------------+-------------+------+-----+----------------------+-------------------+
+
+@Entity
+@Table(
+        name="payment_event",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name="uk_payment_event_payment_type",
+                        columnNames = {"payment_id","event_type"}
+                )
+        },
+        indexes = {
+                @Index(name="idx_payment_event_request_id",columnList="request_id"),
+                @Index(name="idx_payment_event_payment_id_occurred_at",columnList="payment_id, occurred_at"),
+                @Index(name = "idx_payment_event_type_occurred_at", columnList = "event_type, occurred_at")
+        }
+)
+public class PaymentEvent {
+
+    private final static String MDC_KEY = "requestId";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_event_id", nullable = false)
+    private Long paymentEventId;
+
+    @Column(name = "payment_id", columnDefinition = "char(36)", nullable = false)
+    private String paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", length = 32, nullable = false)
+    private Action eventType;
+
+    @Column(name = "status_before", length = 64)
+    private PaymentStatus statusBefore;
+
+    @Column(name = "status_after", length = 64)
+    private PaymentStatus statusAfter;
+
+    @Column(name = "request_id", columnDefinition = "char(36)", nullable = false)
+    private String requestId;
+
+    // DB DEFAULT CURRENT_TIMESTAMP(6)
+    @Column(name = "occurred_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime occurredAt;
+
+    public static PaymentEvent create(String paymentId, Action eventType, PaymentStatus statusBefore, PaymentStatus statusAfter){
+        String requestId = MDC.get(MDC_KEY);
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 MDC에 없습니다. RequestIdFilter 설정을 확인하세요.");
+        }
+        if (paymentId == null || paymentId.isBlank()) {
+            throw new IllegalArgumentException("paymentId는 필수입니다.");
+        }
+        if (eventType == null) {
+            throw new IllegalArgumentException("eventType은 필수입니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = eventType;
+        e.statusBefore = statusBefore;
+        e.statusAfter = statusAfter;
+        e.requestId = requestId;
+        return e;
+    }
+    private static PaymentEvent of(
+            String paymentId,
+            Action action,
+            PaymentStatus before,
+            PaymentStatus after
+    ) {
+        String requestId = MDC.get("requestId");
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 없습니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = action;
+        e.statusBefore = before;
+        e.statusAfter = after;
+        e.requestId = requestId;
+        return e;
+    }
+
+    public static PaymentEvent created(String paymentId) {
+        String requestId = MDC.get("requestId");
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 없습니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = Action.PAYMENT_CREATED;
+        e.statusBefore = null;
+        e.statusAfter = PaymentStatus.CREATED;
+        e.requestId = requestId;
+        return e;
+    }
+
+    public static PaymentEvent captured(String paymentId) {
+        return of(
+                paymentId,
+                Action.PAYMENT_CAPTURED,
+                PaymentStatus.CREATED,
+                PaymentStatus.CAPTURED
+        );
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentStatus.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentStatus.java
@@ -1,0 +1,6 @@
+package com.settleops.domain.payment.domain;
+
+public enum PaymentStatus {
+    CREATED,
+    CAPTURED
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/IdempotencyRecordRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/IdempotencyRecordRepository.java
@@ -1,0 +1,18 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.IdempotencyRecord;
+import com.settleops.domain.payment.domain.Payment;
+import com.settleops.global.enums.IdempotencyTargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IdempotencyRecordRepository extends JpaRepository<IdempotencyRecord, Long> {
+
+    /** c1-> c2 order 결제 중복 조회 */
+    public Optional<IdempotencyRecord> findByTargetTypeAndTargetIdAndIdempotencyKey(
+            IdempotencyTargetType targetType,
+            String targetId,
+            String idempotencyKey
+    );
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
@@ -1,0 +1,8 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.PaymentEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentEventRepository extends JpaRepository<PaymentEvent,Long> {
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentRepository.java
@@ -1,0 +1,12 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, String> {
+
+
+    Optional<Payment> findByOrderId(String orderId);
+}

--- a/server/src/main/java/com/settleops/global/enums/IdempotencyTargetType.java
+++ b/server/src/main/java/com/settleops/global/enums/IdempotencyTargetType.java
@@ -1,0 +1,7 @@
+package com.settleops.global.enums;
+
+public enum IdempotencyTargetType {
+    PAY_ORDER,
+    HOLD,
+    REFUND
+}


### PR DESCRIPTION
## What
- `orders` 테이블(주문 SoT) 신규 도입
- `payment.order_id`를 `CHAR(36)`으로 정합 수정
- MVP 기준 `order 1 : payment 1` 강제 (`payment.order_id` UNIQUE 추가)
- Order 도메인 추가 (`Orders`, `OrderStatus`, `OrdersRepository`, `OrderService`)
- 소비자 결제 API 추가: `POST /api/consumer/orders/{orderId}/pay`
- `X-Idempotency-Key` 기반 멱등 처리 로직 구현 (`IdempotencyRecord` 도입)
- Payment 및 PaymentEvent 엔티티 추가
- Seed 데이터 수정 (`V2__seed_2cases.sql` → `V3__seed_2cases.sql`, UUID 기반 정합)
- `V99__fk_on.sql`에 `payment → orders` FK 추가 (통합 직전용)

## Why
- 기획서 LOCKED 기준에 맞춰 주문 SoT(`orders`)와 결제 SoT(`payment`)를 명확히 분리.
- MVP 요구사항인 주문 1건당 결제 1건(1:1)을 DB 레벨에서 강제.
- 결제 API의 재시도 안전성을 보장하기 위해 멱등 처리 로직이 필요.
- 기존 seed 데이터가 주문 SoT 구조와 맞지 않아 UUID 기준으로 정합.

## How to test
- 로컬 DB 초기화 (권장)
  - 기존 DB를 drop 후 재생성
  - 애플리케이션 재기동하여 Flyway가 V1부터 순차 적용되는지 확인
- 마이그레이션 확인
  - `orders` 테이블 생성 여부 확인
  - `payment.order_id`가 `CHAR(36)`인지 확인
  - `uk_payment_order_id` UNIQUE 제약 생성 여부 확인
- 결제 API 테스트
  - `POST /api/consumer/orders/{orderId}/pay`
  - Header: `X-Idempotency-Key: test-key-1`
  - 1차 호출: 200 OK 및 payment 정보 반환 확인
  - 동일 키로 재호출: 200 OK (no-op) 및 동일 payment 반환 확인
  - 헤더 없이 호출: 400 Bad Request 확인
- Seed 데이터 확인
  - `orders.order_id`와 `payment.order_id`가 동일 UUID인지 확인
  - `idempotency_record.target_id`가 order UUID 기준으로 저장되는지 확인