### PR TITLE
Feat/audit log standardization

### DIFF
--- a/server/src/main/java/com/settleops/global/audit/AuditLog.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLog.java
@@ -72,11 +72,28 @@ public class AuditLog {
         this.metaJson = metaJson;
     }
 
+    /** AuditLogCommand → AuditLog 엔티티 변환 */
+    public static AuditLog of(AuditLogCommand cmd) {
+        return AuditLog.builder()
+                .requestId(cmd.getRequestId())
+                .action(cmd.getAction())
+                .actorType(cmd.getActorType())
+                .actorId(cmd.getActorId())
+                .occurredAt(cmd.getOccurredAt())
+                .entityType(cmd.getEntityType())
+                .entityId(cmd.getEntityId())
+                .statusBefore(cmd.getStatusBefore())
+                .statusAfter(cmd.getStatusAfter())
+                .merchantId(cmd.getMerchantId())
+                .metaJson(cmd.getMetaJson())
+                .build();
+    }
+
     //occurredAt null방지
     @PrePersist
     void prePersist() {
         if (occurredAt == null) occurredAt = LocalDateTime.now();
-        if (metaJson == null || metaJson.isBlank()) metaJson = "{}";
+        if (metaJson == null || metaJson.isBlank()) metaJson = "{\"noOp\":false}";
     }
 
 }

--- a/server/src/main/java/com/settleops/global/audit/AuditLogger.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogger.java
@@ -3,6 +3,7 @@ package com.settleops.global.audit;
 import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 // audit_log 저장을 단일 진입점으로 강제(직접 save 금지)하고, requestId 포함/필수값 검증 후 일관된 포맷으로 감사로그를 남긴다.
