### PR TITLE
refactor: standardize requestId flow (filter + resolver)

### DIFF
--- a/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
+++ b/server/src/main/java/com/settleops/global/filter/RequestIdFilter.java
@@ -2,8 +2,6 @@ package com.settleops.global.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -27,10 +25,6 @@ import static com.settleops.global.logging.RequestIdKeys.*;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class RequestIdFilter extends OncePerRequestFilter {
 
-    private static final String REQUEST_ID_HEADER = HEADER;
-    private static final String REQUEST_ID_MDC = MDC_KEY;
-    private static final String REQUEST_ID_ATTR = ATTR_KEY;
-
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -39,20 +33,20 @@ public class RequestIdFilter extends OncePerRequestFilter {
         long startTime = System.currentTimeMillis();
 
         // 1. 헤더에서 기존 ID가 있는지 확인, 없으면 새로 생성
-        String requestId = request.getHeader(REQUEST_ID_HEADER);
+        String requestId = request.getHeader(HEADER);
         if (requestId == null || requestId.isBlank()) {
             requestId = UUID.randomUUID().toString();
         }
 
         // 2. MDC에 저장 (로그에 찍히도록 설정)
-        MDC.put(REQUEST_ID_MDC,requestId);
+        MDC.put(MDC_KEY, requestId);
 
         // 2-1. Controller가 꺼내 쓸 수 있도록 request attribute에도 저장
-        request.setAttribute(REQUEST_ID_ATTR, requestId);
+        request.setAttribute(ATTR_KEY, requestId);
 
         // 3. 응답 헤더에 추가 (클라이언트 확인용)
         // ✅ 모든 API 응답은 반드시 X-Request-Id 헤더를 포함해야 한다.
-        response.setHeader(REQUEST_ID_HEADER, requestId);
+        response.setHeader(HEADER, requestId);
 
         // 4. QueryString 포함 full URI 구성
         String fullUri = request.getRequestURI() +
@@ -69,7 +63,7 @@ public class RequestIdFilter extends OncePerRequestFilter {
             log.info("<<< {}ms status={}", duration, response.getStatus());
 
             // 5. MDC 정리
-            MDC.remove(REQUEST_ID_MDC);
+            MDC.remove(MDC_KEY);
         }
     }
 }

--- a/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
+++ b/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
@@ -1,6 +1,5 @@
 package com.settleops.global.web;
 
-import com.settleops.global.error.BadRequestException;
 import com.settleops.global.logging.RequestIdKeys;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
@@ -9,7 +8,6 @@ import org.springframework.stereotype.Component;
  * HttpServletRequest 에서 requestId 를 표준 방식으로 추출한다.
  *
  * <p>requestId 는 RequestIdFilter 가 request attribute 에 주입한 값을 사용한다.</p>
- * <p>누락 또는 공백이면 400(BAD_REQUEST)로 처리한다.</p>
  */
 @Component
 public class RequestIdResolver {
@@ -18,7 +16,9 @@ public class RequestIdResolver {
         String requestId = (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
 
         if (requestId == null || requestId.isBlank()) {
-            throw new BadRequestException("X-Request-Id attribute is missing.");
+            throw new IllegalStateException(
+                    "requestId attribute missing. This should be set by RequestIdFilter. Check filter registration/order."
+            );
         }
 
         return requestId;

--- a/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
+++ b/server/src/main/java/com/settleops/global/web/RequestIdResolver.java
@@ -4,23 +4,29 @@ import com.settleops.global.logging.RequestIdKeys;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
+import static com.settleops.global.logging.RequestIdKeys.HEADER;
+
 /**
  * HttpServletRequest 에서 requestId 를 표준 방식으로 추출한다.
- *
  * <p>requestId 는 RequestIdFilter 가 request attribute 에 주입한 값을 사용한다.</p>
  */
 @Component
 public class RequestIdResolver {
 
     public String resolve(HttpServletRequest request) {
-        String requestId = (String) request.getAttribute(RequestIdKeys.ATTR_KEY);
-
-        if (requestId == null || requestId.isBlank()) {
-            throw new IllegalStateException(
-                    "requestId attribute missing. This should be set by RequestIdFilter. Check filter registration/order."
-            );
+        Object attr = request.getAttribute(RequestIdKeys.ATTR_KEY);
+        if (attr instanceof String s && !s.isBlank()) {
+            return s; // 1순위: Filter가 주입한 attribute
         }
 
-        return requestId;
+        // 2순위: 테스트/특수상황에서 attribute가 없을 수 있으니 header fallback
+        String header = request.getHeader(HEADER);
+        if (header != null && !header.isBlank()) {
+            return header;
+        }
+
+        // Filter 단일 책임 계약: requestId는 Filter가 보장한다.
+        // 여기서 500(IllegalStateException) 만들지 않는다. (없으면 호출부에서 정책적으로 처리)
+        return null;
     }
 }

--- a/server/src/test/java/com/settleops/global/filter/RequestIdFilterTest.java
+++ b/server/src/test/java/com/settleops/global/filter/RequestIdFilterTest.java
@@ -1,0 +1,55 @@
+package com.settleops.global.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.settleops.global.logging.RequestIdKeys.HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RequestIdFilterTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(new DummyController())
+                .addFilters(new RequestIdFilter())
+                .build();
+    }
+
+    @Test
+    void whenHeaderMissing_thenResponseHasXRequestId() throws Exception {
+        var result = mockMvc.perform(get("/__request-id-smoke"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String requestId = result.getResponse().getHeader(HEADER);
+        assertThat(requestId).isNotBlank();
+    }
+
+    @Test
+    void whenHeaderProvided_thenEchoSameXRequestId() throws Exception {
+        var result = mockMvc.perform(get("/__request-id-smoke")
+                        .header(HEADER, "req-test-123"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(result.getResponse().getHeader(HEADER))
+                .isEqualTo("req-test-123");
+    }
+
+    @RestController
+    static class DummyController {
+        @GetMapping("/__request-id-smoke")
+        public String ok() {
+            return "ok";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- X-Request-Id 표준화: 요청 헤더 있으면 그대로 사용, 없으면 UUID 생성
- MDC에 requestId 세팅 + 모든 응답에 X-Request-Id 헤더 항상 포함
- RequestIdResolver: attribute 우선 + header fallback, 누락 시 IllegalStateException 제거
  - requestId 필수 경로(AuditLogger 등)는 호출부에서 require 처리(BadRequest)로 일관화

## Test
- `./gradlew test --tests "com.settleops.global.filter.RequestIdFilterTest"`

## Notes
- requestId 생성/주입 책임은 Filter 단일로 유지(Controller/Service에서 생성/조회 로직 금지)
- Resolver는 최후에 `null`을 반환할 수 있으므로, requestId 필수 경로(AuditLogger 등)는 호출부에서 require 처리 예정
