### PR TITLE
feat(audit): add AuditLogger actorId validation + required field guards

### DIFF
--- a/server/src/main/java/com/settleops/global/audit/AuditLogger.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogger.java
@@ -11,6 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuditLogger {
     private final AuditLogRepository auditLogRepository;
+    private static final int ACTOR_ID_MAX = 32;
+
+    private void validateActorId(String actorId) {
+        if (actorId == null) throw new BadRequestException("actorId is null");
+        if (actorId.isBlank()) throw new BadRequestException("actorId is blank");
+        if (actorId.length() > ACTOR_ID_MAX) throw new BadRequestException("actorId too long (max 32)");
+        if (actorId.chars().anyMatch(ch -> ch <= 0x20 || ch >= 0x7F)) {
+            // 0x20(space) 이하 제어문자/공백 금지 + 0x7F 이상 비ASCII 금지
+            throw new BadRequestException("actorId must be ASCII without whitespace");
+        }
+
+    }
 
     @Transactional
     public void log(AuditLogCommand cmd) {
@@ -23,7 +35,8 @@ public class AuditLogger {
 
         if (cmd.getAction() == null) throw new BadRequestException("action is null");
         if (cmd.getActorType() == null) throw new BadRequestException("actorType is null");
-        if (cmd.getActorId() == null) throw new BadRequestException("actorId is null");
+        validateActorId(cmd.getActorId());
+
         if (cmd.getEntityType() == null) throw new BadRequestException("entityType is null");
         if (cmd.getEntityId() == null) throw new BadRequestException("entityId is null");
 


### PR DESCRIPTION
## Summary
- 목적: `audit_log` 저장을 `AuditLogger.log(...)` **단일 진입점**으로 강제하고, 저장 전 입력값을 표준 규칙으로 검증합니다.

## Changes
- `actor_id` 표준 검증 추가: **ASCII only + whitespace 금지 + length ≤ 32** (위반 시 400)
- 필수 필드 가드 추가: `requestId`, `action`, `actorType`, `entityType`, `entityId` null/blank 방어

## Impact
- 도메인(A/B/C)은 `audit_log` 직접 save 대신 `AuditLogger.log(cmd)` 호출로 통일 (운영 재현/Trace 품질 보호)