### PR TITLE
refactor: RequestIdResolver 도입 및 pay 도메인 requestId 추출 표준화

### DIFF
--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
@@ -4,6 +4,7 @@ import com.settleops.domain.payment.api.dto.PayResponseDTO;
 import com.settleops.domain.payment.application.PayService;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.logging.RequestIdKeys;
+import com.settleops.global.web.RequestIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class ConsumerPayController {
 
     private final PayService payService;
+    private final RequestIdResolver requestIdResolver;
 
     /** 주문 상세 조회 */
     @GetMapping("/{orderId}")
@@ -64,10 +66,8 @@ public class ConsumerPayController {
             @RequestHeader("X-Idempotency-Key") String idempotencyKey,
             HttpServletRequest request
     ) {
-        String requestId =  (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
-        if (requestId == null || requestId.isBlank()) {
-            throw new BadRequestException("X-Request-Id attribute is missing.");
-        }
+
+        String requestId = requestIdResolver.resolve(request);
 
         PayResponseDTO response =
                 payService.pay(orderId, idempotencyKey,requestId);

--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPaymentController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPaymentController.java
@@ -6,6 +6,7 @@ import com.settleops.global.auth.controller.MeController;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.UnauthorizedException;
 import com.settleops.global.logging.RequestIdKeys;
+import com.settleops.global.web.RequestIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ConsumerPaymentController {
 
     private final ConfirmService confirmService;
+    private final RequestIdResolver requestIdResolver;
 
     /**
      * 결제 확정(Confirm) API
@@ -74,10 +76,7 @@ public class ConsumerPaymentController {
             throw new UnauthorizedException("인증이 필요합니다.");
         }
 
-        String requestId = (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
-        if (requestId == null || requestId.isBlank()) {
-            throw new BadRequestException("X-Request-Id attribute is missing.");
-        }
+        String requestId = requestIdResolver.resolve(request);
 
         return confirmService.confirm(paymentId, buyerId, requestId);
     }

--- a/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
@@ -93,11 +93,11 @@ public class ConfirmService {
 
     /**
      * requestId는 추적 / 감사 로그 기준값이므로 필수입니다.
-     * 누락 시 내부 오류가 아니라 잘못된 요청으로 처리합니다.
+     * 누락 시 내부 오류가 아니라 내부 계약 위반으로 잘못된 요청으로 처리합니다.
      */
     private void validateRequestId(String requestId) {
         if (requestId == null || requestId.isBlank()) {
-            throw new BadRequestException("X-Request-Id는 필수입니다.");
+            throw new IllegalStateException("X-Request-Id는 필수입니다.");
         }
     }
 

--- a/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
@@ -93,11 +93,11 @@ public class ConfirmService {
 
     /**
      * requestId는 추적 / 감사 로그 기준값이므로 필수입니다.
-     * 누락 시 내부 오류가 아니라 내부 계약 위반으로 잘못된 요청으로 처리합니다.
+     * 누락 시 내부 오류가 아니라 잘못된 요청으로 처리합니다.
      */
     private void validateRequestId(String requestId) {
         if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException("X-Request-Id는 필수입니다.");
+            throw new BadRequestException("X-Request-Id는 필수입니다.");
         }
     }
 

--- a/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
+++ b/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
@@ -1,0 +1,26 @@
+package com.settleops.global.web;
+
+import com.settleops.global.error.BadRequestException;
+import com.settleops.global.logging.RequestIdKeys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * HttpServletRequest 에서 requestId 를 표준 방식으로 추출한다.
+ *
+ * <p>requestId 는 RequestIdFilter 가 request attribute 에 주입한 값을 사용한다.</p>
+ * <p>누락 또는 공백이면 400(BAD_REQUEST)로 처리한다.</p>
+ */
+@Component
+public class RequestIdResolver {
+
+    public String resolve(HttpServletRequest request) {
+        String requestId = (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
+
+        if (requestId == null || requestId.isBlank()) {
+            throw new BadRequestException("X-Request-Id attribute is missing.");
+        }
+
+        return requestId;
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항

### 1) `RequestIdResolver` 도입
- `HttpServletRequest`에서 `requestId`를 공통 방식으로 추출하는 Resolver 추가
- Controller 단의 `request.getAttribute(...)` 직접 호출 제거
- `requestId` 추출 실패 시 Resolver 기준 예외 처리로 수렴

### 2) pay 도메인 Controller 적용
- pay Controller의 `requestId` 직접 추출 로직 제거
- `RequestIdResolver` 기반 추출 방식으로 변경
- Controller 단 requestId 처리 로직 단순화

## 후속 적용 가이드
** @ggeuri @heyin-hein @yeowoniing  **

다른 도메인/Controller에서 동일 패턴이 있는 경우 아래 방식으로 동일하게 정리하면 됩니다.

### 적용 대상
- `HttpServletRequest`를 직접 받아서
- `request.getAttribute(RequestIdKeys.ATTR_KEY)` 로 `requestId`를 꺼내는 Controller
- `requestId` 누락 시 `IllegalStateException` 또는 유사 예외를 직접 던지는 Controller

### 변경 전 패턴
```java
String requestId = (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
if (requestId == null || requestId.isBlank()) {
    throw new IllegalStateException("requestId attribute missing. Check RequestIdFilter.");
}
```

### 변경 후 패턴
- Controller에 `RequestIdResolver` 주입
- `requestId` 추출은 `requestIdResolver.resolve(request)` 호출로 통일

```
String requestId = requestIdResolver.resolve(request);
```

## 참고

- `request_id` 생성/주입 책임은 기존과 동일하게 `RequestIdFilter` 단일 책임 유지
- 이번 PR 범위는 **RequestIdResolver 도입 및 pay 도메인 적용**으로 한정
- pay 멱등 처리 구조 변경 PR은 별도 PR에서 반영 및 머지 완료