### PR TITLE
refactor: 공통 BaseEntity(Audit) 추가 및 datetime(6) 기준 통일

### DIFF
--- a/server/src/main/java/com/settleops/global/entity/BaseEntity.java
+++ b/server/src/main/java/com/settleops/global/entity/BaseEntity.java
@@ -1,0 +1,85 @@
+package com.settleops.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+
+/**
+ * <p>공통 감사(Audit) 컬럼을 제공하는 BaseEntity 입니다.</p>
+ * <ul>
+ *     <li>기획서 SoT 기준에 따라 모든 시간 컬럼은 DATETIME(6)으로 고정합니다.</li>
+ *     <li>created_at, updated_at 컬럼명을 전 도메인에서 통일합니다.</li>
+ *     <li>DB 정밀도(마이크로초)와 정합성을 맞추기 위해 columnDefinition = "datetime(6)"을 명시합니다.</li>
+ * </ul>
+ *
+ * <p>주의</p>
+ * <ul>
+ *     <li>request 단위 추적과 무관한 순수 감사 컬럼입니다.</li>
+ *     <li>시간 생성은 애플리케이션 레벨(LocalDateTime.now()) 기준입니다.</li>
+ * </ul>
+ */
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    /**
+     * 엔티티 최초 생성 시각입니다.
+     *
+     * <ul>
+     *     <li>컬럼명: created_at</li>
+     *     <li>nullable = false</li>
+     *     <li>updatable = false (생성 이후 변경 금지)</li>
+     *     <li>DB 타입: datetime(6)</li>
+     * </ul>
+     */
+    @Column(name = "created_at",
+            nullable = false,
+            updatable = false,
+            columnDefinition = "datetime(6)")
+    protected LocalDateTime createdAt;
+
+    /**
+     * 엔티티 최종 수정 시각입니다.
+     *
+     * <ul>
+     *     <li>컬럼명: updated_at</li>
+     *     <li>nullable = false</li>
+     *     <li>DB 타입: datetime(6)</li>
+     *     <li>Update 발생 시마다 자동 갱신됩니다.</li>
+     * </ul>
+     */
+    @Column(name = "updated_at",
+            nullable = false,
+            columnDefinition = "datetime(6)")
+    protected LocalDateTime updatedAt;
+
+    /**
+     * 엔티티가 최초 영속화(Persist) 되기 직전에 실행됩니다.
+     *
+     * <ul>
+     *     <li>createdAt, updatedAt을 현재 시각으로 초기화합니다.</li>
+     *     <li>JPA 생명주기 콜백(@PrePersist)을 사용합니다.</li>
+     * </ul>
+     */
+    @PrePersist
+    protected void prePersist() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /**
+     * 엔티티가 수정(Update) 되기 직전에 실행됩니다.
+     *
+     * <ul>
+     *     <li>updatedAt을 현재 시각으로 갱신합니다.</li>
+     *     <li>createdAt은 변경되지 않습니다.</li>
+     *     <li>JPA 생명주기 콜백(@PreUpdate)을 사용합니다.</li>
+     * </ul>
+     */
+    @PreUpdate
+    protected void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
## 변경 내용
- global.entity.BaseEntity 신규 추가
- created_at, updated_at 컬럼 DATETIME(6) 고정
- JPA 생명주기 콜백으로 시간 자동 세팅
  - @PrePersist: 생성 시각 초기화
  - @PreUpdate: 수정 시각 갱신

## 목적
- 기획서 SoT 기준 시간 컬럼 규격 통일
- 전 도메인 공통 Audit 구조 마련
- 향후 Payment / Order / PaymentEvent 상속 적용 기반 준비

## 영향 범위
- 기존 엔터티 변경 없음
- DB 스키마 변경 없음
- 기능 변경 없음 (Refactor 성격)

## 주의사항
- 본 PR은 “기반(BaseEntity) 추가”만 포함합니다.
- 이후 각 도메인 엔터티에 BaseEntity 상속을 적용할 때는 다음 수정이 필요할 수 있습니다.
  - 엔터티별 기존 created_at/updated_at 필드 중복 제거 및 매핑 정리
  - DB DDL/마이그레이션에서 DEFAULT/ON UPDATE 정책(예: CURRENT_TIMESTAMP(6))과의 정합성 재확인
  - 테스트/쿼리/정렬 조건에서 컬럼 사용 방식 점검

## 체크리스트
> 리뷰 시 필수 확인 사항을 명시하여 누락을 방지하기 위한 확인용 항목입니다.

- [x] DATETIME(6) 명시
- [x] 컬럼명 created_at / updated_at 통일
- [x] created_at updatable=false 설정 확인