### PR TITLE
refactor: requestId MDC/HEADER 키 공통 상수화

### DIFF
--- a/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
+++ b/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
@@ -16,6 +16,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.UUID;
 
+import static com.settleops.global.logging.RequestIdKeys.HEADER;
+import static com.settleops.global.logging.RequestIdKeys.MDC_KEY;
+
 /**
  * 🚨 requestId는 시스템 전역에서 본 Filter에서만 생성/주입한다.
  * 다른 계층(Interceptor, AOP 등)에서 중복 생성 금지
@@ -25,8 +28,8 @@ import java.util.UUID;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestIdFilter extends OncePerRequestFilter {
 
-    private static final String REQUEST_ID_HEADER = "X-Request-Id";
-    private static final String REQUEST_ID = "requestId";
+    private static final String REQUEST_ID_HEADER = HEADER;
+    private static final String REQUEST_ID = MDC_KEY;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/server/src/main/java/com/settleops/global/logging/RequestIdKeys.java
+++ b/server/src/main/java/com/settleops/global/logging/RequestIdKeys.java
@@ -1,0 +1,8 @@
+package com.settleops.global.logging;
+
+public final class RequestIdKeys {
+    private RequestIdKeys() {}
+
+    public static final String HEADER = "X-Request-Id";
+    public static final String MDC_KEY = "requestId";
+}


### PR DESCRIPTION
- requestId 문자열 하드코딩 제거
- MDC 키와 X-Request-Id 헤더 키를 공통 상수로 중앙화
- Filter / Audit / Service 간 키 일관성 보장
- 기능 변경 없음 (No behavior change)