### PR TITLE
feat: add admin settlement list query API

### DIFF
--- a/server/src/main/java/com/settleops/domain/settlement/api/AdminSettlementQueryController.java
+++ b/server/src/main/java/com/settleops/domain/settlement/api/AdminSettlementQueryController.java
@@ -1,0 +1,38 @@
+package com.settleops.domain.settlement.api;
+
+import com.settleops.domain.settlement.application.SettlementQueryService;
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/settlements")
+public class AdminSettlementQueryController {
+
+    private final SettlementQueryService settlementQueryService;
+
+    @GetMapping
+    public ResponseEntity<Page<AdminSettlementListItemResponse>> getSettlements(
+            @RequestParam(required = false)SettlementStatus status,
+            @RequestParam(required = false) String merchantId,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Pageable fixedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize()
+        );
+        return ResponseEntity.ok(
+                settlementQueryService.getAdminSettlements(status, merchantId, fixedPageable)
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementDetailQueryService.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementDetailQueryService.java
@@ -1,0 +1,7 @@
+package com.settleops.domain.settlement.application;
+
+import com.settleops.domain.settlement.dto.AdminSettlementDetailResponse;
+
+public interface SettlementDetailQueryService {
+    AdminSettlementDetailResponse getAdminSettlementDetail(String settlementId);
+}

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementQueryService.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementQueryService.java
@@ -1,0 +1,14 @@
+package com.settleops.domain.settlement.application;
+
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SettlementQueryService {
+    Page<AdminSettlementListItemResponse> getAdminSettlements(
+            SettlementStatus status,
+            String merchantId,
+            Pageable pageable
+    );
+}

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementQueryServiceImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementQueryServiceImpl.java
@@ -1,0 +1,27 @@
+package com.settleops.domain.settlement.application;
+
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import com.settleops.domain.settlement.infra.SettlementRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementQueryServiceImpl implements SettlementQueryService{
+
+    private final SettlementRepository settlementRepository;
+
+    @Override
+    public Page<AdminSettlementListItemResponse> getAdminSettlements(
+            SettlementStatus status,
+            String merchantId,
+            Pageable pageable
+    ){
+        return settlementRepository.searchAdminSettlements(status, merchantId, pageable);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementDetailResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementDetailResponse.java
@@ -1,0 +1,21 @@
+package com.settleops.domain.settlement.dto;
+
+import com.settleops.domain.settlement.enums.SettlementStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record AdminSettlementDetailResponse(
+        String settlementId,
+        String merchantId,
+        LocalDate baseDate,
+        SettlementStatus status,
+        long gross,
+        long fee,
+        long vat,
+        long net,
+        List<AdminSettlementLineItemResponse> lines,
+        AdminSettlementHoldSummaryResponse hold,
+        AdminSettlementRefundSummaryResponse refund
+) {
+}

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementHoldSummaryResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementHoldSummaryResponse.java
@@ -1,0 +1,25 @@
+package com.settleops.domain.settlement.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminSettlementHoldSummaryResponse(
+        boolean exists,
+        String holdId,
+        String status,
+        String reasonCode,
+        String comment,
+        String approvedBy,
+        LocalDateTime approvedAt
+) {
+    public static AdminSettlementHoldSummaryResponse empty() {
+        return new AdminSettlementHoldSummaryResponse(
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementLineItemResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementLineItemResponse.java
@@ -1,0 +1,11 @@
+package com.settleops.domain.settlement.dto;
+
+import com.settleops.domain.settlement.enums.SettlementLineType;
+
+public record AdminSettlementLineItemResponse (
+        String settlementLineId,
+        SettlementLineType type,
+        String paymentId,
+        long amount
+){
+}

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementListItemResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementListItemResponse.java
@@ -3,11 +3,16 @@ package com.settleops.domain.settlement.dto;
 import com.settleops.domain.settlement.enums.SettlementStatus;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record AdminSettlementListItemResponse(
         String settlementId,
         String merchantId,
-        SettlementStatus status,
         LocalDate baseDate,
-        long net
+        SettlementStatus status,
+        long gross,
+        long fee,
+        long vat,
+        long net,
+        LocalDateTime createdAt
 ){ }

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementRefundSummaryResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementRefundSummaryResponse.java
@@ -1,0 +1,10 @@
+package com.settleops.domain.settlement.dto;
+
+public record AdminSettlementRefundSummaryResponse (
+        boolean hasApprovedRefund,
+        boolean refundAdjustmentPending
+){
+    public static AdminSettlementRefundSummaryResponse empty() {
+        return new AdminSettlementRefundSummaryResponse(false, false);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementLineRepository.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementLineRepository.java
@@ -3,5 +3,8 @@ package com.settleops.domain.settlement.infra;
 import com.settleops.domain.settlement.entity.SettlementLine;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SettlementLineRepository extends JpaRepository<SettlementLine, Long> {
+import java.util.List;
+
+public interface SettlementLineRepository extends JpaRepository<SettlementLine, String> {
+    List<SettlementLine> findBySettlementIdOrderByCreatedAtAsc(String settlementId);
 }

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementLineRepository.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementLineRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface SettlementLineRepository extends JpaRepository<SettlementLine, String> {
+public interface SettlementLineRepository extends JpaRepository<SettlementLine, Long> {
     List<SettlementLine> findBySettlementIdOrderByCreatedAtAsc(String settlementId);
 }

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepository.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface SettlementRepository extends JpaRepository<Settlement, String> {
+public interface SettlementRepository extends JpaRepository<Settlement, String>, SettlementRepositoryCustom {
 
     /**
      * [FREEZE] approve-paid 동시성 정책용 DB 락

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryCustom.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.settleops.domain.settlement.infra;
+
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SettlementRepositoryCustom {
+    Page<AdminSettlementListItemResponse> searchAdminSettlements(
+            SettlementStatus status,
+            String merchantId,
+            Pageable pageable
+    );
+}

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.settleops.domain.settlement.infra;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.entity.QSettlement;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SettlementRepositoryImpl implements SettlementRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AdminSettlementListItemResponse> searchAdminSettlements(
+            SettlementStatus status,
+            String merchantId,
+            Pageable pageable
+    ) {
+        QSettlement settlement = QSettlement.settlement;
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        if (status != null) {
+            where.and(settlement.status.eq(status));
+        }
+
+        if (StringUtils.hasText(merchantId)) {
+            where.and(settlement.merchantId.eq(merchantId));
+        }
+
+        List<AdminSettlementListItemResponse> content = queryFactory
+                .select(Projections.constructor(
+                        AdminSettlementListItemResponse.class,
+                        settlement.settlementId,
+                        settlement.merchantId,
+                        settlement.baseDate,
+                        settlement.status,
+                        settlement.gross,
+                        settlement.fee,
+                        settlement.vat,
+                        settlement.net,
+                        settlement.createdAt
+                ))
+                .from(settlement)
+                .where(where)
+                .orderBy(
+                        settlement.baseDate.desc(),
+                        settlement.createdAt.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        var countQuery = queryFactory
+                .select(settlement.count())
+                .from(settlement)
+                .where(where);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
@@ -1,0 +1,62 @@
+package com.settleops.domain.settlement.api;
+
+import com.settleops.domain.settlement.application.SettlementQueryService;
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AdminSettlementQueryControllerTest {
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 status 파라미터를 서비스로 전달한다")
+    void getSettlements_withStatusFilter() {
+        SettlementQueryService settlementQueryService = Mockito.mock(SettlementQueryService.class);
+        AdminSettlementQueryController controller = new AdminSettlementQueryController(settlementQueryService);
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        AdminSettlementListItemResponse item = new AdminSettlementListItemResponse(
+                "settlement-1",
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                SettlementStatus.READY,
+                10000L,
+                0L,
+                0L,
+                10000L,
+                LocalDateTime.of(2026, 3, 11, 10, 0)
+        );
+
+        Mockito.when(settlementQueryService.getAdminSettlements(
+                SettlementStatus.READY,
+                null,
+                PageRequest.of(0, 20)
+        )).thenReturn(new PageImpl<>(List.of(item), pageable, 1));
+
+        ResponseEntity<?> response = controller.getSettlements(
+                SettlementStatus.READY,
+                null,
+                pageable
+        );
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+
+        Mockito.verify(settlementQueryService).getAdminSettlements(
+                SettlementStatus.READY,
+                null,
+                PageRequest.of(0, 20)
+        );
+    }
+}

--- a/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
@@ -19,6 +19,48 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AdminSettlementQueryControllerTest {
 
     @Test
+    @DisplayName("관리자 정산 리스트 조회 시 merchantId 파라미터를 서비스로 전달한다")
+    void getSettlements_withMerchantIdFilter() {
+        SettlementQueryService settlementQueryService = Mockito.mock(SettlementQueryService.class);
+        AdminSettlementQueryController controller = new AdminSettlementQueryController(settlementQueryService);
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        AdminSettlementListItemResponse item = new AdminSettlementListItemResponse(
+                "settlement-1",
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                SettlementStatus.READY,
+                10000L,
+                0L,
+                0L,
+                10000L,
+                LocalDateTime.of(2026, 3, 11, 10, 0)
+        );
+
+        Mockito.when(settlementQueryService.getAdminSettlements(
+                null,
+                "merchant-1",
+                PageRequest.of(0, 20)
+        )).thenReturn(new PageImpl<>(List.of(item), pageable, 1));
+
+        ResponseEntity<?> response = controller.getSettlements(
+                null,
+                "merchant-1",
+                pageable
+        );
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+
+        Mockito.verify(settlementQueryService).getAdminSettlements(
+                null,
+                "merchant-1",
+                PageRequest.of(0, 20)
+        );
+    }
+
+    @Test
     @DisplayName("관리자 정산 리스트 조회 시 status 파라미터를 서비스로 전달한다")
     void getSettlements_withStatusFilter() {
         SettlementQueryService settlementQueryService = Mockito.mock(SettlementQueryService.class);

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementQueryServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementQueryServiceImplTest.java
@@ -56,4 +56,83 @@ public class SettlementQueryServiceImplTest {
         Mockito.verify(settlementRepository)
                 .searchAdminSettlements(SettlementStatus.READY, null, pageable);
     }
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 merchantId 필터를 적용한다")
+    void getAdminSettlements_withMerchantIdFilter() {
+        SettlementRepository settlementRepository = Mockito.mock(SettlementRepository.class);
+        SettlementQueryServiceImpl service = new SettlementQueryServiceImpl(settlementRepository);
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        AdminSettlementListItemResponse item = new AdminSettlementListItemResponse(
+                "settlement-1",
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                SettlementStatus.READY,
+                10000L,
+                0L,
+                0L,
+                10000L,
+                LocalDateTime.of(2026, 3, 11, 10, 0)
+        );
+
+        Page<AdminSettlementListItemResponse> page = new PageImpl<>(List.of(item), pageable, 1);
+
+        Mockito.when(settlementRepository.searchAdminSettlements(
+                null,
+                "merchant-1",
+                pageable
+        )).thenReturn(page);
+
+        Page<AdminSettlementListItemResponse> result =
+                service.getAdminSettlements(null, "merchant-1", pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).merchantId()).isEqualTo("merchant-1");
+
+        Mockito.verify(settlementRepository)
+                .searchAdminSettlements(null, "merchant-1", pageable);
+    }
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 status와 merchantId 필터를 함께 적용한다")
+    void getAdminSettlements_withStatusAndMerchantIdFilter() {
+        SettlementRepository settlementRepository = Mockito.mock(SettlementRepository.class);
+        SettlementQueryServiceImpl service = new SettlementQueryServiceImpl(settlementRepository);
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        AdminSettlementListItemResponse item = new AdminSettlementListItemResponse(
+                "settlement-1",
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                SettlementStatus.READY,
+                10000L,
+                0L,
+                0L,
+                10000L,
+                LocalDateTime.of(2026, 3, 11, 10, 0)
+        );
+
+        Page<AdminSettlementListItemResponse> page = new PageImpl<>(List.of(item), pageable, 1);
+
+        Mockito.when(settlementRepository.searchAdminSettlements(
+                SettlementStatus.READY,
+                "merchant-1",
+                pageable
+        )).thenReturn(page);
+
+        Page<AdminSettlementListItemResponse> result =
+                service.getAdminSettlements(SettlementStatus.READY, "merchant-1", pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).status()).isEqualTo(SettlementStatus.READY);
+        assertThat(result.getContent().get(0).merchantId()).isEqualTo("merchant-1");
+
+        Mockito.verify(settlementRepository)
+                .searchAdminSettlements(SettlementStatus.READY, "merchant-1", pageable);
+    }
 }

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementQueryServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementQueryServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.settleops.domain.settlement.application;
+
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import com.settleops.domain.settlement.infra.SettlementRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SettlementQueryServiceImplTest {
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 status 필터를 적용한다")
+    void getAdminSettlements_withStatusFilter() {
+        SettlementRepository settlementRepository = Mockito.mock(SettlementRepository.class);
+        SettlementQueryServiceImpl service = new SettlementQueryServiceImpl(settlementRepository);
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        AdminSettlementListItemResponse readyItem = new AdminSettlementListItemResponse(
+                "settlement-1",
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                SettlementStatus.READY,
+                10000L,
+                0L,
+                0L,
+                10000L,
+                LocalDateTime.of(2026, 3, 11, 10, 0)
+        );
+
+        Page<AdminSettlementListItemResponse> page = new PageImpl<>(List.of(readyItem), pageable, 1);
+
+        Mockito.when(settlementRepository.searchAdminSettlements(
+                SettlementStatus.READY,
+                null,
+                pageable
+        )).thenReturn(page);
+
+        Page<AdminSettlementListItemResponse> result =
+                service.getAdminSettlements(SettlementStatus.READY, null, pageable);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).status()).isEqualTo(SettlementStatus.READY);
+
+        Mockito.verify(settlementRepository)
+                .searchAdminSettlements(SettlementStatus.READY, null, pageable);
+    }
+}

--- a/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
@@ -1,0 +1,153 @@
+package com.settleops.domain.settlement.infra;
+
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.entity.Settlement;
+import com.settleops.domain.settlement.enums.SettlementStatus;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class SettlementRepositoryImplTest {
+
+    @Autowired
+    SettlementRepository settlementRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 status와 merchantId 조건을 함께 적용한다")
+    void searchAdminSettlements_filtersByStatusAndMerchantId() {
+        // given
+        Settlement target1 = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                10000L
+        );
+        Settlement target2 = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 9),
+                9000L
+        );
+        Settlement otherMerchant = createSettlement(
+                "merchant-2",
+                LocalDate.of(2026, 3, 10),
+                11000L
+        );
+        Settlement otherStatus = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 8),
+                12000L
+        );
+
+        settlementRepository.saveAll(List.of(target1, target2, otherMerchant, otherStatus));
+        entityManager.flush();
+
+        forceStatus(otherStatus.getSettlementId(), SettlementStatus.PAY_REQUESTED);
+        entityManager.clear();
+
+        // when
+        Page<AdminSettlementListItemResponse> result = settlementRepository.searchAdminSettlements(
+                SettlementStatus.READY,
+                "merchant-1",
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(AdminSettlementListItemResponse::merchantId)
+                .containsOnly("merchant-1");
+
+        assertThat(result.getContent())
+                .extracting(AdminSettlementListItemResponse::status)
+                .containsOnly(SettlementStatus.READY);
+    }
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회는 baseDate desc 순으로 정렬된다")
+    void searchAdminSettlements_ordersByBaseDateDesc() {
+        // given
+        Settlement newest = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 11),
+                12000L
+        );
+        Settlement middle = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                11000L
+        );
+        Settlement oldest = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 9),
+                9000L
+        );
+
+        settlementRepository.saveAll(List.of(middle, newest, oldest));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        Page<AdminSettlementListItemResponse> result = settlementRepository.searchAdminSettlements(
+                null,
+                "merchant-1",
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+
+        List<AdminSettlementListItemResponse> content = result.getContent();
+
+        // 1순위: baseDate desc
+        assertThat(content.get(0).baseDate()).isEqualTo(LocalDate.of(2026, 3, 11));
+        assertThat(content.get(1).baseDate()).isEqualTo(LocalDate.of(2026, 3, 10));
+        assertThat(content.get(2).baseDate()).isEqualTo(LocalDate.of(2026, 3, 9));
+    }
+
+    private Settlement createSettlement(
+            String merchantId,
+            LocalDate baseDate,
+            long net
+    ) {
+        return Settlement.createReady(
+                UUID.randomUUID().toString(),
+                "SET-" + baseDate.toString().replace("-", "") + "-" + merchantId + "-" + UUID.randomUUID().toString().substring(0, 8),
+                1L,
+                merchantId,
+                baseDate,
+                net,
+                0L,
+                0L,
+                net
+        );
+    }
+
+    private void forceStatus(String settlementId, SettlementStatus status) {
+        jdbcTemplate.update(
+                "UPDATE settlement SET status = ? WHERE settlement_id = ?",
+                status.name(),
+                settlementId
+        );
+    }
+}

--- a/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
@@ -14,7 +14,9 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -84,7 +86,7 @@ public class SettlementRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("관리자 정산 리스트 조회는 baseDate desc 순으로 정렬된다")
+    @DisplayName("관리자 정산 리스트 조회는 baseDate desc를 우선 적용한다")
     void searchAdminSettlements_ordersByBaseDateDesc() {
         // given
         Settlement newest = createSettlement(
@@ -147,6 +149,65 @@ public class SettlementRepositoryImplTest {
         jdbcTemplate.update(
                 "UPDATE settlement SET status = ? WHERE settlement_id = ?",
                 status.name(),
+                settlementId
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 정산 리스트 조회 시 같은 baseDate에서는 createdAt desc 순으로 정렬된다")
+    void searchAdminSettlements_ordersByCreatedAtDescWithinSameBaseDate() {
+        // given
+        Settlement olderCreatedAt = createSettlement(
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                10000L
+        );
+        Settlement newerCreatedAt = createSettlement(
+                "merchant-2",
+                LocalDate.of(2026, 3, 10),
+                11000L
+        );
+        Settlement olderBaseDate = createSettlement(
+                "merchant-3",
+                LocalDate.of(2026, 3, 9),
+                9000L
+        );
+
+        settlementRepository.saveAll(List.of(olderCreatedAt, newerCreatedAt, olderBaseDate));
+        entityManager.flush();
+
+        updateCreatedAt(olderCreatedAt.getSettlementId(), LocalDateTime.of(2026, 3, 11, 9, 0));
+        updateCreatedAt(newerCreatedAt.getSettlementId(), LocalDateTime.of(2026, 3, 11, 10, 0));
+        updateCreatedAt(olderBaseDate.getSettlementId(), LocalDateTime.of(2026, 3, 11, 11, 0));
+
+        entityManager.clear();
+
+        // when
+        Page<AdminSettlementListItemResponse> result = settlementRepository.searchAdminSettlements(
+                null,
+                null,
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        List<AdminSettlementListItemResponse> content = result.getContent();
+
+        assertThat(content).hasSize(3);
+
+        // 1순위: baseDate desc
+        assertThat(content.get(0).baseDate()).isEqualTo(LocalDate.of(2026, 3, 10));
+        assertThat(content.get(1).baseDate()).isEqualTo(LocalDate.of(2026, 3, 10));
+        assertThat(content.get(2).baseDate()).isEqualTo(LocalDate.of(2026, 3, 9));
+
+        // 2순위: 같은 baseDate면 createdAt desc
+        assertThat(content.get(0).merchantId()).isEqualTo("merchant-2");
+        assertThat(content.get(1).merchantId()).isEqualTo("merchant-1");
+    }
+
+    private void updateCreatedAt(String settlementId, LocalDateTime createdAt) {
+        jdbcTemplate.update(
+                "UPDATE settlement SET created_at = ? WHERE settlement_id = ?",
+                Timestamp.valueOf(createdAt),
                 settlementId
         );
     }


### PR DESCRIPTION
작업 내용
- GET /api/admin/settlements?status=&merchantId= 추가
- 관리자 정산 리스트 DTO 추가
- Settlement QueryService / RepositoryCustom(QueryDSL) 추가
- status 필터 기반 조회 및 정렬(baseDate desc, createdAt desc) 적용
- 서비스/컨트롤러 테스트 추가

테스트
- ./gradlew test --tests "com.settleops.domain.settlement.application.SettlementQueryServiceImplTest" --tests "com.settleops.domain.settlement.api.AdminSettlementQueryControllerTest"