### PR TITLE
Feat/payment service refactor

### DIFF
--- a/server/src/main/java/com/settleops/domain/order/application/OrderService.java
+++ b/server/src/main/java/com/settleops/domain/order/application/OrderService.java
@@ -1,0 +1,34 @@
+package com.settleops.domain.order.application;
+
+import com.settleops.domain.order.domain.Orders;
+import com.settleops.domain.order.infra.OrdersRepository;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    final private OrdersRepository ordersRepository;
+
+    @Transactional(readOnly = true)
+    public Orders getByOrderId(String orderId) {
+
+        if (orderId == null || orderId.isBlank()) {
+            throw new BadRequestException("orderId는 필수입니다.");
+        }
+
+        return ordersRepository.findByOrderId(orderId)
+                .orElseThrow(() ->
+                        new BadRequestException("존재하지 않는 orderId 입니다.")
+                );
+    }
+
+    @Transactional
+    public Orders markPaid(Orders order) {
+        order.markPaid();   // 엔티티 내부 상태 변경
+        return order;       // 별도 save 필요 없음 (영속 상태라면)
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/application/OrderService.java
+++ b/server/src/main/java/com/settleops/domain/order/application/OrderService.java
@@ -27,7 +27,8 @@ public class OrderService {
     }
 
     @Transactional
-    public Orders markPaid(Orders order) {
+    public Orders markPaid(String orderId) {
+        Orders order = getByOrderId(orderId);
         order.markPaid();   // 엔티티 내부 상태 변경
         return order;       // 별도 save 필요 없음 (영속 상태라면)
     }

--- a/server/src/main/java/com/settleops/domain/order/domain/OrderStatus.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/OrderStatus.java
@@ -1,0 +1,6 @@
+package com.settleops.domain.order.domain;
+
+public enum OrderStatus {
+    CREATED,
+    PAID
+}

--- a/server/src/main/java/com/settleops/domain/order/domain/Orders.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/Orders.java
@@ -1,5 +1,6 @@
 package com.settleops.domain.order.domain;
 
+import com.settleops.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,16 +36,16 @@ import java.util.UUID;
                 @Index(name = "idx_order_status", columnList = "status")
         }
 )