@@ -13,20 +14,23 @@ public class AuditLogger {
     private final AuditLogRepository auditLogRepository;
     private static final int ACTOR_ID_MAX = 32;
 
-    private void validateActorId(String actorId) {
-        if (actorId == null) throw new BadRequestException("actorId is null");
-        if (actorId.isBlank()) throw new BadRequestException("actorId is blank");
-        if (actorId.length() > ACTOR_ID_MAX) throw new BadRequestException("actorId too long (max 32)");
-        if (actorId.chars().anyMatch(ch -> ch <= 0x20 || ch >= 0x7F)) {
-            // 0x20(space) 이하 제어문자/공백 금지 + 0x7F 이상 비ASCII 금지
-            throw new BadRequestException("actorId must be ASCII without whitespace");
-        }
-
-    }
-
     @Transactional
     public void log(AuditLogCommand cmd) {
+        saveInternal(cmd);
+    }
 
+    /** 409 실패 Audit 전용(GlobalExceptionHandler 사용) */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void logFailureRequiresNew(AuditLogCommand cmd) {
+        saveInternal(cmd);
+    }
+
+    private void saveInternal(AuditLogCommand cmd) {
+        validateCommand(cmd);
+        auditLogRepository.save(AuditLog.of(cmd));
+    }
+
+    private void validateCommand(AuditLogCommand cmd) {
         if (cmd == null) throw new BadRequestException("auditLogCommand is null");
 
         if (cmd.getRequestId() == null || cmd.getRequestId().isBlank()) {
@@ -38,22 +42,19 @@ public class AuditLogger {
         validateActorId(cmd.getActorId());
 
         if (cmd.getEntityType() == null) throw new BadRequestException("entityType is null");
-        if (cmd.getEntityId() == null) throw new BadRequestException("entityId is null");
+        if (cmd.getEntityId() == null || cmd.getEntityId().isBlank()) {
+            throw new BadRequestException("entityId is null/blank");
+        }
+    }
 
-        AuditLog auditLog = AuditLog.builder()
-                .requestId(cmd.getRequestId())
-                .action(cmd.getAction())
-                .actorType(cmd.getActorType())
-                .actorId(cmd.getActorId())
-                .occurredAt(cmd.getOccurredAt())
-                .entityType(cmd.getEntityType())
-                .entityId(cmd.getEntityId())
-                .statusBefore(cmd.getStatusBefore())
-                .statusAfter(cmd.getStatusAfter())
-                .metaJson(cmd.getMetaJson())
-                .merchantId(cmd.getMerchantId())
-                .build();
-
-        auditLogRepository.save(auditLog);
+    private void validateActorId(String actorId) {
+        if (actorId == null) throw new BadRequestException("actorId is null");
+        if (actorId.isBlank()) throw new BadRequestException("actorId is blank");
+        if (actorId.length() > ACTOR_ID_MAX) {
+            throw new BadRequestException("actorId too long (max 32)");
+        }
+        if (actorId.chars().anyMatch(ch -> ch <= 0x20 || ch >= 0x7F)) {
+            throw new BadRequestException("actorId must be ASCII without whitespace");
+        }
     }
 }

--- a/server/src/main/java/com/settleops/global/audit/AuditLogger.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogger.java
@@ -1,5 +1,6 @@
 package com.settleops.global.audit;
 
+import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -21,7 +22,8 @@ public class AuditLogger {
 
     /** 409 실패 Audit 전용(GlobalExceptionHandler 사용) */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void logFailureRequiresNew(AuditLogCommand cmd) {
+    public void logFailureRequiresNew(AuditLogCommand cmd, ReasonCode reasonCode) {
+        validateFailureReason(reasonCode);
         saveInternal(cmd);
     }
 
@@ -55,6 +57,16 @@ public class AuditLogger {
         }
         if (actorId.chars().anyMatch(ch -> ch <= 0x20 || ch >= 0x7F)) {
             throw new BadRequestException("actorId must be ASCII without whitespace");
+        }
+    }
+
+    private void validateFailureReason(ReasonCode reasonCode) {
+        if (reasonCode == null) {
+            throw new BadRequestException("reasonCode is null");
+        }
+        if (reasonCode != ReasonCode.SAME_APPROVER_NOT_ALLOWED
+                && reasonCode != ReasonCode.PAID_ALREADY) {
+            throw new BadRequestException("unsupported failure audit reason");
         }
     }
 }

--- a/server/src/main/java/com/settleops/global/audit/AuditMetaFactory.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditMetaFactory.java
@@ -1,0 +1,170 @@
+package com.settleops.global.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.settleops.global.error.BadRequestException;
+
+public final class AuditMetaFactory {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private AuditMetaFactory() {
+    }
+
+    /**
+     * 성공 기본 메타
+     * 예: {"noOp": false}
+     */
+    public static ObjectNode success() {
+        ObjectNode meta = MAPPER.createObjectNode();
+        meta.put("noOp", false);
+        return meta;
+    }
+
+    /**
+     * 성공 + comment
+     * 예: {"noOp": false, "comment": "..."}
+     */
+    public static ObjectNode successWithComment(String comment) {
+        ObjectNode meta = success();
+        putIfHasText(meta, "comment", comment);
+        return meta;
+    }
+
+    /**
+     * 성공 + reasonCode + comment
+     * 예: {"noOp": false, "reasonCode": "MANUAL_REVIEW", "comment": "..."}
+     */
+    public static ObjectNode successWithReasonAndComment(String reasonCode, String comment) {
+        ObjectNode meta = success();
+        putIfHasText(meta, "reasonCode", reasonCode);
+        putIfHasText(meta, "comment", comment);
+        return meta;
+    }
+
+    /**
+     * no-op 기본 메타
+     * 예: {"noOp": true, "noOpReason": "ALREADY_CONFIRMED"}
+     */
+    public static ObjectNode noOp(NoOpReason noOpReason) {
+        ObjectNode meta = MAPPER.createObjectNode();
+        meta.put("noOp", true);
+        meta.put("noOpReason", noOpReason.name());
+        return meta;
+    }
+
+    /**
+     * no-op + 멱등 재시도 여부 포함 메타 생성
+     * 예: {"noOp": true, "noOpReason": "ALREADY_CONFIRMED", "idempotent": true}
+     */
+    public static ObjectNode noOp(NoOpReason noOpReason, boolean idempotent) {
+        ObjectNode meta = noOp(noOpReason);
+        meta.put("idempotent", idempotent);
+        return meta;
+    }
+
+    /**
+     * no-op + 현재 상태 스냅샷
+     * 예:
+     * {
+     *   "noOp": true,
+     *   "noOpReason": "ALREADY_APPROVED",
+     *   "after": {"status": "APPROVED"}
+     * }
+     */
+    public static ObjectNode noOpWithStatus(NoOpReason noOpReason, String currentStatus) {
+        ObjectNode meta = noOp(noOpReason);
+        meta.set("after", statusNode(currentStatus));
+        return meta;
+    }
+
+    /**
+     * no-op + 현재 상태(after.status) + 멱등 재시도 여부 포함 메타 생성
+     * 예:
+     * {
+     *   "noOp": true,
+     *   "noOpReason": "ALREADY_PAY_REQUESTED",
+     *   "idempotent": true,
+     *   "after": {"status": "PAY_REQUESTED"}
+     * }
+     */
+    public static ObjectNode noOpWithStatus(NoOpReason noOpReason, String currentStatus, boolean idempotent) {
+        ObjectNode meta = noOp(noOpReason, idempotent);
+        meta.set("after", statusNode(currentStatus));
+        return meta;
+    }
+
+    /**
+     * 상태 전이 기본 메타
+     * 예:
+     * {
+     *   "noOp": false,
+     *   "before": {"status": "READY"},
+     *   "after": {"status": "PAY_REQUESTED"}
+     * }
+     */
+    public static ObjectNode statusChange(String beforeStatus, String afterStatus) {
+        ObjectNode meta = success();
+        meta.set("before", statusNode(beforeStatus));
+        meta.set("after", statusNode(afterStatus));
+        return meta;
+    }
+
+    /**
+     * 상태 전이 + comment
+     */
+    public static ObjectNode statusChange(String beforeStatus, String afterStatus, String comment) {
+        requireComment(comment);
+
+        ObjectNode meta = statusChange(beforeStatus, afterStatus);
+        meta.put("comment", comment);
+        return meta;
+    }
+
+    /**
+     * 상태 전이 + reasonCode + comment
+     */
+    public static ObjectNode statusChange(
+            String beforeStatus,
+            String afterStatus,
+            String reasonCode,
+            String comment
+    ) {
+        requireComment(comment);
+
+        ObjectNode meta = statusChange(beforeStatus, afterStatus);
+        putIfHasText(meta, "reasonCode", reasonCode);
+        meta.put("comment", comment);
+        return meta;
+    }
+
+    /**
+     * 상태값 JSON 노드 생성
+     * 예: {"status": "READY"}
+     */
+    private static ObjectNode statusNode(String status) {
+        ObjectNode node = MAPPER.createObjectNode();
+        putIfHasText(node, "status", status);
+        return node;
+    }
+
+    /**
+     * 문자열 값 존재 시 JSON 필드 추가
+     * null/blank 값은 저장하지 않음
+     */
+    private static void putIfHasText(ObjectNode node, String fieldName, String value) {
+        if (value != null && !value.isBlank()) {
+            node.put(fieldName, value);
+        }
+    }
+
+    /**
+     * comment 필수값 검증
+     * null/blank 입력 시 BadRequestException 발생
+     */
+    private static void requireComment(String comment) {
+        if (comment == null || comment.isBlank()) {
+            throw new BadRequestException("comment is null/blank");
+        }
+    }
+}

--- a/server/src/main/java/com/settleops/global/audit/AuditMetaFactory.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditMetaFactory.java
@@ -43,6 +43,31 @@ public final class AuditMetaFactory {
     }
 
     /**
+     * 필수 comment 성공 메타 생성
+     * 예: {"noOp": false, "comment": "..."}
+     */
+    public static ObjectNode requiredCommentSuccess(String comment) {
+        requireComment(comment);
+
+        ObjectNode meta = success();
+        meta.put("comment", comment);
+        return meta;
+    }
+
+    /**
+     * 필수 comment + reasonCode 성공 메타 생성
+     * 예: {"noOp": false, "reasonCode": "MANUAL_REVIEW", "comment": "..."}
+     */
+    public static ObjectNode requiredCommentSuccessWithReason(String reasonCode, String comment) {
+        requireComment(comment);
+
+        ObjectNode meta = success();
+        putIfHasText(meta, "reasonCode", reasonCode);
+        meta.put("comment", comment);
+        return meta;
+    }
+
+    /**
      * no-op 기본 메타
      * 예: {"noOp": true, "noOpReason": "ALREADY_CONFIRMED"}
      */

--- a/server/src/main/java/com/settleops/global/audit/NoOpReason.java
+++ b/server/src/main/java/com/settleops/global/audit/NoOpReason.java
@@ -1,0 +1,18 @@
+package com.settleops.global.audit;
+
+public enum NoOpReason {
+    // Confirm
+    ALREADY_CONFIRMED,
+
+    // Hold / Refund 공용
+    ALREADY_APPROVED,
+    ALREADY_RELEASED,
+    ALREADY_REJECTED,
+
+    // Paid
+    ALREADY_PAID,
+    ALREADY_PAY_REQUESTED,
+
+    // Batch
+    BATCH_KEY_EXISTS
+}

--- a/server/src/main/java/com/settleops/global/error/AuditableConflictException.java
+++ b/server/src/main/java/com/settleops/global/error/AuditableConflictException.java
@@ -1,0 +1,46 @@
+package com.settleops.global.error;
+
+import com.settleops.global.audit.ActorType;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.enums.Action;
+import com.settleops.global.enums.ReasonCode;
+import lombok.Getter;
+
+@Getter
+public class AuditableConflictException extends ConflictException {
+
+    private final ActorType actorType;
+    private final String actorId;
+    private final Action action;
+    private final EntityType entityType;
+    private final String entityId;
+    private final String merchantId;
+    private final String statusBefore;
+    private final String statusAfter;
+    private final String comment;
+
+    public AuditableConflictException(
+            ReasonCode reasonCode,
+            String message,
+            ActorType actorType,
+            String actorId,
+            Action action,
+            EntityType entityType,
+            String entityId,
+            String merchantId,
+            String statusBefore,
+            String statusAfter,
+            String comment
+    ) {
+        super(reasonCode, message);
+        this.actorType = actorType;
+        this.actorId = actorId;
+        this.action = action;
+        this.entityType = entityType;
+        this.entityId = entityId;
+        this.merchantId = merchantId;
+        this.statusBefore = statusBefore;
+        this.statusAfter = statusAfter;
+        this.comment = comment;
+    }
+}

--- a/server/src/main/java/com/settleops/global/error/ConflictException.java
+++ b/server/src/main/java/com/settleops/global/error/ConflictException.java
@@ -18,6 +18,10 @@ public class ConflictException extends BusinessException {
         this.reasonCode = reasonCode;
     }
 
+    public ReasonCode getReasonCode() {
+        return reasonCode;
+    }
+
     @Override
     public ErrorResponse toErrorResponse() {
         // 기획서 409 포맷: code는 RULE_VIOLATION, reason은 필수

--- a/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,12 @@
 package com.settleops.global.error;
 
+import com.settleops.global.audit.AuditLogCommand;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.audit.AuditMetaFactory;
+import com.settleops.global.enums.ReasonCode;
+import com.settleops.global.logging.RequestIdKeys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,13 +18,17 @@ import java.util.Comparator;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final AuditLogger auditLogger;
 
     /**
      * [LOCKED] 비즈니스 예외 처리 (403, 409 등)
      */
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e, HttpServletRequest request) {
+        tryLog409Failure(e, request);
         return ResponseEntity.status(e.getStatus()).body(e.toErrorResponse());
     }
 
@@ -106,5 +117,51 @@ public class GlobalExceptionHandler {
         log.error("Unhandled exception occurred", e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponse.ofInternalError("시스템 오류가 발생했습니다. 관리자에게 문의하세요."));
+    }
+
+    private void tryLog409Failure(BusinessException e, HttpServletRequest request) {
+        if (e.getStatus() != HttpStatus.CONFLICT) {
+            return;
+        }
+
+        if (!(e instanceof AuditableConflictException ace)) {
+            return;
+        }
+
+        ReasonCode reasonCode = ace.getReasonCode();
+        if (reasonCode != ReasonCode.SAME_APPROVER_NOT_ALLOWED
+                && reasonCode != ReasonCode.PAID_ALREADY) {
+            return;
+        }
+
+        try {
+            AuditLogCommand cmd = AuditLogCommand.builder()
+                    .requestId(resolveRequestId(request))
+                    .actorType(ace.getActorType())
+                    .actorId(ace.getActorId())
+                    .action(ace.getAction())
+                    .entityType(ace.getEntityType())
+                    .entityId(ace.getEntityId())
+                    .statusBefore(ace.getStatusBefore())
+                    .statusAfter(ace.getStatusAfter())
+                    .merchantId(ace.getMerchantId())
+                    .metaJson(AuditMetaFactory.requiredCommentSuccessWithReason(
+                            reasonCode.name(),
+                            ace.getComment()
+                    ).toString())
+                    .build();
+
+            auditLogger.logFailureRequiresNew(cmd, reasonCode);
+        } catch (Exception ex) {
+            log.error("409 failure audit logging failed", ex);
+        }
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        Object requestId = request.getAttribute(RequestIdKeys.ATTR_KEY);
+        if (requestId instanceof String s && !s.isBlank()) {
+            return s;
+        }
+        return request.getHeader(RequestIdKeys.HEADER);
     }
 }

--- a/server/src/test/java/com/settleops/global/filter/RequestIdHeaderContractTest.java
+++ b/server/src/test/java/com/settleops/global/filter/RequestIdHeaderContractTest.java
@@ -1,5 +1,6 @@
 package com.settleops.global.filter;
 
+import com.settleops.global.audit.AuditLogger;
 import com.settleops.global.error.GlobalExceptionHandler;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
@@ -8,12 +9,15 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.settleops.global.logging.RequestIdKeys.HEADER;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class RequestIdHeaderContractTest {
+
+    private final AuditLogger auditLogger = mock(AuditLogger.class);
 
     @RestController
     static class TestController {
@@ -24,27 +28,27 @@ class RequestIdHeaderContractTest {
         String boom() { throw new RuntimeException("boom"); }
     }
 
-    @Test
-    void should_generate_request_id_header_when_missing() throws Exception {
-        MockMvc mvc = MockMvcBuilders
+    private MockMvc mockMvc() {
+        return MockMvcBuilders
                 .standaloneSetup(new TestController())
-                .setControllerAdvice(new GlobalExceptionHandler())
+                .setControllerAdvice(new GlobalExceptionHandler(auditLogger))
                 .addFilters(new RequestIdFilter())
                 .build();
+    }
+
+    @Test
+    void should_generate_request_id_header_when_missing() throws Exception {
+        MockMvc mvc = mockMvc();
 
         mvc.perform(get("/ok"))
                 .andExpect(status().isOk())
                 .andExpect(header().exists(HEADER))
-                .andExpect(header().string(HEADER, not(isEmptyOrNullString()))); // 선택: 빈 값 방지
+                .andExpect(header().string(HEADER, not(isEmptyOrNullString())));
     }
 
     @Test
     void should_echo_request_id_header_when_provided() throws Exception {
-        MockMvc mvc = MockMvcBuilders
-                .standaloneSetup(new TestController())
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .addFilters(new RequestIdFilter())
-                .build();
+        MockMvc mvc = mockMvc();
 
         mvc.perform(get("/ok").header(HEADER, "test-request-id"))
                 .andExpect(status().isOk())
@@ -53,11 +57,7 @@ class RequestIdHeaderContractTest {
 
     @Test
     void should_still_include_request_id_header_on_exception() throws Exception {
-        MockMvc mvc = MockMvcBuilders
-                .standaloneSetup(new TestController())
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .addFilters(new RequestIdFilter())
-                .build();
+        MockMvc mvc = mockMvc();
 
         mvc.perform(get("/boom"))
                 .andExpect(status().isInternalServerError())


### PR DESCRIPTION
## what
### audit_log 표준화
- `AuditLogger` 단일 진입점 적용
- `AuditLog.of(AuditLogCommand)` 정적 팩토리 메서드 추가
- `AuditMetaFactory` 기반 `meta_json` 생성 규격 표준화
- `NoOpReason` enum 도입 및 no-op 사유 상수화
- `logFailureRequiresNew()` 추가 및 409 실패 감사로그 트랜잭션 분리
- `AuditLog.metaJson` 기본값 `{"noOp":false}` 보정
- `entityId` blank 검증 추가

## why
- 감사로그 저장 경로 단일화
- 감사로그 메타 구조 표준화
- no-op 사유 관리 일관성 확보
- 409 실패 로그 유실 방지
- 리뷰 및 운영 관점의 로그 해석 용이성 확보

## how to use
- 감사로그 저장 경로로 `AuditLogger` 단일 사용
- `AuditLogRepository` 직접 호출 금지
- 정상 / no-op 로그는 `auditLogger.log(cmd)` 사용
- 409 실패 로그는 `auditLogger.logFailureRequiresNew(cmd)` 사용
- `metaJson` 생성 시 `AuditMetaFactory` 사용
- no-op 사유 관리 시 `NoOpReason` enum 사용
- `AuditLogCommand` 필수값 누락 방지
  - `requestId`
  - `action`
  - `actorType`
  - `actorId`
  - `entityType`
  - `entityId`