-public class Orders {
+public class Orders extends BaseEntity {
 
     @Id
     @Column(name = "order_id", columnDefinition = "char(36)", nullable = false, updatable = false)
     private String orderId;   // 서버 발급 불변 ID (UUIDv7/ULID 권장)
 
-    @Column(name = "merchant_id", length = 64, nullable = false)
+    @Column(name = "merchant_id", length = 32, nullable = false)
     private String merchantId;
 
-    @Column(name = "buyer_id", length = 64, nullable = false)
+    @Column(name = "buyer_id", length = 32, nullable = false)
     private String buyerId;
 
     @Column(name = "item_name", length = 255, nullable = false)
@@ -54,17 +55,12 @@ public class Orders {
     @Column(name = "amount", nullable = false)
     private long amount;
 
+    @Column(name = "currency", columnDefinition = "char(3)", nullable = false)
+    private String currency;
+
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", length = 20, nullable = false)
+    @Column(name = "status", length = 16, nullable = false)
     private OrderStatus status; // CREATED | PAID (MVP 2상태 LOCKED)
-
-    @Column(name = "created_at", nullable = false, updatable = false,
-            columnDefinition = "datetime(6)")
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false,
-            columnDefinition = "datetime(6)")
-    private LocalDateTime updatedAt;
 
     /* =========================
        생성/상태전이 메서드 (SoT 변경은 Service에서만 호출)
@@ -84,10 +80,9 @@ public class Orders {
         orders.merchantId = merchantId;
         orders.buyerId = buyerId;
         orders.itemName = itemName;
+        orders.currency = "KRW";
         orders.amount = amount;
         orders.status = OrderStatus.CREATED;
-        orders.createdAt = LocalDateTime.now();
-        orders.updatedAt = LocalDateTime.now();
         return orders;
     }
 
@@ -96,6 +91,5 @@ public class Orders {
             return; // no-op (멱등 안전)
         }
         this.status = OrderStatus.PAID;
-        this.updatedAt = LocalDateTime.now();
     }
 }

--- a/server/src/main/java/com/settleops/domain/order/domain/Orders.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/Orders.java
@@ -71,6 +71,10 @@ public class Orders extends BaseEntity {
                                 String itemName,
                                 long amount) {
 
+        validateNotBlank(merchantId, "merchantId");
+        validateNotBlank(buyerId, "buyerId");
+        validateNotBlank(itemName, "itemName");
+
         if (amount <= 0) {
             throw new IllegalArgumentException("amount must be positive");
         }
@@ -91,5 +95,11 @@ public class Orders extends BaseEntity {
             return; // no-op (멱등 안전)
         }
         this.status = OrderStatus.PAID;
+    }
+
+    private static void validateNotBlank(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " must not be null or blank");
+        }
     }
 }

--- a/server/src/main/java/com/settleops/domain/order/domain/Orders.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/Orders.java
@@ -8,6 +8,22 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/*
+* mysql> desc orders;
+ * +-------------+--------------+------+-----+---------+-------+
+ * | Field       | Type         | Null | Key | Default | Extra |
+ * +-------------+--------------+------+-----+---------+-------+
+ * | order_id    | char(36)     | NO   | PRI | NULL    |       |
+ * | merchant_id | varchar(32)  | NO   | MUL | NULL    |       |
+ * | buyer_id    | varchar(32)  | NO   | MUL | NULL    |       |
+ * | item_name   | varchar(255) | NO   |     | NULL    |       |
+ * | amount      | bigint       | NO   |     | NULL    |       |
+ * | currency    | char(3)      | NO   |     | KRW     |       |
+ * | status      | varchar(16)  | NO   | MUL | NULL    |       |
+ * | created_at  | datetime(6)  | NO   | MUL | NULL    |       |
+ * | updated_at  | datetime(6)  | NO   |     | NULL    |       |
+ * +-------------+--------------+------+-----+---------+-------+
+* */
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity

--- a/server/src/main/java/com/settleops/domain/order/domain/Orders.java
+++ b/server/src/main/java/com/settleops/domain/order/domain/Orders.java
@@ -1,0 +1,85 @@
+package com.settleops.domain.order.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "orders",
+        indexes = {
+                @Index(name = "idx_order_merchant", columnList = "merchant_id"),
+                @Index(name = "idx_order_buyer", columnList = "buyer_id"),
+                @Index(name = "idx_order_status", columnList = "status")
+        }
+)
+public class Orders {
+
+    @Id
+    @Column(name = "order_id", columnDefinition = "char(36)", nullable = false, updatable = false)
+    private String orderId;   // 서버 발급 불변 ID (UUIDv7/ULID 권장)
+
+    @Column(name = "merchant_id", length = 64, nullable = false)
+    private String merchantId;
+
+    @Column(name = "buyer_id", length = 64, nullable = false)
+    private String buyerId;
+
+    @Column(name = "item_name", length = 255, nullable = false)
+    private String itemName;
+
+    // KRW 정수 고정 (long / BIGINT)
+    @Column(name = "amount", nullable = false)
+    private long amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    private OrderStatus status; // CREATED | PAID (MVP 2상태 LOCKED)
+
+    @Column(name = "created_at", nullable = false, updatable = false,
+            columnDefinition = "datetime(6)")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "datetime(6)")
+    private LocalDateTime updatedAt;
+
+    /* =========================
+       생성/상태전이 메서드 (SoT 변경은 Service에서만 호출)
+       ========================= */
+
+    public static Orders create(String merchantId,
+                                String buyerId,
+                                String itemName,
+                                long amount) {
+
+        if (amount <= 0) {
+            throw new IllegalArgumentException("amount must be positive");
+        }
+
+        Orders orders = new Orders();
+        orders.orderId = UUID.randomUUID().toString(); // ULID/UUIDv7 교체 가능
+        orders.merchantId = merchantId;
+        orders.buyerId = buyerId;
+        orders.itemName = itemName;
+        orders.amount = amount;
+        orders.status = OrderStatus.CREATED;
+        orders.createdAt = LocalDateTime.now();
+        orders.updatedAt = LocalDateTime.now();
+        return orders;
+    }
+
+    public void markPaid() {
+        if (this.status == OrderStatus.PAID) {
+            return; // no-op (멱등 안전)
+        }
+        this.status = OrderStatus.PAID;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/infra/OrdersRepository.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/OrdersRepository.java
@@ -1,0 +1,10 @@
+package com.settleops.domain.order.infra;
+
+import com.settleops.domain.order.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OrdersRepository extends JpaRepository<Orders, String> {
+    public Optional<Orders> findByOrderId(String orderId);
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
@@ -1,0 +1,38 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.PayResponseDTO;
+import com.settleops.domain.payment.application.PayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/consumer/orders")
+public class ConsumerPayController {
+
+    private final PayService payService;
+
+    /** 주문 상세 조회 */
+    @GetMapping("/{orderId}")
+    public ResponseEntity<?> getOrderDetail( // <OrderDetailResponseDTO>
+            @PathVariable String orderId
+    ){
+        // payService.findOrderDetail();
+        return null;
+    }
+
+    /** 결제하기 */
+    @PostMapping("/{orderId}/pay")
+    public ResponseEntity<PayResponseDTO> pay(
+            @PathVariable String orderId,
+            @RequestHeader("X-Idempotency-Key") String idempotencyKey
+    ) {
+        PayResponseDTO response =
+                payService.pay(orderId, idempotencyKey);
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
@@ -10,11 +10,11 @@ public record PayResponseDTO(
         String status,
         LocalDateTime capturedAt
 ) {
-    public static PayResponseDTO from(Payment payment) {
+    public static PayResponseDTO from(Payment payment, LocalDateTime capturedAt) {
         return new PayResponseDTO(
                 payment.getPaymentId(),
                 payment.getStatus().name(), // status = PaymentStatus enum
-                payment.getUpdatedAt() // 추후 변경 예정 PAYMENT_CAPTURED event의 occurred_at을 조회
+                capturedAt // 추후 변경 예정 PAYMENT_CAPTURED event의 occurred_at을 조회
         );
     }
 }

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
@@ -1,0 +1,20 @@
+package com.settleops.domain.payment.api.dto;
+
+import com.settleops.domain.payment.domain.Payment;
+
+import java.time.LocalDateTime;
+
+
+public record PayResponseDTO(
+        String paymentId,
+        String status,
+        LocalDateTime capturedAt
+) {
+    public static PayResponseDTO from(Payment payment) {
+        return new PayResponseDTO(
+                payment.getPaymentId(),
+                payment.getStatus().name(), // status = PaymentStatus enum
+                payment.getUpdatedAt() // 추후 변경 예정 PAYMENT_CAPTURED event의 occurred_at을 조회
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/PayResponseDTO.java
@@ -14,7 +14,7 @@ public record PayResponseDTO(
         return new PayResponseDTO(
                 payment.getPaymentId(),
                 payment.getStatus().name(), // status = PaymentStatus enum
-                capturedAt // 추후 변경 예정 PAYMENT_CAPTURED event의 occurred_at을 조회
+                capturedAt // PAYMENT_CAPTURED event의 occurred_at
         );
     }
 }

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -11,7 +11,7 @@ import com.settleops.domain.payment.domain.PaymentStatus;
 import com.settleops.domain.payment.infra.IdempotencyRecordRepository;
 import com.settleops.domain.payment.infra.PaymentEventRepository;
 import com.settleops.domain.payment.infra.PaymentRepository;
-import com.settleops.global.enums.Action;
+import com.settleops.global.db.DbConstraintUtils;
 import com.settleops.global.enums.IdempotencyTargetType;
 import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -84,8 +84,15 @@ public class PayService {
                                 existingPayment.getPaymentId(),
                                 200)
                 );
-            } catch (DataIntegrityViolationException ignore) {
-                // 이미 다른 요청이 먼저 멱등레코드 저장
+            } catch (DataIntegrityViolationException e) {
+                if (DbConstraintUtils.isDuplicateKey(e)) {
+                    log.info("IDEMPOTENCY_RECORD 복구 저장 중복(UNIQUE)으로 무시. orderId={}, paymentId={}, cause={}",
+                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(e));
+                } else {
+                    log.error("IDEMPOTENCY_RECORD 복구 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
+                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
+                    throw e;
+                }
             }
             return PayResponseDTO.from(existingPayment);
         }
@@ -101,16 +108,37 @@ public class PayService {
         try {
             paymentRepository.save(payment);
         } catch (DataIntegrityViolationException e) {
-            // 동시에 다른 요청이 먼저 payment를 만든 케이스 → 기존 payment로 수렴
+            if (!DbConstraintUtils.isDuplicateKey(e)) {
+                log.error("PAYMENT 저장 실패(UNIQUE 외). orderId={}, cause={}",
+                        orderId, DbConstraintUtils.rootMessage(e), e);
+                throw e;
+            }
+
+            log.info("PAYMENT 생성 중복(UNIQUE)으로 기존 payment로 수렴. orderId={}, cause={}",
+                    orderId, DbConstraintUtils.rootMessage(e));
             Payment existingPayment = paymentRepository.findByOrderId(orderId)
-                    .orElseThrow(() -> e); // 진짜 이상 케이스만 throw
-            // 멱등레코드 best-effort 저장 후 기존 결과 반환
+                    .orElseThrow(() -> e);  // duplicate인데 조회가 안되면 비정상
+
+            // 멱등레코드 best-effort 저장: duplicate만 무시
             try {
                 idempotencyRecordRepository.save(
-                        IdempotencyRecord.create(idempotencytype, orderId, idempotencyKey, existingPayment.getPaymentId(), 200)
+                        IdempotencyRecord.create(
+                                idempotencytype,
+                                orderId,
+                                idempotencyKey,
+                                existingPayment.getPaymentId(),
+                                200
+                        )
                 );
-            } catch (DataIntegrityViolationException ignore) {
-
+            } catch (DataIntegrityViolationException ex) {
+                if (DbConstraintUtils.isDuplicateKey(ex)) {
+                    log.info("IDEMPOTENCY_RECORD best-effort 저장 중복(UNIQUE)으로 무시. orderId={}, paymentId={}, cause={}",
+                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(ex));
+                } else {
+                    log.error("IDEMPOTENCY_RECORD best-effort 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
+                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(ex), ex);
+                    throw ex;
+                }
             }
             return PayResponseDTO.from(existingPayment);
         }
@@ -119,16 +147,33 @@ public class PayService {
         try {
             // 내부에서 requestId(MDC) 주입
             paymentEventRepository.save(PaymentEvent.created(payment.getPaymentId()));
-        }catch (DataIntegrityViolationException ignore) {}
+        }catch (DataIntegrityViolationException e) {
+            if (DbConstraintUtils.isDuplicateKey(e)) {
+                log.info("PAYMENT_EVENT CREATED 중복(UNIQUE)으로 무시. paymentId={}, cause={}",
+                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e));
+            } else {
+                log.error("PAYMENT_EVENT CREATED 저장 실패(UNIQUE 외). paymentId={}, cause={}",
+                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
+                throw e;
+            }
+        }
 
 // ------ 4) CAPTURE(도메인에서 amount/status 확정)
         payment.capture(); // status=CAPTURED, capturedAmount=requestedAmount
+        log.info("PAY 성공. orderId={}, paymentId={}, amount={}", orderId, payment.getPaymentId(), payment.getRequestedAmount());
 
 // ------ 5) PAYMENT_EVENT[insert-only] :: CAPTURED (before=CREATED, after=CAPTURED)
         try {
             paymentEventRepository.save(PaymentEvent.captured(payment.getPaymentId()));
             // transaction commit 시 payment update 자동반영
         } catch (DataIntegrityViolationException e) {
+
+            if (!DbConstraintUtils.isDuplicateKey(e)) {
+                log.error("PAYMENT_EVENT CAPTURED 저장 실패(UNIQUE 외). paymentId={}, cause={}",
+                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
+                throw e;
+            }// duplicate인 경우만 수렴 로직
+
             // 이미 CAPTURED 이벤트가 존재(=다른 요청이 먼저 적재) → payment 상태 확정 검증(재조회 1회)
             Payment dbPayment = paymentRepository.findById(payment.getPaymentId())
                     .orElseThrow(() -> new IllegalStateException("payment가 없습니다. 정합성 오류"));
@@ -146,8 +191,6 @@ public class PayService {
             log.info("PAYMENT_CAPTURED 이벤트 중복(UNIQUE). 이미 처리됨으로 수렴. paymentId={}", payment.getPaymentId());
         }
 
-// ------ 6) payment CAPTURED 저장 (명시적으로 반영)
-        paymentRepository.save(payment);
 
 // ------ 7) order 상태 전이 (OrderService에게 위임)
         orderService.markPaid(orderId);
@@ -165,14 +208,22 @@ public class PayService {
             );
         } catch (DataIntegrityViolationException e) {
             // 이미 응답 처리 된 payment 라면 200 결과 재반환
-            IdempotencyRecord existing =
-                idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(idempotencytype, orderId, idempotencyKey)
-                    .orElseThrow(() -> e);
+            if (DbConstraintUtils.isDuplicateKey(e)) {
+                log.info("IDEMPOTENCY_RECORD 중복(UNIQUE)으로 수렴. orderId={}, paymentId={}, cause={}",
+                        orderId, payment.getPaymentId(), DbConstraintUtils.rootMessage(e));
 
-            Payment existingPayment = paymentRepository.findById(existing.getPaymentId())
-                    .orElseThrow(() -> new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"));
+                IdempotencyRecord existing =
+                    idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(idempotencytype, orderId, idempotencyKey)
+                        .orElseThrow(() -> e);
 
-            return PayResponseDTO.from(existingPayment);
+                Payment existingPayment = paymentRepository.findById(existing.getPaymentId())
+                        .orElseThrow(() -> new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"));
+
+                return PayResponseDTO.from(existingPayment);
+            }
+            log.error("IDEMPOTENCY_RECORD 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
+                    orderId, payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
+            throw e;
         }
 
         return PayResponseDTO.from(payment);

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -52,7 +52,7 @@ public class PayService {
      * <ol>
      *     <li>입력값 검증</li>
      *     <li>멱등키 기반 기존 성공 요청 조회 (no-op 처리)</li>
-     *     <li>order=PAID 이지만 멱등 레코드가 없는 복구 케이스 처리</li>
+     *     <li>order=PAID 이지만 결제 시도 시 409 처리</li>
      *     <li>Payment 생성 (UNIQUE 충돌 시 기존 payment로 수렴)</li>
      *     <li>CREATED 이벤트 적재 (insert-only)</li>
      *     <li>capture 수행 + flush 보장</li>

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -11,16 +11,27 @@ import com.settleops.domain.payment.domain.PaymentStatus;
 import com.settleops.domain.payment.infra.IdempotencyRecordRepository;
 import com.settleops.domain.payment.infra.PaymentEventRepository;
 import com.settleops.domain.payment.infra.PaymentRepository;
+import com.settleops.global.audit.ActorType;
+import com.settleops.global.audit.AuditLogCommand;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.audit.EntityType;
 import com.settleops.global.db.DbConstraintUtils;
+import com.settleops.global.enums.Action;
 import com.settleops.global.enums.IdempotencyTargetType;
+import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.BadRequestException;
+import com.settleops.global.error.ConflictException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+
+import static com.settleops.global.logging.RequestIdKeys.MDC_KEY;
 
 @Slf4j
 @Service
@@ -32,202 +43,272 @@ public class PayService {
     private final IdempotencyRecordRepository idempotencyRecordRepository;
     private final OrderService orderService;
 
+    private final AuditLogger auditLogger;
+
     /**
-    * <p>1. `X-Idempotency-Key` 헤더가 들어왔는지 확인 (없으면 400).</p>
-    * <p>2. DB에서 `(orderId, idempotencyKey)` 조합으로 이미 성공한 기록이 있는지 조회.</p>
-    * <p>3. 있다면 실제 결제 로직을 타지 않고 **기존 결과 반환 (no-op 200)**.</p>
-    * <p>4. 없다면 결제 처리 후 `payment_event`에 기록. </p>
-    */
+     * 결제 진입점.
+     *
+     * <p><b>처리 순서</b></p>
+     * <ol>
+     *     <li>입력값 검증</li>
+     *     <li>멱등키 기반 기존 성공 요청 조회 (no-op 처리)</li>
+     *     <li>order=PAID 이지만 멱등 레코드가 없는 복구 케이스 처리</li>
+     *     <li>Payment 생성 (UNIQUE 충돌 시 기존 payment로 수렴)</li>
+     *     <li>CREATED 이벤트 적재 (insert-only)</li>
+     *     <li>capture 수행 + flush 보장</li>
+     *     <li>CAPTURED 이벤트 적재 (중복 시 DB 상태로 수렴)</li>
+     *     <li>Order 상태 전이</li>
+     *     <li>멱등 레코드 저장 (중복 시 기존 payment로 수렴)</li>
+     * </ol>
+     */
     @Transactional
     public PayResponseDTO pay(String orderId, String idempotencyKey) {
 
-        // 입력 검증(400)
-        if (idempotencyKey == null || idempotencyKey.isBlank()) {
-            throw new BadRequestException("X-Idempotency-Key는 필수입니다.");
-        }
-        if (orderId == null || orderId.isBlank()) {
-            throw new BadRequestException("orderId는 필수입니다.");
-        }
+        // 1. 필수 파라미터 검증
+        validateInputs(orderId, idempotencyKey);
 
-        final IdempotencyTargetType idempotencytype = IdempotencyTargetType.PAY_ORDER;
+        final IdempotencyTargetType targetType = IdempotencyTargetType.PAY_ORDER;
 
-// ------ 0) 이미 처리된 요청인 경우
-        Optional<IdempotencyRecord> recordOpt = idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(
-                idempotencytype,
-                orderId,
-                idempotencyKey
-        );
-
-        if(recordOpt.isPresent()) {
-            IdempotencyRecord idempotencyRecord = recordOpt.get();
-            Payment payment = paymentRepository.findById( // find by ~~~ 설정필요!
-                        idempotencyRecord.getPaymentId()
-                    ).orElseThrow(()->(new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"))); // 데이터 정합성방어용 코드
-            // 기존 응답 재반환 no-op 200 *** 캡쳐시간 타 테이블에서 조회 필요
-            return PayResponseDTO.from(payment);
+        // 2. 멱등키 기반 기존 성공 요청 조회 (이미 처리된 경우 즉시 반환)
+        Payment idempotent = findIdempotentPaymentOrNull(targetType, orderId, idempotencyKey);
+        if (idempotent != null) {
+            return PayResponseDTO.from(idempotent);
         }
 
-// ------ 1) 신규 결제 처리
+        // 3. 주문 조회
         Orders orders = orderService.getByOrderId(orderId);
-        if (orders.getStatus() == OrderStatus.PAID) { // 기존데이터 충돌 방지용
-            // 1-1. 기존 payment 조회 (1:1 전제)
-            Payment existingPayment = paymentRepository.findByOrderId(orderId)
-                    .orElseThrow(() -> new IllegalStateException("order가 PAID인데 payment가 없습니다. 정합성 오류"));
+        assertOrderNotPaid(orders);
 
-            // 1-2. idempotency_record 복구 저장 (동시성 대비 try-catch)
-            try {
-                idempotencyRecordRepository.save(
-                        IdempotencyRecord.create(
-                                idempotencytype,
-                                orderId,
-                                idempotencyKey,
-                                existingPayment.getPaymentId(),
-                                200)
-                );
-            } catch (DataIntegrityViolationException e) {
-                if (DbConstraintUtils.isDuplicateKey(e)) {
-                    log.info("IDEMPOTENCY_RECORD 복구 저장 중복(UNIQUE)으로 무시. orderId={}, paymentId={}, cause={}",
-                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(e));
-                } else {
-                    log.error("IDEMPOTENCY_RECORD 복구 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
-                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
-                    throw e;
-                }
-            }
-            return PayResponseDTO.from(existingPayment);
-        }
-
-// ------ 2) PAYMENT_CREATED
-        Payment payment = Payment.create(
+        // 5. 신규 Payment 엔티티 생성
+        Payment newPayment = Payment.create(
                 orders.getOrderId(),
                 orders.getMerchantId(),
                 orders.getBuyerId(),
                 orders.getAmount()
         );
 
-        try {
-            paymentRepository.save(payment);
-        } catch (DataIntegrityViolationException e) {
-            if (!DbConstraintUtils.isDuplicateKey(e)) {
-                log.error("PAYMENT 저장 실패(UNIQUE 외). orderId={}, cause={}",
-                        orderId, DbConstraintUtils.rootMessage(e), e);
-                throw e;
+        // 6. payment insert 시 UNIQUE 충돌이면 기존 payment로 수렴
+        Payment payment = createPaymentOrConverge(newPayment, orderId);
+        if (payment != newPayment) {
+            if (payment.getStatus() != PaymentStatus.CAPTURED) {
+                throw new ConflictException(ReasonCode.IN_PROGRESS, "결제가 진행 중입니다.");
             }
-
-            log.info("PAYMENT 생성 중복(UNIQUE)으로 기존 payment로 수렴. orderId={}, cause={}",
-                    orderId, DbConstraintUtils.rootMessage(e));
-            Payment existingPayment = paymentRepository.findByOrderId(orderId)
-                    .orElseThrow(() -> e);  // duplicate인데 조회가 안되면 비정상
-
-            // 멱등레코드 best-effort 저장: duplicate만 무시
-            try {
-                idempotencyRecordRepository.save(
-                        IdempotencyRecord.create(
-                                idempotencytype,
-                                orderId,
-                                idempotencyKey,
-                                existingPayment.getPaymentId(),
-                                200
-                        )
-                );
-            } catch (DataIntegrityViolationException ex) {
-                if (DbConstraintUtils.isDuplicateKey(ex)) {
-                    log.info("IDEMPOTENCY_RECORD best-effort 저장 중복(UNIQUE)으로 무시. orderId={}, paymentId={}, cause={}",
-                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(ex));
-                } else {
-                    log.error("IDEMPOTENCY_RECORD best-effort 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
-                            orderId, existingPayment.getPaymentId(), DbConstraintUtils.rootMessage(ex), ex);
-                    throw ex;
-                }
-            }
-            return PayResponseDTO.from(existingPayment);
+            // CAPTURED가 확정된 경우에만 멱등 저장
+            saveIdempotencyIgnoreDuplicate(targetType, orderId, idempotencyKey, payment.getPaymentId());
+            return PayResponseDTO.from(payment);
         }
 
-// ------ 3) PAYMENT_EVENT[insert-only] :: CREATED (before=null, after=CREATED)
-        try {
-            // 내부에서 requestId(MDC) 주입
-            paymentEventRepository.save(PaymentEvent.created(payment.getPaymentId()));
-        }catch (DataIntegrityViolationException e) {
-            if (DbConstraintUtils.isDuplicateKey(e)) {
-                log.info("PAYMENT_EVENT CREATED 중복(UNIQUE)으로 무시. paymentId={}, cause={}",
-                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e));
-            } else {
-                log.error("PAYMENT_EVENT CREATED 저장 실패(UNIQUE 외). paymentId={}, cause={}",
-                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
-                throw e;
-            }
-        }
+        // 7. PAYMENT_EVENT :: CREATED (insert-only, duplicate ignore)
+        saveEventIgnoreDuplicate(PaymentEvent.created(payment.getPaymentId()));
 
-// ------ 4) CAPTURE(도메인에서 amount/status 확정)
-        payment.capture(); // status=CAPTURED, capturedAmount=requestedAmount
-        log.info("PAY 성공. orderId={}, paymentId={}, amount={}", orderId, payment.getPaymentId(), payment.getRequestedAmount());
+        PaymentStatus paymentStatusBefore = payment.getStatus();
 
-// ------ 5) PAYMENT_EVENT[insert-only] :: CAPTURED (before=CREATED, after=CAPTURED)
-        try {
-            paymentEventRepository.save(PaymentEvent.captured(payment.getPaymentId()));
-            // transaction commit 시 payment update 자동반영
-        } catch (DataIntegrityViolationException e) {
+        // 8. CAPTURE 수행 (도메인 로직)
+        payment.capture();
 
-            if (!DbConstraintUtils.isDuplicateKey(e)) {
-                log.error("PAYMENT_EVENT CAPTURED 저장 실패(UNIQUE 외). paymentId={}, cause={}",
-                        payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
-                throw e;
-            }// duplicate인 경우만 수렴 로직
+        // 9. flush 보장 (UPDATE SQL 실행 시점 확정)
+        payment = paymentRepository.saveAndFlush(payment);
 
-            // 이미 CAPTURED 이벤트가 존재(=다른 요청이 먼저 적재) → payment 상태 확정 검증(재조회 1회)
-            Payment dbPayment = paymentRepository.findById(payment.getPaymentId())
-                    .orElseThrow(() -> new IllegalStateException("payment가 없습니다. 정합성 오류"));
+        // 10. PAYMENT_EVENT :: CAPTURED (duplicate면 DB 상태로 수렴)
+        payment = saveCapturedEventOrConverge(payment);
 
-            if (dbPayment.getStatus() != PaymentStatus.CAPTURED) {
-                throw new IllegalStateException("CAPTURED 이벤트는 있는데 payment.status가 CAPTURED가 아닙니다. 정합성 오류");
-            }
-            if (dbPayment.getCapturedAmount() != dbPayment.getRequestedAmount()) {
-                throw new IllegalStateException("CAPTURED인데 capturedAmount != requestedAmount 입니다. 정합성 오류");
-            }
+        // MVP: pay에서는 PAYMENT_CAPTURED만 audit (PAYMENT_CREATED는 payment_event로 대체)
+        auditLogger.log(AuditLogCommand.builder()
+                .requestId(MDC.get(MDC_KEY))            // MDC에서 전역 requestId 획득
+                .action(Action.PAYMENT_CAPTURED)            // 기획서 명시 액션 코드
+                .actorType(ActorType.BUYER)                 // 또는 SYSTEM
+                .actorId(orders.getBuyerId())
+                .entityType(EntityType.PAYMENT)
+                .entityId(payment.getPaymentId())
+                .statusBefore(paymentStatusBefore.name())   // 상태 전이 기록
+                .statusAfter(payment.getStatus().name())
+                .merchantId(orders.getMerchantId())
+                .occurredAt(LocalDateTime.now())
+                .metaJson("{}")                             // 필요 시 추가 상세 데이터
+                .build());
 
-            // 이 요청의 payment 객체는 stale일 수 있으니, 이후 응답/흐름은 dbPayment로 수렴하는게 안전
-            payment = dbPayment;
+        log.info("PAY 성공. orderId={}, paymentId={}, amount={}",
+                orderId, payment.getPaymentId(), payment.getRequestedAmount());
 
-            log.info("PAYMENT_CAPTURED 이벤트 중복(UNIQUE). 이미 처리됨으로 수렴. paymentId={}", payment.getPaymentId());
-        }
-
-
-// ------ 7) order 상태 전이 (OrderService에게 위임)
+        // 11. 주문 상태 PAID 전이
         orderService.markPaid(orderId);
 
-// ------ 8). idempotency_record 저장 (UNIQUE 충돌 시 기존 레코드로 수렴)
-        try{
-            idempotencyRecordRepository.save(
-                IdempotencyRecord.create(
-                        idempotencytype, // Locked
-                        orderId,
-                        idempotencyKey,
-                        payment.getPaymentId(),
-                        200
-                )
-            );
-        } catch (DataIntegrityViolationException e) {
-            // 이미 응답 처리 된 payment 라면 200 결과 재반환
-            if (DbConstraintUtils.isDuplicateKey(e)) {
-                log.info("IDEMPOTENCY_RECORD 중복(UNIQUE)으로 수렴. orderId={}, paymentId={}, cause={}",
-                        orderId, payment.getPaymentId(), DbConstraintUtils.rootMessage(e));
+        // 12. idempotency_record 저장 (duplicate면 기존 payment로 수렴)
+        Payment finalPayment = saveIdempotencyOrConverge(targetType, orderId, idempotencyKey, payment);
 
-                IdempotencyRecord existing =
-                    idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(idempotencytype, orderId, idempotencyKey)
-                        .orElseThrow(() -> e);
-
-                Payment existingPayment = paymentRepository.findById(existing.getPaymentId())
-                        .orElseThrow(() -> new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"));
-
-                return PayResponseDTO.from(existingPayment);
-            }
-            log.error("IDEMPOTENCY_RECORD 저장 실패(UNIQUE 외). orderId={}, paymentId={}, cause={}",
-                    orderId, payment.getPaymentId(), DbConstraintUtils.rootMessage(e), e);
-            throw e;
-        }
-
-        return PayResponseDTO.from(payment);
+        return PayResponseDTO.from(finalPayment);
     }
 
+    /**
+     * 입력값 검증.
+     *
+     * <p>orderId와 idempotencyKey는 필수값이다.</p>
+     * <p>누락 시 400 BadRequestException 발생.</p>
+     */
+    private static void validateInputs(String orderId, String idempotencyKey) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new BadRequestException("X-Idempotency-Key는 필수입니다.");
+        }
+        if (orderId == null || orderId.isBlank()) {
+            throw new BadRequestException("orderId는 필수입니다.");
+        }
+    }
 
+    /**
+     * 중복키 예외 판별.
+     *
+     * <p>DB UNIQUE 제약 위반 여부를 판별한다.</p>
+     */
+    private boolean isDuplicate(DataIntegrityViolationException e) {
+        return DbConstraintUtils.isDuplicateKey(e);
+    }
+
+    /**
+     * payment 생성 시 UNIQUE 충돌이 발생하면 기존 payment로 수렴한다.
+     *
+     * <p>동시성 상황에서 orderId UNIQUE 제약으로 인해 insert 충돌이 발생할 수 있다.</p>
+     */
+    private Payment createPaymentOrConverge(Payment payment,
+                                            String orderId) {
+        try {
+            return paymentRepository.save(payment);
+        } catch (DataIntegrityViolationException e) {
+            if (!isDuplicate(e)) throw e;
+
+            log.info("PAYMENT 생성 중복. orderId={}", orderId);
+
+            Payment existing = paymentRepository.findByOrderId(orderId)
+                    .orElseThrow(() -> new IllegalStateException("기존 payment 조회 실패"));
+            return existing; // UNIQUE 충돌
+        }
+    }
+
+    /**
+     * payment 이벤트 insert-only 저장.
+     *
+     * <p>UNIQUE 중복은 무시하고, 그 외 예외는 전파한다.</p>
+     */
+    private void saveEventIgnoreDuplicate(PaymentEvent event) {
+        try {
+            paymentEventRepository.save(event);
+        } catch (DataIntegrityViolationException e) {
+            if (isDuplicate(e)) {
+                log.info("EVENT 중복 무시. paymentId={}", event.getPaymentId());
+                return;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * CAPTURED 이벤트 적재.
+     *
+     * <p>이미 존재하는 경우 DB의 payment 상태를 재조회하여 수렴한다.</p>
+     */
+    private Payment saveCapturedEventOrConverge(Payment payment) {
+        try {
+            paymentEventRepository.save(PaymentEvent.captured(payment.getPaymentId()));
+            return payment;
+        } catch (DataIntegrityViolationException e) {
+            if (!isDuplicate(e)) throw e;
+
+            Payment dbPayment = paymentRepository.findById(payment.getPaymentId())
+                    .orElseThrow(() -> new IllegalStateException("payment 조회 실패"));
+
+            if (dbPayment.getStatus() != PaymentStatus.CAPTURED) {
+                throw new IllegalStateException("CAPTURED 이벤트 존재하지만 상태 불일치");
+            }
+
+            return dbPayment;
+        }
+    }
+
+    /**
+     * 멱등 레코드 저장.
+     *
+     * <p>이미 존재하는 경우 기존 레코드가 가리키는 payment로 수렴한다.</p>
+     */
+    private Payment saveIdempotencyOrConverge(IdempotencyTargetType targetType,
+                                              String orderId,
+                                              String idempotencyKey,
+                                              Payment payment) {
+        try {
+            idempotencyRecordRepository.save(
+                    IdempotencyRecord.create(
+                            targetType,
+                            orderId,
+                            idempotencyKey,
+                            payment.getPaymentId(),
+                            200
+                    )
+            );
+            return payment;
+        } catch (DataIntegrityViolationException e) {
+            if (!isDuplicate(e)) throw e;
+
+            IdempotencyRecord existing = idempotencyRecordRepository
+                    .findByTargetTypeAndTargetIdAndIdempotencyKey(targetType, orderId, idempotencyKey)
+                    .orElseThrow(() -> new IllegalStateException("멱등 레코드 조회 실패"));
+
+            return paymentRepository.findById(existing.getPaymentId())
+                    .orElseThrow(() -> new IllegalStateException("payment 조회 실패"));
+        }
+    }
+
+    /**
+     * 멱등 레코드 best-effort 저장.
+     *
+     * <p>중복은 무시하고 그 외 예외는 전파한다.</p>
+     */
+    private void saveIdempotencyIgnoreDuplicate(IdempotencyTargetType targetType,
+                                                String orderId,
+                                                String idempotencyKey,
+                                                String paymentId) {
+        try {
+            idempotencyRecordRepository.save(
+                    IdempotencyRecord.create(
+                            targetType,
+                            orderId,
+                            idempotencyKey,
+                            paymentId,
+                            200
+                    )
+            );
+        } catch (DataIntegrityViolationException e) {
+            if (!isDuplicate(e)) throw e;
+        }
+    }
+
+    /**
+     * 멱등키 기반 기존 성공 payment 조회.
+     *
+     * <p>존재하지 않으면 null 반환.</p>
+     */
+    private Payment findIdempotentPaymentOrNull(IdempotencyTargetType targetType,
+                                                String orderId,
+                                                String idempotencyKey) {
+
+        Optional<IdempotencyRecord> record =
+                idempotencyRecordRepository
+                        .findByTargetTypeAndTargetIdAndIdempotencyKey(targetType, orderId, idempotencyKey);
+
+        if (record.isEmpty()) return null;
+
+        return paymentRepository.findById(record.get().getPaymentId())
+                .orElseThrow(() -> new IllegalStateException(
+                        "idempotency_record는 존재하지만 참조 payment가 없습니다. 정합성 오류"
+                ));
+    }
+
+    /**
+     * 주문이 이미 PAID이면 새 결제 요청을 차단한다.
+     *
+     * <p>동일 (orderId, idempotencyKey) 재시도는 2단계에서 이미 no-op 200으로 반환되므로,
+     * 여기서는 '멱등 레코드 없음 + order=PAID' = 새 멱등키 재요청(상태 위반)만 처리한다.</p>
+     */
+    private static void assertOrderNotPaid(Orders orders) {
+        if (orders.getStatus() == OrderStatus.PAID) {
+            throw new ConflictException(ReasonCode.PAID_ALREADY, "이미 PAID 상태입니다.");
+        }
+    }
 }

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -72,7 +72,8 @@ public class PayService {
         // 2. 멱등키 기반 기존 성공 요청 조회 (이미 처리된 경우 즉시 반환)
         Payment idempotent = findIdempotentPaymentOrNull(targetType, orderId, idempotencyKey);
         if (idempotent != null) {
-            return PayResponseDTO.from(idempotent);
+            LocalDateTime capturedAt = getCapturedAtOrThrow(idempotent);
+            return PayResponseDTO.from(idempotent, capturedAt);
         }
 
         // 3. 주문 조회
@@ -95,7 +96,9 @@ public class PayService {
             }
             // CAPTURED가 확정된 경우에만 멱등 저장
             saveIdempotencyIgnoreDuplicate(targetType, orderId, idempotencyKey, payment.getPaymentId());
-            return PayResponseDTO.from(payment);
+
+            LocalDateTime capturedAt = getCapturedAtOrThrow(payment);
+            return PayResponseDTO.from(payment,capturedAt);
         }
 
         // 7. PAYMENT_EVENT :: CREATED (insert-only, duplicate ignore)
@@ -123,7 +126,7 @@ public class PayService {
                 .statusBefore(paymentStatusBefore.name())   // 상태 전이 기록
                 .statusAfter(payment.getStatus().name())
                 .merchantId(orders.getMerchantId())
-                .occurredAt(LocalDateTime.now())
+                .occurredAt(getCapturedAtOrThrow(payment))
                 .metaJson("{}")                             // 필요 시 추가 상세 데이터
                 .build());
 
@@ -136,7 +139,10 @@ public class PayService {
         // 12. idempotency_record 저장 (duplicate면 기존 payment로 수렴)
         Payment finalPayment = saveIdempotencyOrConverge(targetType, orderId, idempotencyKey, payment);
 
-        return PayResponseDTO.from(finalPayment);
+        // capturedAt 체크
+        LocalDateTime capturedAt = getCapturedAtOrThrow(finalPayment);
+
+        return PayResponseDTO.from(finalPayment, capturedAt);
     }
 
     /**
@@ -221,6 +227,40 @@ public class PayService {
 
             return dbPayment;
         }
+    }
+
+    /**
+     * PAYMENT_CAPTURED 이벤트의 occurred_at을 조회한다.
+     *
+     * <p>capturedAt은 payment.updatedAt이 아니라,
+     * PAYMENT_CAPTURED 이벤트의 발생 시각(occurred_at)을 SoT로 사용한다.</p>
+     *
+     * <p>전제:
+     * (payment_id, event_type) 유니크 제약으로
+     * PAYMENT_CAPTURED 이벤트는 최대 1건 존재해야 한다.</p>
+     *
+     * <p>예외:
+     * - CAPTURED 상태가 아닌데 조회 시도 시 IllegalStateException
+     * - 이벤트가 존재하지 않으면 정합성 오류로 간주</p>
+     */
+    private LocalDateTime getCapturedAtOrThrow(Payment payment) {
+
+        if (payment.getStatus() != PaymentStatus.CAPTURED) {
+            throw new IllegalStateException(
+                    "CAPTURED 상태가 아닌데 capturedAt 조회 시도. paymentId="
+                            + payment.getPaymentId()
+            );
+        }
+
+        return paymentEventRepository
+                .findOccurredAtByPaymentIdAndEventType(
+                        payment.getPaymentId(),
+                        Action.PAYMENT_CAPTURED
+                )
+                .orElseThrow(() -> new IllegalStateException(
+                        "CAPTURE 이벤트가 존재하지 않습니다. paymentId="
+                                + payment.getPaymentId()
+                ));
     }
 
     /**

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -4,10 +4,7 @@ import com.settleops.domain.order.application.OrderService;
 import com.settleops.domain.order.domain.OrderStatus;
 import com.settleops.domain.order.domain.Orders;
 import com.settleops.domain.payment.api.dto.PayResponseDTO;
-import com.settleops.domain.payment.domain.IdempotencyRecord;
-import com.settleops.domain.payment.domain.Payment;
-import com.settleops.domain.payment.domain.PaymentEvent;
-import com.settleops.domain.payment.domain.PaymentStatus;
+import com.settleops.domain.payment.domain.*;
 import com.settleops.domain.payment.infra.IdempotencyRecordRepository;
 import com.settleops.domain.payment.infra.PaymentEventRepository;
 import com.settleops.domain.payment.infra.PaymentRepository;
@@ -21,17 +18,15 @@ import com.settleops.global.enums.IdempotencyTargetType;
 import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.ConflictException;
+import com.settleops.global.logging.RequestIdProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.MDC;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
-
-import static com.settleops.global.logging.RequestIdKeys.MDC_KEY;
 
 @Slf4j
 @Service
@@ -117,7 +112,7 @@ public class PayService {
 
         // MVP: pay에서는 PAYMENT_CAPTURED만 audit (PAYMENT_CREATED는 payment_event로 대체)
         auditLogger.log(AuditLogCommand.builder()
-                .requestId(MDC.get(MDC_KEY))            // MDC에서 전역 requestId 획득
+                .requestId(RequestIdProvider.current())            // MDC에서 전역 requestId 획득
                 .action(Action.PAYMENT_CAPTURED)            // 기획서 명시 액션 코드
                 .actorType(ActorType.BUYER)                 // 또는 SYSTEM
                 .actorId(orders.getBuyerId())
@@ -255,7 +250,7 @@ public class PayService {
         return paymentEventRepository
                 .findOccurredAtByPaymentIdAndEventType(
                         payment.getPaymentId(),
-                        Action.PAYMENT_CAPTURED
+                        PaymentEventType.PAYMENT_CREATED
                 )
                 .orElseThrow(() -> new IllegalStateException(
                         "CAPTURE 이벤트가 존재하지 않습니다. paymentId="

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -250,7 +250,7 @@ public class PayService {
         return paymentEventRepository
                 .findOccurredAtByPaymentIdAndEventType(
                         payment.getPaymentId(),
-                        PaymentEventType.PAYMENT_CREATED
+                        PaymentEventType.PAYMENT_CAPTURED
                 )
                 .orElseThrow(() -> new IllegalStateException(
                         "CAPTURE 이벤트가 존재하지 않습니다. paymentId="

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -16,6 +16,7 @@ import com.settleops.global.enums.IdempotencyTargetType;
 import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,22 +41,28 @@ public class PayService {
     @Transactional
     public PayResponseDTO pay(String orderId, String idempotencyKey) {
 
+        // 입력 검증(400)
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
             throw new BadRequestException("X-Idempotency-Key는 필수입니다.");
         }
+        if (orderId == null || orderId.isBlank()) {
+            throw new BadRequestException("orderId는 필수입니다.");
+        }
 
+        final IdempotencyTargetType idempotencytype = IdempotencyTargetType.PAY_ORDER;
+
+// ------ 0) 이미 처리된 요청인 경우
         Optional<IdempotencyRecord> recordOpt = idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(
-                IdempotencyTargetType.PAY_ORDER,
+                idempotencytype,
                 orderId,
                 idempotencyKey
         );
 
-// ------ 0) 이미 처리된 요청인 경우
         if(recordOpt.isPresent()) {
             IdempotencyRecord idempotencyRecord = recordOpt.get();
             Payment payment = paymentRepository.findById( // find by ~~~ 설정필요!
                         idempotencyRecord.getPaymentId()
-                    ).orElseThrow(()->(new IllegalStateException("결제정보를 찾을 수 없습니다."))); // 데이터 정합성방어용 코드
+                    ).orElseThrow(()->(new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"))); // 데이터 정합성방어용 코드
             // 기존 응답 재반환 no-op 200 *** 캡쳐시간 타 테이블에서 조회 필요
             return PayResponseDTO.from(payment);
         }
@@ -64,29 +71,26 @@ public class PayService {
         Orders orders = orderService.getByOrderId(orderId);
         if (orders.getStatus() == OrderStatus.PAID) { // 기존데이터 충돌 방지용
             // 1-1. 기존 payment 조회 (1:1 전제)
-            Payment payment = paymentRepository.findByOrderId(orderId)
-                    .orElseThrow(() ->
-                            new IllegalStateException("PAID 상태인데 payment가 없습니다. 데이터 정합성 오류")
-                    );
+            Payment existingPayment = paymentRepository.findByOrderId(orderId)
+                    .orElseThrow(() -> new IllegalStateException("order가 PAID인데 payment가 없습니다. 정합성 오류"));
+
             // 1-2. idempotency_record 복구 저장 (동시성 대비 try-catch)
             try {
-                IdempotencyRecord record = IdempotencyRecord.create(
-                        IdempotencyTargetType.PAY_ORDER,
-                        orderId,
-                        idempotencyKey,
-                        payment.getPaymentId(),
-                        200
+                idempotencyRecordRepository.save(
+                        IdempotencyRecord.create(
+                                idempotencytype,
+                                orderId,
+                                idempotencyKey,
+                                existingPayment.getPaymentId(),
+                                200)
                 );
-                idempotencyRecordRepository.save(record);
-            } catch (org.springframework.dao.DataIntegrityViolationException e) {
-                // UNIQUE 충돌 → 이미 다른 요청이 먼저 저장한 것
-                // 아무것도 하지 않음
+            } catch (DataIntegrityViolationException ignore) {
+                // 이미 다른 요청이 먼저 멱등레코드 저장
             }
-            log.warn("Idempotency 복구 발생 - orderId={}", orderId);
-            // 1-3. 기존 결과 반환 (no-op 200)
-            return PayResponseDTO.from(payment);
+            return PayResponseDTO.from(existingPayment);
         }
 
+// ------ 2) PAYMENT_CREATED
         Payment payment = Payment.create(
                 orders.getOrderId(),
                 orders.getMerchantId(),
@@ -94,35 +98,82 @@ public class PayService {
                 orders.getAmount()
         );
 
+        try {
+            paymentRepository.save(payment);
+        } catch (DataIntegrityViolationException e) {
+            // 동시에 다른 요청이 먼저 payment를 만든 케이스 → 기존 payment로 수렴
+            Payment existingPayment = paymentRepository.findByOrderId(orderId)
+                    .orElseThrow(() -> e); // 진짜 이상 케이스만 throw
+            // 멱등레코드 best-effort 저장 후 기존 결과 반환
+            try {
+                idempotencyRecordRepository.save(
+                        IdempotencyRecord.create(idempotencytype, orderId, idempotencyKey, existingPayment.getPaymentId(), 200)
+                );
+            } catch (DataIntegrityViolationException ignore) {
+
+            }
+            return PayResponseDTO.from(existingPayment);
+        }
+
+// ------ 3) PAYMENT_EVENT[insert-only] :: CREATED (before=null, after=CREATED)
+        try {
+            // 내부에서 requestId(MDC) 주입
+            paymentEventRepository.save(PaymentEvent.created(payment.getPaymentId()));
+        }catch (DataIntegrityViolationException ignore) {}
+
+// ------ 4) CAPTURE(도메인에서 amount/status 확정)
+        payment.capture(); // status=CAPTURED, capturedAmount=requestedAmount
+
+// ------ 5) PAYMENT_EVENT[insert-only] :: CAPTURED (before=CREATED, after=CAPTURED)
+        try {
+            paymentEventRepository.save(PaymentEvent.captured(payment.getPaymentId()));
+            // transaction commit 시 payment update 자동반영
+        } catch (DataIntegrityViolationException e) {
+            // 이미 CAPTURED 이벤트가 존재(=다른 요청이 먼저 적재) → payment 상태 확정 검증(재조회 1회)
+            Payment dbPayment = paymentRepository.findById(payment.getPaymentId())
+                    .orElseThrow(() -> new IllegalStateException("payment가 없습니다. 정합성 오류"));
+
+            if (dbPayment.getStatus() != PaymentStatus.CAPTURED) {
+                throw new IllegalStateException("CAPTURED 이벤트는 있는데 payment.status가 CAPTURED가 아닙니다. 정합성 오류");
+            }
+            if (dbPayment.getCapturedAmount() != dbPayment.getRequestedAmount()) {
+                throw new IllegalStateException("CAPTURED인데 capturedAmount != requestedAmount 입니다. 정합성 오류");
+            }
+
+            // 이 요청의 payment 객체는 stale일 수 있으니, 이후 응답/흐름은 dbPayment로 수렴하는게 안전
+            payment = dbPayment;
+
+            log.info("PAYMENT_CAPTURED 이벤트 중복(UNIQUE). 이미 처리됨으로 수렴. paymentId={}", payment.getPaymentId());
+        }
+
+// ------ 6) payment CAPTURED 저장 (명시적으로 반영)
         paymentRepository.save(payment);
 
-        // 1) PAYMENT_CREATED event (before=null, after=CREATED)
-        paymentEventRepository.save(
-                PaymentEvent.created(payment.getPaymentId()) // 내부에서 requestId(MDC) 주입
-        );
-        payment.capture(); // status=CAPTURED
+// ------ 7) order 상태 전이 (OrderService에게 위임)
+        orderService.markPaid(orderId);
 
-        // 2) PAYMENT_CAPTURED event (before=CREATED, after=CAPTURED)
-        paymentEventRepository.save(
-                PaymentEvent.captured(payment.getPaymentId())
-        );
+// ------ 8). idempotency_record 저장 (UNIQUE 충돌 시 기존 레코드로 수렴)
+        try{
+            idempotencyRecordRepository.save(
+                IdempotencyRecord.create(
+                        idempotencytype, // Locked
+                        orderId,
+                        idempotencyKey,
+                        payment.getPaymentId(),
+                        200
+                )
+            );
+        } catch (DataIntegrityViolationException e) {
+            // 이미 응답 처리 된 payment 라면 200 결과 재반환
+            IdempotencyRecord existing =
+                idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(idempotencytype, orderId, idempotencyKey)
+                    .orElseThrow(() -> e);
 
-        // payment 상태 저장 반영
-        paymentRepository.save(payment);
+            Payment existingPayment = paymentRepository.findById(existing.getPaymentId())
+                    .orElseThrow(() -> new IllegalStateException("멱등 레코드가 가리키는 payment가 없습니다. 정합성 오류"));
 
-        // order 상태 전이 (OrderService에게 위임)
-        orderService.markPaid(orders);
-
-
-// ------ 2. idempotency_record 저장
-        IdempotencyRecord record = IdempotencyRecord.create(
-                IdempotencyTargetType.PAY_ORDER,
-                orderId,
-                idempotencyKey,
-                payment.getPaymentId(),
-                200
-        );
-        idempotencyRecordRepository.save(record);
+            return PayResponseDTO.from(existingPayment);
+        }
 
         return PayResponseDTO.from(payment);
     }

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -1,0 +1,131 @@
+package com.settleops.domain.payment.application;
+
+import com.settleops.domain.order.application.OrderService;
+import com.settleops.domain.order.domain.OrderStatus;
+import com.settleops.domain.order.domain.Orders;
+import com.settleops.domain.payment.api.dto.PayResponseDTO;
+import com.settleops.domain.payment.domain.IdempotencyRecord;
+import com.settleops.domain.payment.domain.Payment;
+import com.settleops.domain.payment.domain.PaymentEvent;
+import com.settleops.domain.payment.domain.PaymentStatus;
+import com.settleops.domain.payment.infra.IdempotencyRecordRepository;
+import com.settleops.domain.payment.infra.PaymentEventRepository;
+import com.settleops.domain.payment.infra.PaymentRepository;
+import com.settleops.global.enums.Action;
+import com.settleops.global.enums.IdempotencyTargetType;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PayService {
+
+    private final PaymentRepository paymentRepository;
+    private final PaymentEventRepository paymentEventRepository;
+    private final IdempotencyRecordRepository idempotencyRecordRepository;
+    private final OrderService orderService;
+
+    /**
+    * <p>1. `X-Idempotency-Key` 헤더가 들어왔는지 확인 (없으면 400).</p>
+    * <p>2. DB에서 `(orderId, idempotencyKey)` 조합으로 이미 성공한 기록이 있는지 조회.</p>
+    * <p>3. 있다면 실제 결제 로직을 타지 않고 **기존 결과 반환 (no-op 200)**.</p>
+    * <p>4. 없다면 결제 처리 후 `payment_event`에 기록. </p>
+    */
+    @Transactional
+    public PayResponseDTO pay(String orderId, String idempotencyKey) {
+
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
+            throw new BadRequestException("X-Idempotency-Key는 필수입니다.");
+        }
+
+        Optional<IdempotencyRecord> recordOpt = idempotencyRecordRepository.findByTargetTypeAndTargetIdAndIdempotencyKey(
+                IdempotencyTargetType.PAY_ORDER,
+                orderId,
+                idempotencyKey
+        );
+
+// ------ 0) 이미 처리된 요청인 경우
+        if(recordOpt.isPresent()) {
+            IdempotencyRecord idempotencyRecord = recordOpt.get();
+            Payment payment = paymentRepository.findById( // find by ~~~ 설정필요!
+                        idempotencyRecord.getPaymentId()
+                    ).orElseThrow(()->(new IllegalStateException("결제정보를 찾을 수 없습니다."))); // 데이터 정합성방어용 코드
+            // 기존 응답 재반환 no-op 200 *** 캡쳐시간 타 테이블에서 조회 필요
+            return PayResponseDTO.from(payment);
+        }
+
+// ------ 1) 신규 결제 처리
+        Orders orders = orderService.getByOrderId(orderId);
+        if (orders.getStatus() == OrderStatus.PAID) { // 기존데이터 충돌 방지용
+            // 1-1. 기존 payment 조회 (1:1 전제)
+            Payment payment = paymentRepository.findByOrderId(orderId)
+                    .orElseThrow(() ->
+                            new IllegalStateException("PAID 상태인데 payment가 없습니다. 데이터 정합성 오류")
+                    );
+            // 1-2. idempotency_record 복구 저장 (동시성 대비 try-catch)
+            try {
+                IdempotencyRecord record = IdempotencyRecord.create(
+                        IdempotencyTargetType.PAY_ORDER,
+                        orderId,
+                        idempotencyKey,
+                        payment.getPaymentId(),
+                        200
+                );
+                idempotencyRecordRepository.save(record);
+            } catch (org.springframework.dao.DataIntegrityViolationException e) {
+                // UNIQUE 충돌 → 이미 다른 요청이 먼저 저장한 것
+                // 아무것도 하지 않음
+            }
+            log.warn("Idempotency 복구 발생 - orderId={}", orderId);
+            // 1-3. 기존 결과 반환 (no-op 200)
+            return PayResponseDTO.from(payment);
+        }
+
+        Payment payment = Payment.create(
+                orders.getOrderId(),
+                orders.getMerchantId(),
+                orders.getBuyerId(),
+                orders.getAmount()
+        );
+
+        paymentRepository.save(payment);
+
+        // 1) PAYMENT_CREATED event (before=null, after=CREATED)
+        paymentEventRepository.save(
+                PaymentEvent.created(payment.getPaymentId()) // 내부에서 requestId(MDC) 주입
+        );
+        payment.capture(); // status=CAPTURED
+
+        // 2) PAYMENT_CAPTURED event (before=CREATED, after=CAPTURED)
+        paymentEventRepository.save(
+                PaymentEvent.captured(payment.getPaymentId())
+        );
+
+        // payment 상태 저장 반영
+        paymentRepository.save(payment);
+
+        // order 상태 전이 (OrderService에게 위임)
+        orderService.markPaid(orders);
+
+
+// ------ 2. idempotency_record 저장
+        IdempotencyRecord record = IdempotencyRecord.create(
+                IdempotencyTargetType.PAY_ORDER,
+                orderId,
+                idempotencyKey,
+                payment.getPaymentId(),
+                200
+        );
+        idempotencyRecordRepository.save(record);
+
+        return PayResponseDTO.from(payment);
+    }
+
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
@@ -1,6 +1,7 @@
 package com.settleops.domain.payment.domain;
 
 import com.settleops.global.enums.IdempotencyTargetType;
+import com.settleops.global.logging.RequestIdProvider;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -78,10 +79,7 @@ public class IdempotencyRecord {
                         throw new IllegalArgumentException("paymentId는 필수입니다.");
                 }
 
-                String requestId = MDC.get(MDC_KEY);
-                if (requestId == null || requestId.isBlank()) {
-                        throw new IllegalStateException("requestId가 존재하지 않습니다. Filter 설정을 확인하세요.");
-                }
+                String requestId = RequestIdProvider.current();
 
                 IdempotencyRecord record = new IdempotencyRecord();
                 record.targetType = targetType;

--- a/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/IdempotencyRecord.java
@@ -1,0 +1,97 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.global.enums.IdempotencyTargetType;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.slf4j.MDC;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "idempotency_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_idempotency",
+                        columnNames = {"target_type", "target_id", "idempotency_key"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_idem_target", columnList = "target_type, target_id"),
+                @Index(name = "idx_idem_request_id", columnList = "request_id"),
+                @Index(name = "idx_idem_created_at", columnList = "created_at")
+        }
+)
+public class IdempotencyRecord {
+
+        private final static String MDC_KEY = "requestId";
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "idempotency_id")
+        private Long idempotencyId;
+
+        @Enumerated(EnumType.STRING)
+        @Column(name = "target_type", length = 32, nullable = false)
+        private IdempotencyTargetType targetType;// 고정: PAY_ORDER
+
+        @Column(name = "target_id", length = 64, nullable = false)
+        private String targetId;   // orderId
+
+        @Column(name = "idempotency_key", length = 128, nullable = false)
+        private String idempotencyKey; // X-Idempotency-Key
+
+        @Column(name = "payment_id", columnDefinition = "char(36)")
+        private String paymentId; // 성공 시 생성된 paymentId
+
+        @Column(name = "response_status", nullable = false)
+        private Integer responseStatus; // 최초 처리 HTTP 상태코드 (예: 200)
+
+        @Column(name = "request_id", columnDefinition = "char(36)", nullable = false)
+        private String requestId; // X-Request-Id (E2E 재현용)
+
+        @Column(name = "created_at", nullable = false, updatable = false,
+                columnDefinition = "datetime(3)")
+        private LocalDateTime createdAt;
+
+
+        public static IdempotencyRecord create(
+                IdempotencyTargetType targetType,
+                String orderId,
+                String idempotencyKey,
+                String paymentId,
+                int responseStatus
+        ) {
+                if (targetType == null) {
+                        throw new IllegalArgumentException("targetType은 필수입니다.");
+                }
+                if (orderId == null || orderId.isBlank()) {
+                        throw new IllegalArgumentException("orderId는 필수입니다.");
+                }
+                if (idempotencyKey == null || idempotencyKey.isBlank()) {
+                        throw new IllegalArgumentException("idempotencyKey는 필수입니다.");
+                }
+                if (paymentId == null || paymentId.isBlank()) {
+                        throw new IllegalArgumentException("paymentId는 필수입니다.");
+                }
+
+                String requestId = MDC.get(MDC_KEY);
+                if (requestId == null || requestId.isBlank()) {
+                        throw new IllegalStateException("requestId가 존재하지 않습니다. Filter 설정을 확인하세요.");
+                }
+
+                IdempotencyRecord record = new IdempotencyRecord();
+                record.targetType = targetType;
+                record.targetId = orderId;
+                record.idempotencyKey = idempotencyKey;
+                record.paymentId = paymentId;
+                record.responseStatus = responseStatus;
+                record.requestId = requestId;
+                record.createdAt = LocalDateTime.now();
+
+                return record;
+        }
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -60,10 +60,10 @@ public class Payment extends BaseEntity {
     private String currency;
 
     @Column(name = "requested_amount", nullable = false)
-    private Long requestedAmount;
+    private long requestedAmount;
 
     @Column(name = "captured_amount", nullable = false)
-    private Long capturedAmount;
+    private long capturedAmount;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", length = 32, nullable = false)
@@ -73,7 +73,7 @@ public class Payment extends BaseEntity {
             String orderId,
             String merchantId,
             String buyerId,
-            Long amount
+            long amount
     ) {
         Payment payment = new Payment();
 

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -1,6 +1,7 @@
 package com.settleops.domain.payment.domain;
 
 import com.settleops.domain.order.domain.OrderStatus;
+import com.settleops.global.entity.BaseEntity;
 import com.settleops.global.enums.Action;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -40,7 +41,7 @@ import java.util.UUID;
                 @Index(name = "idx_payment_buyer_id", columnList = "buyer_id")
         }
 )
-public class Payment {
+public class Payment extends BaseEntity {
 
     @Id
     @Column(name = "payment_id", columnDefinition = "char(36)", nullable = false)
@@ -68,12 +69,6 @@ public class Payment {
     @Column(name = "status", length = 32, nullable = false)
     private PaymentStatus status;
 
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
-
     public static Payment create(
             String orderId,
             String merchantId,
@@ -90,8 +85,6 @@ public class Payment {
         payment.requestedAmount = amount;
         payment.capturedAmount = 0L;
         payment.status = PaymentStatus.CREATED;
-        payment.createdAt = LocalDateTime.now();
-        payment.updatedAt = payment.createdAt;
 
         return payment;
     }
@@ -103,7 +96,6 @@ public class Payment {
         }
         this.status = PaymentStatus.CAPTURED;
         this.capturedAmount = this.requestedAmount; // 전액 캡처 고정
-        this.updatedAt = LocalDateTime.now();
     }
 
 }

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -101,6 +101,7 @@ public class Payment {
             return; // no-op (멱등 안전)
         }
         this.status = PaymentStatus.CAPTURED;
+        this.capturedAmount = this.requestedAmount; // 전액 캡처 고정
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -91,6 +91,7 @@ public class Payment {
         payment.capturedAmount = 0L;
         payment.status = PaymentStatus.CREATED;
         payment.createdAt = LocalDateTime.now();
+        payment.updatedAt = payment.createdAt;
 
         return payment;
     }

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -1,0 +1,107 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.domain.order.domain.OrderStatus;
+import com.settleops.global.enums.Action;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/*
+* mysql> desc payment;
+    +------------------+-------------+------+-----+---------+-------+
+    | Field            | Type        | Null | Key | Default | Extra |
+    +------------------+-------------+------+-----+---------+-------+
+    | payment_id       | char(36)    | NO   | PRI | NULL    |       |
+    | order_id         | varchar(64) | NO   | MUL | NULL    |       |
+    | merchant_id      | varchar(32) | NO   | MUL | NULL    |       |
+    | buyer_id         | varchar(32) | NO   | MUL | NULL    |       |
+    | currency         | char(3)     | NO   |     | KRW     |       |
+    | requested_amount | bigint      | NO   |     | NULL    |       |
+    | captured_amount  | bigint      | NO   |     | 0       |       |
+    | status           | varchar(32) | NO   | MUL | NULL    |       |
+    | created_at       | datetime(6) | NO   | MUL | NULL    |       |
+    | updated_at       | datetime(6) | NO   |     | NULL    |       |
+    +------------------+-------------+------+-----+---------+-------+
+* */
+
+@Getter
+@Setter
+@Entity
+@Table(
+        name = "payment",
+        indexes = {
+                @Index(name = "idx_payment_status", columnList = "status"),
+                @Index(name = "idx_payment_created_at", columnList = "created_at"),
+                @Index(name = "idx_payment_order_id", columnList = "order_id"),
+                @Index(name = "idx_payment_merchant_id", columnList = "merchant_id"),
+                @Index(name = "idx_payment_buyer_id", columnList = "buyer_id")
+        }
+)
+public class Payment {
+
+    @Id
+    @Column(name = "payment_id", columnDefinition = "char(36)", nullable = false)
+    private String paymentId;
+
+    @Column(name = "order_id", columnDefinition = "char(36)", nullable = false)
+    private String orderId;
+
+    @Column(name = "merchant_id", length = 32, nullable = false)
+    private String merchantId;
+
+    @Column(name = "buyer_id", length = 32, nullable = false)
+    private String buyerId;
+
+    @Column(name = "currency", columnDefinition = "char(3)", nullable = false)
+    private String currency;
+
+    @Column(name = "requested_amount", nullable = false)
+    private Long requestedAmount;
+
+    @Column(name = "captured_amount", nullable = false)
+    private Long capturedAmount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 32, nullable = false)
+    private PaymentStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Payment create(
+            String orderId,
+            String merchantId,
+            String buyerId,
+            Long amount
+    ) {
+        Payment payment = new Payment();
+
+        payment.paymentId = UUID.randomUUID().toString();
+        payment.orderId = orderId;
+        payment.merchantId = merchantId;
+        payment.buyerId = buyerId;
+        payment.currency = "KRW";
+        payment.requestedAmount = amount;
+        payment.capturedAmount = 0L;
+        payment.status = PaymentStatus.CREATED;
+        payment.createdAt = LocalDateTime.now();
+
+        return payment;
+    }
+
+
+    public void capture() {
+        if (this.status == PaymentStatus.CAPTURED) {
+            return; // no-op (멱등 안전)
+        }
+        this.status = PaymentStatus.CAPTURED;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
@@ -2,6 +2,7 @@ package com.settleops.domain.payment.domain;
 
 import com.settleops.global.enums.Action;
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.slf4j.MDC;
 
 import java.time.LocalDateTime;
@@ -19,6 +20,7 @@ import java.time.LocalDateTime;
 // | occurred_at      | datetime(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED |
 // +------------------+-------------+------+-----+----------------------+-------------------+
 
+@Getter
 @Entity
 @Table(
         name="payment_event",

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
@@ -1,0 +1,130 @@
+package com.settleops.domain.payment.domain;
+
+import com.settleops.global.enums.Action;
+import jakarta.persistence.*;
+import org.slf4j.MDC;
+
+import java.time.LocalDateTime;
+
+// mysql> desc payment_event;
+// +------------------+-------------+------+-----+----------------------+-------------------+
+// | Field            | Type        | Null | Key | Default              | Extra             |
+// +------------------+-------------+------+-----+----------------------+-------------------+
+// | payment_event_id | bigint      | NO   | PRI | NULL                 | auto_increment    |
+// | payment_id       | char(36)    | NO   | MUL | NULL                 |                   |
+// | event_type       | varchar(32) | NO   | MUL | NULL                 |                   |
+// | status_before    | varchar(64) | YES  |     | NULL                 |                   |
+// | status_after     | varchar(64) | YES  |     | NULL                 |                   |
+// | request_id       | char(36)    | NO   | MUL | NULL                 |                   |
+// | occurred_at      | datetime(6) | NO   |     | CURRENT_TIMESTAMP(6) | DEFAULT_GENERATED |
+// +------------------+-------------+------+-----+----------------------+-------------------+
+
+@Entity
+@Table(
+        name="payment_event",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name="uk_payment_event_payment_type",
+                        columnNames = {"payment_id","event_type"}
+                )
+        },
+        indexes = {
+                @Index(name="idx_payment_event_request_id",columnList="request_id"),
+                @Index(name="idx_payment_event_payment_id_occurred_at",columnList="payment_id, occurred_at"),
+                @Index(name = "idx_payment_event_type_occurred_at", columnList = "event_type, occurred_at")
+        }
+)
+public class PaymentEvent {
+
+    private final static String MDC_KEY = "requestId";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_event_id", nullable = false)
+    private Long paymentEventId;
+
+    @Column(name = "payment_id", columnDefinition = "char(36)", nullable = false)
+    private String paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", length = 32, nullable = false)
+    private Action eventType;
+
+    @Column(name = "status_before", length = 64)
+    private PaymentStatus statusBefore;
+
+    @Column(name = "status_after", length = 64)
+    private PaymentStatus statusAfter;
+
+    @Column(name = "request_id", columnDefinition = "char(36)", nullable = false)
+    private String requestId;
+
+    // DB DEFAULT CURRENT_TIMESTAMP(6)
+    @Column(name = "occurred_at", nullable = false, insertable = false, updatable = false)
+    private LocalDateTime occurredAt;
+
+    public static PaymentEvent create(String paymentId, Action eventType, PaymentStatus statusBefore, PaymentStatus statusAfter){
+        String requestId = MDC.get(MDC_KEY);
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 MDC에 없습니다. RequestIdFilter 설정을 확인하세요.");
+        }
+        if (paymentId == null || paymentId.isBlank()) {
+            throw new IllegalArgumentException("paymentId는 필수입니다.");
+        }
+        if (eventType == null) {
+            throw new IllegalArgumentException("eventType은 필수입니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = eventType;
+        e.statusBefore = statusBefore;
+        e.statusAfter = statusAfter;
+        e.requestId = requestId;
+        return e;
+    }
+    private static PaymentEvent of(
+            String paymentId,
+            Action action,
+            PaymentStatus before,
+            PaymentStatus after
+    ) {
+        String requestId = MDC.get("requestId");
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 없습니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = action;
+        e.statusBefore = before;
+        e.statusAfter = after;
+        e.requestId = requestId;
+        return e;
+    }
+
+    public static PaymentEvent created(String paymentId) {
+        String requestId = MDC.get("requestId");
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("requestId가 없습니다.");
+        }
+
+        PaymentEvent e = new PaymentEvent();
+        e.paymentId = paymentId;
+        e.eventType = Action.PAYMENT_CREATED;
+        e.statusBefore = null;
+        e.statusAfter = PaymentStatus.CREATED;
+        e.requestId = requestId;
+        return e;
+    }
+
+    public static PaymentEvent captured(String paymentId) {
+        return of(
+                paymentId,
+                Action.PAYMENT_CAPTURED,
+                PaymentStatus.CREATED,
+                PaymentStatus.CAPTURED
+        );
+    }
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
@@ -1,6 +1,7 @@
 package com.settleops.domain.payment.domain;
 
 import com.settleops.global.enums.Action;
+import com.settleops.global.logging.RequestIdProvider;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.slf4j.MDC;
@@ -50,7 +51,7 @@ public class PaymentEvent {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "event_type", length = 32, nullable = false)
-    private Action eventType;
+    private PaymentEventType eventType;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status_before", length = 64)
@@ -69,7 +70,7 @@ public class PaymentEvent {
 
     private static PaymentEvent of(
             String paymentId,
-            Action eventType,
+            PaymentEventType eventType,
             PaymentStatus before,
             PaymentStatus after
     ) {
@@ -80,10 +81,7 @@ public class PaymentEvent {
             throw new IllegalArgumentException("eventType은 필수입니다.");
         }
 
-        String requestId = MDC.get(MDC_KEY);
-        if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException("requestId가 MDC에 없습니다.");
-        }
+        String requestId = RequestIdProvider.current();
 
         PaymentEvent e = new PaymentEvent();
         e.paymentId = paymentId;
@@ -97,7 +95,7 @@ public class PaymentEvent {
     public static PaymentEvent created(String paymentId) {
         return of(
                 paymentId,
-                Action.PAYMENT_CREATED,
+                PaymentEventType.PAYMENT_CREATED,
                 null,
                 PaymentStatus.CREATED
         );
@@ -106,7 +104,7 @@ public class PaymentEvent {
     public static PaymentEvent captured(String paymentId) {
         return of(
                 paymentId,
-                Action.PAYMENT_CAPTURED,
+                PaymentEventType.PAYMENT_CAPTURED,
                 PaymentStatus.CREATED,
                 PaymentStatus.CAPTURED
         );

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEvent.java
@@ -50,9 +50,11 @@ public class PaymentEvent {
     @Column(name = "event_type", length = 32, nullable = false)
     private Action eventType;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status_before", length = 64)
     private PaymentStatus statusBefore;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "status_after", length = 64)
     private PaymentStatus statusAfter;
 
@@ -63,11 +65,12 @@ public class PaymentEvent {
     @Column(name = "occurred_at", nullable = false, insertable = false, updatable = false)
     private LocalDateTime occurredAt;
 
-    public static PaymentEvent create(String paymentId, Action eventType, PaymentStatus statusBefore, PaymentStatus statusAfter){
-        String requestId = MDC.get(MDC_KEY);
-        if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException("requestId가 MDC에 없습니다. RequestIdFilter 설정을 확인하세요.");
-        }
+    private static PaymentEvent of(
+            String paymentId,
+            Action eventType,
+            PaymentStatus before,
+            PaymentStatus after
+    ) {
         if (paymentId == null || paymentId.isBlank()) {
             throw new IllegalArgumentException("paymentId는 필수입니다.");
         }
@@ -75,28 +78,14 @@ public class PaymentEvent {
             throw new IllegalArgumentException("eventType은 필수입니다.");
         }
 
-        PaymentEvent e = new PaymentEvent();
-        e.paymentId = paymentId;
-        e.eventType = eventType;
-        e.statusBefore = statusBefore;
-        e.statusAfter = statusAfter;
-        e.requestId = requestId;
-        return e;
-    }
-    private static PaymentEvent of(
-            String paymentId,
-            Action action,
-            PaymentStatus before,
-            PaymentStatus after
-    ) {
-        String requestId = MDC.get("requestId");
+        String requestId = MDC.get(MDC_KEY);
         if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException("requestId가 없습니다.");
+            throw new IllegalStateException("requestId가 MDC에 없습니다.");
         }
 
         PaymentEvent e = new PaymentEvent();
         e.paymentId = paymentId;
-        e.eventType = action;
+        e.eventType = eventType;
         e.statusBefore = before;
         e.statusAfter = after;
         e.requestId = requestId;
@@ -104,18 +93,12 @@ public class PaymentEvent {
     }
 
     public static PaymentEvent created(String paymentId) {
-        String requestId = MDC.get("requestId");
-        if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException("requestId가 없습니다.");
-        }
-
-        PaymentEvent e = new PaymentEvent();
-        e.paymentId = paymentId;
-        e.eventType = Action.PAYMENT_CREATED;
-        e.statusBefore = null;
-        e.statusAfter = PaymentStatus.CREATED;
-        e.requestId = requestId;
-        return e;
+        return of(
+                paymentId,
+                Action.PAYMENT_CREATED,
+                null,
+                PaymentStatus.CREATED
+        );
     }
 
     public static PaymentEvent captured(String paymentId) {

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentEventType.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentEventType.java
@@ -1,0 +1,7 @@
+package com.settleops.domain.payment.domain;
+
+public enum PaymentEventType {
+    PAYMENT_CREATED,
+    PAYMENT_CAPTURED,
+    PAYMENT_CONFIRMED
+}

--- a/server/src/main/java/com/settleops/domain/payment/domain/PaymentStatus.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/PaymentStatus.java
@@ -1,0 +1,6 @@
+package com.settleops.domain.payment.domain;
+
+public enum PaymentStatus {
+    CREATED,
+    CAPTURED
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/IdempotencyRecordRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/IdempotencyRecordRepository.java
@@ -1,0 +1,18 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.IdempotencyRecord;
+import com.settleops.domain.payment.domain.Payment;
+import com.settleops.global.enums.IdempotencyTargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IdempotencyRecordRepository extends JpaRepository<IdempotencyRecord, Long> {
+
+    /** c1-> c2 order 결제 중복 조회 */
+    public Optional<IdempotencyRecord> findByTargetTypeAndTargetIdAndIdempotencyKey(
+            IdempotencyTargetType targetType,
+            String targetId,
+            String idempotencyKey
+    );
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
@@ -1,0 +1,8 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.PaymentEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentEventRepository extends JpaRepository<PaymentEvent,Long> {
+
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
@@ -1,7 +1,7 @@
 package com.settleops.domain.payment.infra;
 
 import com.settleops.domain.payment.domain.PaymentEvent;
-import com.settleops.global.enums.Action;
+import com.settleops.domain.payment.domain.PaymentEventType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +18,6 @@ public interface PaymentEventRepository extends JpaRepository<PaymentEvent,Long>
     """)
     Optional<LocalDateTime> findOccurredAtByPaymentIdAndEventType(
             @Param("paymentId") String paymentId,
-            @Param("eventType") Action eventType
+            @Param("eventType") PaymentEventType eventType
     );
 }

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentEventRepository.java
@@ -1,8 +1,23 @@
 package com.settleops.domain.payment.infra;
 
 import com.settleops.domain.payment.domain.PaymentEvent;
+import com.settleops.global.enums.Action;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 public interface PaymentEventRepository extends JpaRepository<PaymentEvent,Long> {
-
+    @Query("""
+        select e.occurredAt
+        from PaymentEvent e
+        where e.paymentId = :paymentId
+          and e.eventType = :eventType
+    """)
+    Optional<LocalDateTime> findOccurredAtByPaymentIdAndEventType(
+            @Param("paymentId") String paymentId,
+            @Param("eventType") Action eventType
+    );
 }

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentRepository.java
@@ -1,0 +1,12 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, String> {
+
+
+    Optional<Payment> findByOrderId(String orderId);
+}

--- a/server/src/main/java/com/settleops/global/enums/IdempotencyTargetType.java
+++ b/server/src/main/java/com/settleops/global/enums/IdempotencyTargetType.java
@@ -1,0 +1,7 @@
+package com.settleops.global.enums;
+
+public enum IdempotencyTargetType {
+    PAY_ORDER,
+    HOLD,
+    REFUND
+}

--- a/server/src/main/java/com/settleops/global/logging/RequestIdProvider.java
+++ b/server/src/main/java/com/settleops/global/logging/RequestIdProvider.java
@@ -1,0 +1,18 @@
+package com.settleops.global.logging;
+
+import org.slf4j.MDC;
+
+public final class RequestIdProvider {
+
+    private RequestIdProvider() {}
+
+    public static String current() {
+        String requestId = MDC.get(RequestIdKeys.MDC_KEY);
+
+        if (requestId == null || requestId.isBlank()) {
+            throw new IllegalStateException("request_id is missing in MDC");
+        }
+
+        return requestId;
+    }
+}


### PR DESCRIPTION
# feat(payment): add pay service flow and introduce order domain

## What
- `PayService.pay()` 메서드 신규 구현
- `orders` 기반 결제 흐름 연결 (orderId 기준 결제 처리)
- Order 도메인 신규 도입
  - `Orders`
  - `OrderStatus`
  - `OrdersRepository`
  - `OrderService`
- 주문 1건당 결제 1건(1:1) 흐름 전제 로직 구성
- 결제 성공 시
  - `Payment.status = CAPTURED`
  - `capturedAmount` 확정
  - `order.status = PAID` 상태 전이
- `PaymentEvent` 저장 로직 포함 (CAPTURE 이벤트 기록)
- `X-Idempotency-Key` 기반 멱등 처리 로직 적용
  - 중복 요청 시 기존 payment 재조회 후 200 수렴

## Why
- 주문 SoT(`orders`) 기반의 결제 흐름을 명확히 구성하기 위함.
- MVP 요구사항인 주문 1건당 결제 1건(1:1) 구조를 서비스 레벨에서 보장하기 위함.
- 결제 재시도 상황에서 안전하게 수렴하도록 멱등 처리 로직을 적용하기 위함.
- 결제 성공 시 주문 상태와 결제 상태 전이를 명확히 분리 관리하기 위함.

## How to test
- `POST /api/consumer/orders/{orderId}/pay`
- Header: `X-Idempotency-Key: test-key-1`

### 1차 호출
- 200 OK 반환
- Payment 정보 반환 확인
- order.status = PAID 확인
- payment.status = CAPTURED 확인

### 동일 키 재호출
- 200 OK (no-op)
- 동일 payment 반환 확인

### 헤더 없이 호출
- 400 Bad Request 반환 확인