### PR TITLE
Test/payment query api

### DIFF
--- a/server/src/main/java/com/settleops/domain/payment/api/MerchantPaymentQueryController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/MerchantPaymentQueryController.java
@@ -18,7 +18,7 @@ public class MerchantPaymentQueryController {
     @GetMapping
     public List<MerchantPaymentListItemResponse> getMerchantPayments(
             @PathVariable String merchantId,
-            MerchantPaymentSearchCondition condition
+            @ModelAttribute MerchantPaymentSearchCondition condition
             // @AuthenticationPrincipal CustomUser user
     ) {
         // TODO: 로그인 주체 merchantId == path merchantId 검증

--- a/server/src/main/java/com/settleops/domain/payment/api/MerchantPaymentQueryController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/MerchantPaymentQueryController.java
@@ -1,0 +1,27 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.application.PaymentQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/merchants/{merchantId}/payments")
+public class MerchantPaymentQueryController {
+
+    private final PaymentQueryService paymentQueryService;
+
+    @GetMapping
+    public List<MerchantPaymentListItemResponse> getMerchantPayments(
+            @PathVariable String merchantId,
+            MerchantPaymentSearchCondition condition
+            // @AuthenticationPrincipal CustomUser user
+    ) {
+        // TODO: 로그인 주체 merchantId == path merchantId 검증
+        return paymentQueryService.getMerchantPayments(merchantId, condition);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/PaymentQueryController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/PaymentQueryController.java
@@ -1,0 +1,39 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.domain.payment.application.PaymentQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/payments")
+public class PaymentQueryController {
+
+    private final PaymentQueryService paymentQueryService;
+
+    /**
+     * 결제 상세 조회
+     */
+    @GetMapping("/{paymentId}")
+    public PaymentDetailResponse getPaymentDetail(
+            @PathVariable String paymentId
+            // @AuthenticationPrincipal CustomUser user
+    ) {
+        // TODO: role별 소유 검증 적용
+        return paymentQueryService.getPaymentDetail(paymentId);
+    }
+
+    /**
+     * 환불 컨텍스트 조회
+     */
+    @GetMapping("/{paymentId}/refund-context")
+    public RefundContextResponse getRefundContext(
+            @PathVariable String paymentId
+            // @AuthenticationPrincipal CustomUser user
+    ) {
+        // TODO: role별 소유 검증 적용
+        return paymentQueryService.getRefundContext(paymentId);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentListItemResponse.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentListItemResponse.java
@@ -1,0 +1,44 @@
+package com.settleops.domain.payment.api.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class MerchantPaymentListItemResponse {
+
+    private final String paymentId;
+    private final String orderId;
+    private final String status;
+    private final long requestedAmount;
+    private final long capturedAmount;
+    private final String currency;
+    private final String buyerId;
+    private final LocalDateTime capturedAt;
+    private final boolean confirmed;
+    private final LocalDateTime confirmedAt;
+
+    public MerchantPaymentListItemResponse(
+            String paymentId,
+            String orderId,
+            String status,
+            long requestedAmount,
+            long capturedAmount,
+            String currency,
+            String buyerId,
+            LocalDateTime capturedAt,
+            boolean confirmed,
+            LocalDateTime confirmedAt
+    ) {
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.status = status;
+        this.requestedAmount = requestedAmount;
+        this.capturedAmount = capturedAmount;
+        this.currency = currency;
+        this.buyerId = buyerId;
+        this.capturedAt = capturedAt;
+        this.confirmed = confirmed;
+        this.confirmedAt = confirmedAt;
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentSearchCondition.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentSearchCondition.java
@@ -1,11 +1,13 @@
 package com.settleops.domain.payment.api.dto;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
 @Getter
+@Setter
 public class MerchantPaymentSearchCondition {
 
     private String status;

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentSearchCondition.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/MerchantPaymentSearchCondition.java
@@ -1,0 +1,21 @@
+package com.settleops.domain.payment.api.dto;
+
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+public class MerchantPaymentSearchCondition {
+
+    private String status;
+    private String confirmed; // ALL / CONFIRMED
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate from;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate to;
+
+    private String keyword;
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/PaymentDetailResponse.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/PaymentDetailResponse.java
@@ -1,0 +1,76 @@
+package com.settleops.domain.payment.api.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+public class PaymentDetailResponse {
+
+    private String paymentId;
+    private String orderId;
+    private String merchantId;
+    private String buyerId;
+    private String status;
+    private long requestedAmount;
+    private long capturedAmount;
+    private String currency;
+    private LocalDateTime createdAt;
+    private LocalDateTime capturedAt;
+    private boolean confirmed;
+    private LocalDateTime confirmedAt;
+    private List<PaymentEventItem> events = List.of();
+
+    public PaymentDetailResponse(
+            String paymentId,
+            String orderId,
+            String merchantId,
+            String buyerId,
+            String status,
+            long requestedAmount,
+            long capturedAmount,
+            String currency,
+            LocalDateTime createdAt,
+            LocalDateTime capturedAt,
+            boolean confirmed,
+            LocalDateTime confirmedAt
+    ) {
+        this.paymentId = paymentId;
+        this.orderId = orderId;
+        this.merchantId = merchantId;
+        this.buyerId = buyerId;
+        this.status = status;
+        this.requestedAmount = requestedAmount;
+        this.capturedAmount = capturedAmount;
+        this.currency = currency;
+        this.createdAt = createdAt;
+        this.capturedAt = capturedAt;
+        this.confirmed = confirmed;
+        this.confirmedAt = confirmedAt;
+    }
+
+    public void assignEvents(List<PaymentEventItem> events) {
+        this.events = (events == null) ? List.of() : events;
+    }
+
+    @Getter
+    public static class PaymentEventItem {
+        private String eventType;
+        private String statusBefore;
+        private String statusAfter;
+        private LocalDateTime occurredAt;
+
+        public PaymentEventItem(
+                String eventType,
+                String statusBefore,
+                String statusAfter,
+                LocalDateTime occurredAt
+        ) {
+            this.eventType = eventType;
+            this.statusBefore = statusBefore;
+            this.statusAfter = statusAfter;
+            this.occurredAt = occurredAt;
+        }
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/api/dto/RefundContextResponse.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/dto/RefundContextResponse.java
@@ -1,0 +1,37 @@
+package com.settleops.domain.payment.api.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RefundContextResponse {
+
+    private final String paymentId;
+    private final String status;
+    private final long capturedAmount;
+    private final long refundableAmount;
+    private final String currency;
+    private final String merchantId;
+    private final LocalDateTime capturedAt;
+
+    public RefundContextResponse(
+            String paymentId,
+            String status,
+            long capturedAmount,
+            long refundableAmount,
+            String currency,
+            String merchantId,
+            LocalDateTime capturedAt
+    ) {
+        this.paymentId = paymentId;
+        this.status = status;
+        this.capturedAmount = capturedAmount;
+        this.refundableAmount = refundableAmount;
+        this.currency = currency;
+        this.merchantId = merchantId;
+        this.capturedAt = capturedAt;
+    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/ConfirmService.java
@@ -7,7 +7,9 @@ import com.settleops.domain.payment.infra.PaymentRepository;
 import com.settleops.global.audit.ActorType;
 import com.settleops.global.audit.AuditLogCommand;
 import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.audit.AuditMetaFactory;
 import com.settleops.global.audit.EntityType;
+import com.settleops.global.audit.NoOpReason;
 import com.settleops.global.enums.Action;
 import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.BadRequestException;
@@ -65,7 +67,7 @@ public class ConfirmService {
                     requestId,
                     existingConfirmedAt,
                     true,
-                    "ALREADY_CONFIRMED"
+                    NoOpReason.ALREADY_CONFIRMED
             );
             return ConfirmResponseDTO.from(payment, existingConfirmedAt);
         }
@@ -85,7 +87,7 @@ public class ConfirmService {
                 requestId,
                 confirmedAt,
                 !inserted,
-                inserted ? null : "ALREADY_CONFIRMED"
+                inserted ? null : NoOpReason.ALREADY_CONFIRMED
         );
 
         return ConfirmResponseDTO.from(payment, confirmedAt);
@@ -102,7 +104,7 @@ public class ConfirmService {
     }
 
     /**
-     * confirm 가능 여부 및 호출 주체를 검증합니다.
+     * confirm 가능 여부 및 호출 주체 검증
      */
     private void validateConfirmable(Payment payment, String currentBuyerId) {
 
@@ -133,15 +135,11 @@ public class ConfirmService {
     }
 
     /**
-     * confirm 감사 로그
+     * confirm 감사 로그 기록
      *
-     * <p> @param idempotentReplay 멱등 재시도/no-op 여부
-     * <br> @param noOpReason       no-op 사유. 최초 성공이면 null
-     * </p>
-     *
-     * <p>주의
-     * <br>- confirm의 SoT는 PAYMENT_CONFIRMED 이벤트이며,
-     * <br>- payment.status는 변경되지 않으므로 before/after 모두 CAPTURED입니다.
+     * <p>- confirm SoT는 PAYMENT_CONFIRMED 이벤트입니다.
+     * <br>- payment.status는 변경되지 않으므로 before/after는 모두 CAPTURED입니다.
+     * <br>- 최초 성공은 noOp=false, 재시도/중복 확정은 noOp=true로 기록합니다.
      * </p>
      */
     private void logConfirm(
@@ -150,7 +148,7 @@ public class ConfirmService {
             String requestId,
             LocalDateTime confirmedAt,
             boolean idempotentReplay,
-            String noOpReason
+            NoOpReason noOpReason
     ) {
         auditLogger.log(
                 AuditLogCommand.builder()
@@ -169,13 +167,11 @@ public class ConfirmService {
         );
     }
 
-    private String buildConfirmMetaJson(boolean idempotentReplay, String noOpReason) {
-        boolean noOp = noOpReason != null && !noOpReason.isBlank();
-
-        if (!noOp) {
-            return "{\"noOp\":false,\"idempotent\":" + idempotentReplay + "}";
+    private String buildConfirmMetaJson(boolean idempotentReplay, NoOpReason noOpReason) {
+        if (noOpReason == null) {
+            return AuditMetaFactory.success().put("idempotent", idempotentReplay).toString();
         }
 
-        return "{\"noOp\":true,\"noOpReason\":\"" + noOpReason + "\",\"idempotent\":" + idempotentReplay + "}";
+        return AuditMetaFactory.noOp(noOpReason, idempotentReplay).toString();
     }
 }

--- a/server/src/main/java/com/settleops/domain/payment/application/PayService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PayService.java
@@ -15,6 +15,8 @@ import com.settleops.global.audit.ActorType;
 import com.settleops.global.audit.AuditLogCommand;
 import com.settleops.global.audit.AuditLogger;
 import com.settleops.global.audit.EntityType;
+import com.settleops.global.audit.AuditMetaFactory;
+import com.settleops.global.audit.NoOpReason;
 import com.settleops.global.db.DbConstraintUtils;
 import com.settleops.global.enums.Action;
 import com.settleops.global.enums.IdempotencyTargetType;
@@ -76,7 +78,7 @@ public class PayService {
                     PaymentStatus.CAPTURED,
                     PaymentStatus.CAPTURED,
                     true,
-                    "IDEMPOTENT_REPLAY"
+                    NoOpReason.IDEMPOTENT_REPLAY
             );
             return PayResponseDTO.from(idempotent, capturedAt);
         }
@@ -132,7 +134,7 @@ public class PayService {
                 captureResult.converged() ? PaymentStatus.CAPTURED : paymentStatusBefore,
                 payment.getStatus(),
                 captureResult.converged(),
-                captureResult.converged() ? "CAPTURED_EVENT_DUPLICATE_CONVERGED" : null
+                captureResult.converged() ? NoOpReason.CAPTURED_EVENT_DUPLICATE_CONVERGED : null
         );
 
         // 13. 주문 상태 PAID 전이
@@ -282,7 +284,7 @@ public class PayService {
             PaymentStatus statusBefore,
             PaymentStatus statusAfter,
             boolean noOp,
-            String noOpReason
+            NoOpReason noOpReason
     ) {
         auditLogger.log(
                 AuditLogCommand.builder()
@@ -301,11 +303,16 @@ public class PayService {
         );
     }
 
-    private String buildPayMetaJson(boolean noOp, String noOpReason) {
+    private String buildPayMetaJson(boolean noOp, NoOpReason noOpReason) {
         if (!noOp) {
-            return "{\"noOp\":false}";
+            return AuditMetaFactory.success().toString();
         }
-        return "{\"noOp\":true,\"noOpReason\":\"" + noOpReason + "\"}";
+
+        if (noOpReason == null) {
+            throw new IllegalArgumentException("noOpReason must not be null when noOp is true");
+        }
+
+        return AuditMetaFactory.noOp(noOpReason, true).toString();
     }
 
     /**

--- a/server/src/main/java/com/settleops/domain/payment/application/PaymentQueryService.java
+++ b/server/src/main/java/com/settleops/domain/payment/application/PaymentQueryService.java
@@ -1,0 +1,42 @@
+package com.settleops.domain.payment.application;
+
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.domain.payment.infra.PaymentQueryRepository;
+import com.settleops.global.error.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentQueryService {
+
+    private final PaymentQueryRepository paymentQueryRepository;
+
+    public List<MerchantPaymentListItemResponse> getMerchantPayments(
+            String merchantId,
+            MerchantPaymentSearchCondition condition
+    ) {
+        return paymentQueryRepository.searchMerchantPayments(merchantId, condition);
+    }
+
+    public PaymentDetailResponse getPaymentDetail(String paymentId) {
+        PaymentDetailResponse detail = paymentQueryRepository.findPaymentDetail(paymentId);
+        if (detail == null) {
+            throw new NotFoundException("payment not found");
+        }
+        return detail;    }
+
+    public RefundContextResponse getRefundContext(String paymentId) {
+        RefundContextResponse context = paymentQueryRepository.findRefundContext(paymentId);
+        if (context == null) {
+            throw new NotFoundException("payment not found");
+        }
+        return context;    }
+}

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentQueryRepository.java
@@ -168,8 +168,8 @@ public class PaymentQueryRepository {
                 .select(Projections.constructor(
                         PaymentDetailResponse.PaymentEventItem.class,
                         paymentEvent.eventType.stringValue(),
-                        paymentEvent.statusBefore,
-                        paymentEvent.statusAfter,
+                        paymentEvent.statusBefore.stringValue(),
+                        paymentEvent.statusAfter.stringValue(),
                         paymentEvent.occurredAt
                 ))
                 .from(paymentEvent)

--- a/server/src/main/java/com/settleops/domain/payment/infra/PaymentQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/payment/infra/PaymentQueryRepository.java
@@ -1,0 +1,330 @@
+package com.settleops.domain.payment.infra;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.domain.order.domain.QOrders;
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.domain.payment.domain.PaymentEventType;
+import com.settleops.domain.payment.domain.QPayment;
+import com.settleops.domain.payment.domain.QPaymentEvent;
+import com.settleops.domain.refund.domain.QRefund;
+import com.settleops.domain.refund.domain.RefundStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentQueryRepository {
+
+    /** U2 확정여부 필터 기본값 */
+    private static final String CONFIRMED_ALL = "ALL";
+
+    /** U2 확정여부 필터 - 확정 건만 조회 */
+    private static final String CONFIRMED_ONLY = "CONFIRMED";
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * Merchant 결제 목록 조회
+     * - merchantId 기준 기본 범위 제한
+     * - 상태 / 확정여부 / 기간 / 키워드 조건 반영
+     * - confirmed / confirmedAt 은 PAYMENT_CONFIRMED 이벤트 존재 여부로 파생
+     */
+    public List<MerchantPaymentListItemResponse> searchMerchantPayments(
+            String merchantId,
+            MerchantPaymentSearchCondition condition
+    ) {
+        QPayment payment = QPayment.payment;
+        QOrders order = QOrders.orders;
+        QPaymentEvent confirmedEvent = new QPaymentEvent("confirmedEvent");
+        QPaymentEvent confirmedAtEvent = new QPaymentEvent("confirmedAtEvent");
+        QPaymentEvent capturedAtEvent = new QPaymentEvent("capturedAtEvent");
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(payment.merchantId.eq(merchantId));
+        where.and(statusEq(condition.getStatus(), payment));
+        where.and(confirmedFilter(condition.getConfirmed(), payment, confirmedEvent));
+        where.and(createdAtGoe(condition, payment));
+        where.and(createdAtLt(condition, payment));
+        where.and(keywordContains(condition, payment, order));
+
+        return queryFactory
+                .select(Projections.constructor(
+                        MerchantPaymentListItemResponse.class,
+                        payment.paymentId,
+                        payment.orderId,
+                        payment.status.stringValue(),
+                        payment.requestedAmount,
+                        payment.capturedAmount,
+                        payment.currency,
+                        payment.buyerId,
+                        JPAExpressions
+                                .select(capturedAtEvent.occurredAt.min())
+                                .from(capturedAtEvent)
+                                .where(
+                                        capturedAtEvent.paymentId.eq(payment.paymentId),
+                                        capturedAtEvent.eventType.eq(PaymentEventType.PAYMENT_CAPTURED)
+                                ),
+                        JPAExpressions
+                                .selectOne()
+                                .from(confirmedEvent)
+                                .where(
+                                        confirmedEvent.paymentId.eq(payment.paymentId),
+                                        confirmedEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED)
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .select(confirmedAtEvent.occurredAt.min())
+                                .from(confirmedAtEvent)
+                                .where(
+                                        confirmedAtEvent.paymentId.eq(payment.paymentId),
+                                        confirmedAtEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED)
+                                )
+                ))
+                .from(payment)
+                .join(order).on(payment.orderId.eq(order.orderId))
+                .where(where)
+                .orderBy(payment.createdAt.desc())
+                .fetch();
+    }
+
+    /**
+     * 결제 상세 조회
+     * - payment 기본 정보 조회
+     * - capturedAt은 PAYMENT_CAPTURED 이벤트 occurredAt 파생
+     * - confirmed / confirmedAt은 PAYMENT_CONFIRMED 이벤트 기반 파생
+     * - events 타임라인은 별도 조회 후 조립
+     */
+    public PaymentDetailResponse findPaymentDetail(String paymentId) {
+        QPayment payment = QPayment.payment;
+        QPaymentEvent confirmedEvent = new QPaymentEvent("confirmedEvent");
+        QPaymentEvent confirmedAtEvent = new QPaymentEvent("confirmedAtEvent");
+        QPaymentEvent capturedAtEvent = new QPaymentEvent("capturedAtEvent");
+
+        PaymentDetailResponse detail = queryFactory
+                .select(Projections.constructor(
+                        PaymentDetailResponse.class,
+                        payment.paymentId,
+                        payment.orderId,
+                        payment.merchantId,
+                        payment.buyerId,
+                        payment.status.stringValue(),
+                        payment.requestedAmount,
+                        payment.capturedAmount,
+                        payment.currency,
+                        payment.createdAt,
+                        JPAExpressions
+                                .select(capturedAtEvent.occurredAt.min())
+                                .from(capturedAtEvent)
+                                .where(
+                                        capturedAtEvent.paymentId.eq(payment.paymentId),
+                                        capturedAtEvent.eventType.eq(PaymentEventType.PAYMENT_CAPTURED)
+                                ),
+                        JPAExpressions
+                                .selectOne()
+                                .from(confirmedEvent)
+                                .where(
+                                        confirmedEvent.paymentId.eq(payment.paymentId),
+                                        confirmedEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED)
+                                )
+                                .exists(),
+                        JPAExpressions
+                                .select(confirmedAtEvent.occurredAt.min())
+                                .from(confirmedAtEvent)
+                                .where(
+                                        confirmedAtEvent.paymentId.eq(payment.paymentId),
+                                        confirmedAtEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED)
+                                )
+                ))
+                .from(payment)
+                .where(payment.paymentId.eq(paymentId))
+                .fetchOne();
+
+        if (detail == null) {
+            return null;
+        }
+
+        detail.assignEvents(findPaymentEvents(paymentId));
+        return detail;
+    }
+
+    /**
+     * 결제 이벤트 타임라인 조회
+     * - payment_event insert-only 이력 조회
+     * - occurredAt 오름차순 정렬
+     * - 상세 화면 타임라인 표시 목적
+     */
+    private List<PaymentDetailResponse.PaymentEventItem> findPaymentEvents(String paymentId) {
+        QPaymentEvent paymentEvent = QPaymentEvent.paymentEvent;
+
+        return queryFactory
+                .select(Projections.constructor(
+                        PaymentDetailResponse.PaymentEventItem.class,
+                        paymentEvent.eventType.stringValue(),
+                        paymentEvent.statusBefore,
+                        paymentEvent.statusAfter,
+                        paymentEvent.occurredAt
+                ))
+                .from(paymentEvent)
+                .where(paymentEvent.paymentId.eq(paymentId))
+                .orderBy(paymentEvent.occurredAt.asc())
+                .fetch();
+    }
+
+    /**
+     * 상태 필터 조건 생성
+     * - null / blank / ALL 입력 시 조건 미적용
+     */
+    private BooleanBuilder statusEq(String status, QPayment payment) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (status == null || status.isBlank() || "ALL".equalsIgnoreCase(status)) {
+            return builder;
+        }
+
+        builder.and(payment.status.stringValue().eq(status));
+        return builder;
+    }
+
+    /**
+     * 확정여부 필터 조건 생성
+     * - ALL: 조건 미적용
+     * - CONFIRMED: PAYMENT_CONFIRMED 이벤트 존재 건만 조회
+     */
+    private BooleanBuilder confirmedFilter(
+            String confirmed,
+            QPayment payment,
+            QPaymentEvent confirmedEvent
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (confirmed == null || confirmed.isBlank() || CONFIRMED_ALL.equalsIgnoreCase(confirmed)) {
+            return builder;
+        }
+
+        if (CONFIRMED_ONLY.equalsIgnoreCase(confirmed)) {
+            builder.and(
+                    JPAExpressions
+                            .selectOne()
+                            .from(confirmedEvent)
+                            .where(
+                                    confirmedEvent.paymentId.eq(payment.paymentId),
+                                    confirmedEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED)
+                            )
+                            .exists()
+            );
+        }
+
+        return builder;
+    }
+
+    /**
+     * 기간 From 조건 생성
+     * - from 당일 00:00:00 이상 조회
+     */
+    private BooleanBuilder createdAtGoe(MerchantPaymentSearchCondition condition, QPayment payment) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition.getFrom() != null) {
+            builder.and(payment.createdAt.goe(condition.getFrom().atStartOfDay()));
+        }
+
+        return builder;
+    }
+
+    /**
+     * 기간 To 조건 생성
+     * - to 다음날 00:00:00 미만 조회
+     * - 종료일 포함 검색 목적
+     */
+    private BooleanBuilder createdAtLt(MerchantPaymentSearchCondition condition, QPayment payment) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition.getTo() != null) {
+            builder.and(payment.createdAt.lt(condition.getTo().plusDays(1).atStartOfDay()));
+        }
+
+        return builder;
+    }
+
+    /**
+     * 키워드 검색 조건 생성
+     * - paymentId / orderId / itemName 대상 부분일치 검색
+     * - blank 입력 시 조건 미적용
+     */
+    private BooleanBuilder keywordContains(
+            MerchantPaymentSearchCondition condition,
+            QPayment payment,
+            QOrders order
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (condition.getKeyword() == null || condition.getKeyword().isBlank()) {
+            return builder;
+        }
+
+        String keyword = condition.getKeyword().trim();
+
+        builder.and(
+                payment.paymentId.contains(keyword)
+                        .or(payment.orderId.contains(keyword))
+                        .or(order.itemName.contains(keyword))
+        );
+
+        return builder;
+    }
+
+    /**
+     * 환불 컨텍스트 조회
+     * - payment 기본 정보 조회
+     * - capturedAt은 PAYMENT_CAPTURED 이벤트 occurredAt 파생
+     * - refundableAmount는 capturedAmount - 승인된 refund 합계로 계산
+     */
+    public RefundContextResponse findRefundContext(String paymentId) {
+        QPayment payment = QPayment.payment;
+        QRefund refund = QRefund.refund;
+        QPaymentEvent capturedAtEvent = new QPaymentEvent("capturedAtEvent");
+
+        RefundContextResponse response = queryFactory
+                .select(Projections.constructor(
+                        RefundContextResponse.class,
+                        payment.paymentId,
+                        payment.status.stringValue(),
+                        payment.capturedAmount,
+                        payment.capturedAmount.subtract(
+                                JPAExpressions
+                                        .select(refund.amount.sum().coalesce(0L))
+                                        .from(refund)
+                                        .where(
+                                                refund.paymentId.eq(payment.paymentId),
+                                                refund.status.eq(RefundStatus.APPROVED)
+                                        )
+                        ),
+                        payment.currency,
+                        payment.merchantId,
+                        JPAExpressions
+                                .select(capturedAtEvent.occurredAt.min())
+                                .from(capturedAtEvent)
+                                .where(
+                                        capturedAtEvent.paymentId.eq(payment.paymentId),
+                                        capturedAtEvent.eventType.eq(PaymentEventType.PAYMENT_CAPTURED)
+                                )
+                ))
+                .from(payment)
+                .where(payment.paymentId.eq(paymentId))
+                .fetchOne();
+
+        if (response == null) {
+            return null;
+        }
+
+        return response;
+    }
+}

--- a/server/src/main/java/com/settleops/global/audit/NoOpReason.java
+++ b/server/src/main/java/com/settleops/global/audit/NoOpReason.java
@@ -14,5 +14,9 @@ public enum NoOpReason {
     ALREADY_PAY_REQUESTED,
 
     // Batch
-    BATCH_KEY_EXISTS
+    BATCH_KEY_EXISTS,
+
+    // Payment
+    IDEMPOTENT_REPLAY,
+    CAPTURED_EVENT_DUPLICATE_CONVERGED
 }

--- a/server/src/main/java/com/settleops/global/error/ErrorResponse.java
+++ b/server/src/main/java/com/settleops/global/error/ErrorResponse.java
@@ -25,6 +25,7 @@ public record ErrorResponse(
     private static final String UNAUTHORIZED = "UNAUTHORIZED";
     private static final String RULE_VIOLATION = "RULE_VIOLATION";
     private static final String FORBIDDEN = "FORBIDDEN";
+    private static final String NOT_FOUND = "NOT_FOUND";
     private static final String BAD_REQUEST = "BAD_REQUEST";
     private static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
 
@@ -40,6 +41,11 @@ public record ErrorResponse(
     // 403 Forbidden용 (reason은 무조건 null)
     public static ErrorResponse ofForbidden(String message) {
         return new ErrorResponse(FORBIDDEN, null, message);
+    }
+
+    // 404 Notfound용 (reason은 무조건 null)
+    public static ErrorResponse ofNotFound(String message) {
+        return new ErrorResponse(NOT_FOUND, null, message);
     }
 
     // 400 Bad Request 또는 기타 4xx용

--- a/server/src/main/java/com/settleops/global/error/NotFoundException.java
+++ b/server/src/main/java/com/settleops/global/error/NotFoundException.java
@@ -1,0 +1,15 @@
+package com.settleops.global.error;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, message);
+    }
+
+    @Override
+    public ErrorResponse toErrorResponse() {
+        return ErrorResponse.ofNotFound(getMessage());
+    }
+}

--- a/server/src/test/java/com/settleops/domain/payment/api/MerchantPaymentQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/api/MerchantPaymentQueryControllerTest.java
@@ -1,0 +1,242 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.application.PaymentQueryService;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * MerchantPaymentQueryController 웹 계층 테스트
+ *
+ * <p>검증 범위</p>
+ * <ul>
+ *   <li>GET /api/merchants/{merchantId}/payments 매핑</li>
+ *   <li>query param -> MerchantPaymentSearchCondition 바인딩</li>
+ *   <li>서비스 위임 결과의 JSON 응답 변환</li>
+ * </ul>
+ *
+ * <p>주의</p>
+ * <ul>
+ *   <li>보안/공통 필터 영향 없이 컨트롤러 계약만 검증하기 위해 addFilters=false 적용</li>
+ *   <li>GlobalExceptionHandler 생성자 의존성 충족을 위해 AuditLogger를 mock bean으로 등록</li>
+ * </ul>
+ */
+@WebMvcTest(MerchantPaymentQueryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test")
+class MerchantPaymentQueryControllerTest {
+
+    private static final String MERCHANT_ID = "MERCHANT_1";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PaymentQueryService paymentQueryService;
+
+    @MockitoBean
+    private AuditLogger auditLogger;
+
+    // =========================================================
+    // U2. Merchant 결제 목록 조회
+    // =========================================================
+
+    @Nested
+    class GetMerchantPaymentsTest {
+
+        @Test
+        @DisplayName("GET /api/merchants/{merchantId}/payments - 목록 정상 조회")
+        void getMerchantPayments_returns_ok() throws Exception {
+            // given
+            List<MerchantPaymentListItemResponse> response = List.of(
+                    new MerchantPaymentListItemResponse(
+                            "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                            "11111111-1111-1111-1111-111111111111",
+                            "CAPTURED",
+                            100_000L,
+                            100_000L,
+                            "KRW",
+                            "BUYER_1",
+                            LocalDateTime.of(2026, 3, 13, 10, 0, 0),
+                            true,
+                            LocalDateTime.of(2026, 3, 13, 11, 0, 0)
+                    ),
+                    new MerchantPaymentListItemResponse(
+                            "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                            "22222222-2222-2222-2222-222222222222",
+                            "CAPTURED",
+                            200_000L,
+                            200_000L,
+                            "KRW",
+                            "BUYER_2",
+                            LocalDateTime.of(2026, 3, 12, 10, 0, 0),
+                            false,
+                            null
+                    )
+            );
+
+            when(paymentQueryService.getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class)))
+                    .thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/merchants/{merchantId}/payments", MERCHANT_ID)
+                            .param("status", "CAPTURED")
+                            .param("confirmed", "CONFIRMED")
+                            .param("from", "2026-03-10")
+                            .param("to", "2026-03-13")
+                            .param("keyword", "아이폰"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith("application/json"))
+                    .andExpect(jsonPath("$.length()").value(2))
+                    .andExpect(jsonPath("$[0].paymentId").value("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"))
+                    .andExpect(jsonPath("$[0].orderId").value("11111111-1111-1111-1111-111111111111"))
+                    .andExpect(jsonPath("$[0].status").value("CAPTURED"))
+                    .andExpect(jsonPath("$[0].requestedAmount").value(100000))
+                    .andExpect(jsonPath("$[0].capturedAmount").value(100000))
+                    .andExpect(jsonPath("$[0].currency").value("KRW"))
+                    .andExpect(jsonPath("$[0].buyerId").value("BUYER_1"))
+                    .andExpect(jsonPath("$[0].confirmed").value(true))
+                    .andExpect(jsonPath("$[1].paymentId").value("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"))
+                    .andExpect(jsonPath("$[1].confirmed").value(false));
+
+            ArgumentCaptor<MerchantPaymentSearchCondition> captor =
+                    ArgumentCaptor.forClass(MerchantPaymentSearchCondition.class);
+
+            verify(paymentQueryService).getMerchantPayments(eq(MERCHANT_ID), captor.capture());
+
+            MerchantPaymentSearchCondition condition = captor.getValue();
+            assertThat(readField(condition, "status")).isEqualTo("CAPTURED");
+            assertThat(readField(condition, "confirmed")).isEqualTo("CONFIRMED");
+            assertThat(readField(condition, "keyword")).isEqualTo("아이폰");
+            assertThat(readField(condition, "from")).isEqualTo(LocalDate.of(2026, 3, 10));
+            assertThat(readField(condition, "to")).isEqualTo(LocalDate.of(2026, 3, 13));
+        }
+
+        @Test
+        @DisplayName("GET /api/merchants/{merchantId}/payments - 결과 없으면 빈 배열 반환")
+        void getMerchantPayments_returns_empty_list() throws Exception {
+            // given
+            when(paymentQueryService.getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class)))
+                    .thenReturn(List.of());
+
+            // when & then
+            mockMvc.perform(get("/api/merchants/{merchantId}/payments", MERCHANT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith("application/json"))
+                    .andExpect(jsonPath("$.length()").value(0));
+
+            verify(paymentQueryService).getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class));
+        }
+    }
+
+    @Test
+    @DisplayName("GET /api/merchants/{merchantId}/payments - query param 없이 호출 가능")
+    void getMerchantPayments_without_query_params_returns_ok() throws Exception {
+        // given
+        when(paymentQueryService.getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class)))
+                .thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/merchants/{merchantId}/payments", MERCHANT_ID))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.length()").value(0));
+
+        ArgumentCaptor<MerchantPaymentSearchCondition> captor =
+                ArgumentCaptor.forClass(MerchantPaymentSearchCondition.class);
+
+        verify(paymentQueryService).getMerchantPayments(eq(MERCHANT_ID), captor.capture());
+
+        MerchantPaymentSearchCondition condition = captor.getValue();
+        assertThat(readField(condition, "status")).isNull();
+        assertThat(readField(condition, "confirmed")).isNull();
+        assertThat(readField(condition, "from")).isNull();
+        assertThat(readField(condition, "to")).isNull();
+        assertThat(readField(condition, "keyword")).isNull();
+    }
+
+    @Test
+    @DisplayName("GET /api/merchants/{merchantId}/payments - status 단독 바인딩")
+    void getMerchantPayments_binds_status_only() throws Exception {
+        // given
+        when(paymentQueryService.getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class)))
+                .thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/merchants/{merchantId}/payments", MERCHANT_ID)
+                        .param("status", "CAPTURED"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.length()").value(0));
+
+        ArgumentCaptor<MerchantPaymentSearchCondition> captor =
+                ArgumentCaptor.forClass(MerchantPaymentSearchCondition.class);
+
+        verify(paymentQueryService).getMerchantPayments(eq(MERCHANT_ID), captor.capture());
+
+        MerchantPaymentSearchCondition condition = captor.getValue();
+        assertThat(readField(condition, "status")).isEqualTo("CAPTURED");
+        assertThat(readField(condition, "confirmed")).isNull();
+        assertThat(readField(condition, "from")).isNull();
+        assertThat(readField(condition, "to")).isNull();
+        assertThat(readField(condition, "keyword")).isNull();
+    }
+
+    @Test
+    @DisplayName("GET /api/merchants/{merchantId}/payments - from/to 날짜 바인딩")
+    void getMerchantPayments_binds_from_and_to_as_local_date() throws Exception {
+        // given
+        when(paymentQueryService.getMerchantPayments(eq(MERCHANT_ID), any(MerchantPaymentSearchCondition.class)))
+                .thenReturn(List.of());
+
+        // when & then
+        mockMvc.perform(get("/api/merchants/{merchantId}/payments", MERCHANT_ID)
+                        .param("from", "2026-03-10")
+                        .param("to", "2026-03-13"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("application/json"))
+                .andExpect(jsonPath("$.length()").value(0));
+
+        ArgumentCaptor<MerchantPaymentSearchCondition> captor =
+                ArgumentCaptor.forClass(MerchantPaymentSearchCondition.class);
+
+        verify(paymentQueryService).getMerchantPayments(eq(MERCHANT_ID), captor.capture());
+
+        MerchantPaymentSearchCondition condition = captor.getValue();
+        assertThat(readField(condition, "from")).isEqualTo(LocalDate.of(2026, 3, 10));
+        assertThat(readField(condition, "to")).isEqualTo(LocalDate.of(2026, 3, 13));
+    }
+
+    /**
+     * 현재 DTO를 변경하지 않고 query param 바인딩 결과를 확인하기 위해 reflection으로 필드값을 읽는다.
+     */
+    private Object readField(Object target, String fieldName) {
+        return ReflectionTestUtils.getField(target, fieldName);
+    }
+}

--- a/server/src/test/java/com/settleops/domain/payment/api/PaymentQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/api/PaymentQueryControllerTest.java
@@ -1,0 +1,216 @@
+package com.settleops.domain.payment.api;
+
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.domain.payment.application.PaymentQueryService;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.error.GlobalExceptionHandler;
+import com.settleops.global.error.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * PaymentQueryController 웹 계층 테스트
+ *
+ * <p>검증 범위</p>
+ * <ul>
+ *   <li>URL 매핑 및 JSON 응답 구조</li>
+ *   <li>서비스 위임 결과의 HTTP 응답 변환</li>
+ *   <li>NotFoundException 발생 시 404 응답 수렴</li>
+ * </ul>
+ *
+ * <p>주의</p>
+ * <ul>
+ *   <li>보안/공통 필터 영향 없이 컨트롤러 계약만 검증하기 위해 addFilters=false 적용</li>
+ *   <li>GlobalExceptionHandler 생성자 의존성 충족을 위해 AuditLogger를 mock bean으로 등록</li>
+ * </ul>
+ */
+@WebMvcTest(PaymentQueryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+@ActiveProfiles("test")
+class PaymentQueryControllerTest {
+
+    private static final String PAYMENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    private static final String PAYMENT_ID_MISSING = "99999999-9999-9999-9999-999999999999";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    /** 컨트롤러가 의존하는 조회 서비스 mock */
+    @MockitoBean
+    private PaymentQueryService paymentQueryService;
+
+    /** GlobalExceptionHandler 생성자 주입용 mock */
+    @MockitoBean
+    private AuditLogger auditLogger;
+
+    // =========================================================
+    // U3. 결제 상세 조회
+    // =========================================================
+
+    @Nested
+    class GetPaymentDetailTest {
+
+        @Test
+        @DisplayName("GET /api/payments/{paymentId} - 결제 상세 정상 조회")
+        void getPaymentDetail_returns_ok() throws Exception {
+            // given
+            PaymentDetailResponse response = new PaymentDetailResponse(
+                    PAYMENT_ID,
+                    "11111111-1111-1111-1111-111111111111",
+                    "MERCHANT_1",
+                    "BUYER_1",
+                    "CAPTURED",
+                    350_000L,
+                    350_000L,
+                    "KRW",
+                    LocalDateTime.of(2026, 3, 13, 9, 0, 0),
+                    LocalDateTime.of(2026, 3, 13, 9, 5, 0),
+                    true,
+                    LocalDateTime.of(2026, 3, 13, 11, 0, 0)
+            );
+
+            response.assignEvents(List.of(
+                    new PaymentDetailResponse.PaymentEventItem(
+                            "PAYMENT_CREATED",
+                            "CREATED",
+                            "CREATED",
+                            LocalDateTime.of(2026, 3, 13, 9, 0, 0)
+                    ),
+                    new PaymentDetailResponse.PaymentEventItem(
+                            "PAYMENT_CAPTURED",
+                            "CREATED",
+                            "CAPTURED",
+                            LocalDateTime.of(2026, 3, 13, 9, 5, 0)
+                    ),
+                    new PaymentDetailResponse.PaymentEventItem(
+                            "PAYMENT_CONFIRMED",
+                            "CAPTURED",
+                            "CAPTURED",
+                            LocalDateTime.of(2026, 3, 13, 11, 0, 0)
+                    )
+            ));
+
+            when(paymentQueryService.getPaymentDetail(eq(PAYMENT_ID)))
+                    .thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/payments/{paymentId}", PAYMENT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.paymentId").value(PAYMENT_ID))
+                    .andExpect(jsonPath("$.orderId").value("11111111-1111-1111-1111-111111111111"))
+                    .andExpect(jsonPath("$.merchantId").value("MERCHANT_1"))
+                    .andExpect(jsonPath("$.buyerId").value("BUYER_1"))
+                    .andExpect(jsonPath("$.status").value("CAPTURED"))
+                    .andExpect(jsonPath("$.requestedAmount").value(350000))
+                    .andExpect(jsonPath("$.capturedAmount").value(350000))
+                    .andExpect(jsonPath("$.currency").value("KRW"))
+                    .andExpect(jsonPath("$.confirmed").value(true))
+                    .andExpect(jsonPath("$.events.length()").value(3))
+                    .andExpect(jsonPath("$.events[0].eventType").value("PAYMENT_CREATED"))
+                    .andExpect(jsonPath("$.events[1].eventType").value("PAYMENT_CAPTURED"))
+                    .andExpect(jsonPath("$.events[2].eventType").value("PAYMENT_CONFIRMED"));
+
+            verify(paymentQueryService).getPaymentDetail(eq(PAYMENT_ID));
+        }
+
+        @Test
+        @DisplayName("GET /api/payments/{paymentId} - 미존재 paymentId 조회 시 404")
+        void getPaymentDetail_returns_not_found() throws Exception {
+            // given
+            when(paymentQueryService.getPaymentDetail(eq(PAYMENT_ID_MISSING)))
+                    .thenThrow(new NotFoundException("payment not found"));
+
+            // when & then
+            mockMvc.perform(get("/api/payments/{paymentId}", PAYMENT_ID_MISSING)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.reason").doesNotExist())
+                    .andExpect(jsonPath("$.message").value("payment not found"));
+
+            verify(paymentQueryService).getPaymentDetail(eq(PAYMENT_ID_MISSING));
+        }
+    }
+
+    // =========================================================
+    // refund-context 조회
+    // =========================================================
+
+    @Nested
+    class GetRefundContextTest {
+
+        @Test
+        @DisplayName("GET /api/payments/{paymentId}/refund-context - 정상 조회")
+        void getRefundContext_returns_ok() throws Exception {
+            // given
+            RefundContextResponse response = new RefundContextResponse(
+                    PAYMENT_ID,
+                    "CAPTURED",
+                    500_000L,
+                    400_000L,
+                    "KRW",
+                    "MERCHANT_1",
+                    LocalDateTime.of(2026, 3, 13, 11, 3, 0)
+            );
+
+            when(paymentQueryService.getRefundContext(eq(PAYMENT_ID)))
+                    .thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/api/payments/{paymentId}/refund-context", PAYMENT_ID)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.paymentId").value(PAYMENT_ID))
+                    .andExpect(jsonPath("$.status").value("CAPTURED"))
+                    .andExpect(jsonPath("$.capturedAmount").value(500000))
+                    .andExpect(jsonPath("$.refundableAmount").value(400000))
+                    .andExpect(jsonPath("$.currency").value("KRW"))
+                    .andExpect(jsonPath("$.merchantId").value("MERCHANT_1"));
+
+            verify(paymentQueryService).getRefundContext(eq(PAYMENT_ID));
+        }
+
+        @Test
+        @DisplayName("GET /api/payments/{paymentId}/refund-context - 미존재 paymentId 조회 시 404")
+        void getRefundContext_returns_not_found() throws Exception {
+            // given
+            when(paymentQueryService.getRefundContext(eq(PAYMENT_ID_MISSING)))
+                    .thenThrow(new NotFoundException("payment not found"));
+
+            // when & then
+            mockMvc.perform(get("/api/payments/{paymentId}/refund-context", PAYMENT_ID_MISSING)
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                    .andExpect(jsonPath("$.reason").doesNotExist())
+                    .andExpect(jsonPath("$.message").value("payment not found"));
+
+            verify(paymentQueryService).getRefundContext(eq(PAYMENT_ID_MISSING));
+        }
+    }
+}

--- a/server/src/test/java/com/settleops/domain/payment/application/PaymentQueryServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/application/PaymentQueryServiceTest.java
@@ -1,0 +1,175 @@
+package com.settleops.domain.payment.application;
+
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.domain.payment.infra.PaymentQueryRepository;
+import com.settleops.global.error.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentQueryServiceTest {
+
+    private static final String MERCHANT_ID = "MERCHANT_1";
+    private static final String PAYMENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    private static final String PAYMENT_ID_MISSING = "99999999-9999-9999-9999-999999999999";
+
+    @Mock
+    private PaymentQueryRepository paymentQueryRepository;
+
+    @InjectMocks
+    private PaymentQueryService paymentQueryService;
+
+    // =========================================================
+    // U2. Merchant 결제 목록 조회
+    // =========================================================
+
+    @Test
+    @DisplayName("U2_merchant 결제 목록 조회를 repository에 위임")
+    void getMerchantPayments_delegates_to_repository() {
+        // given
+        MerchantPaymentSearchCondition condition = new MerchantPaymentSearchCondition();
+
+        List<MerchantPaymentListItemResponse> expected = List.of(
+                new MerchantPaymentListItemResponse(
+                        PAYMENT_ID,
+                        "11111111-1111-1111-1111-111111111111",
+                        "CAPTURED",
+                        100_000L,
+                        100_000L,
+                        "KRW",
+                        "BUYER_1",
+                        LocalDateTime.of(2026, 3, 13, 10, 0, 0),
+                        true,
+                        LocalDateTime.of(2026, 3, 13, 11, 0, 0)
+                )
+        );
+
+        when(paymentQueryRepository.searchMerchantPayments(MERCHANT_ID, condition))
+                .thenReturn(expected);
+
+        // when
+        List<MerchantPaymentListItemResponse> result =
+                paymentQueryService.getMerchantPayments(MERCHANT_ID, condition);
+
+        // then
+        assertThat(result).isEqualTo(expected);
+        verify(paymentQueryRepository).searchMerchantPayments(MERCHANT_ID, condition);
+    }
+
+    // =========================================================
+    // U3. 결제 상세 조회
+    // =========================================================
+
+    @Nested
+    class GetPaymentDetailTest {
+
+        @Test
+        @DisplayName("U3_결제 상세 조회를 repository에 위임")
+        void getPaymentDetail_returns_detail() {
+            // given
+            PaymentDetailResponse expected = new PaymentDetailResponse(
+                    PAYMENT_ID,
+                    "11111111-1111-1111-1111-111111111111",
+                    "MERCHANT_1",
+                    "BUYER_1",
+                    "CAPTURED",
+                    350_000L,
+                    350_000L,
+                    "KRW",
+                    LocalDateTime.of(2026, 3, 13, 9, 0, 0),
+                    LocalDateTime.of(2026, 3, 13, 9, 5, 0),
+                    true,
+                    LocalDateTime.of(2026, 3, 13, 11, 0, 0)
+            );
+
+            when(paymentQueryRepository.findPaymentDetail(PAYMENT_ID))
+                    .thenReturn(expected);
+
+            // when
+            PaymentDetailResponse result = paymentQueryService.getPaymentDetail(PAYMENT_ID);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+            verify(paymentQueryRepository).findPaymentDetail(PAYMENT_ID);
+        }
+
+        @Test
+        @DisplayName("U3_미존재 paymentId 조회 시 NotFoundException 발생")
+        void getPaymentDetail_throws_not_found_when_repository_returns_null() {
+            // given
+            when(paymentQueryRepository.findPaymentDetail(PAYMENT_ID_MISSING))
+                    .thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> paymentQueryService.getPaymentDetail(PAYMENT_ID_MISSING))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("payment not found");
+
+            verify(paymentQueryRepository).findPaymentDetail(PAYMENT_ID_MISSING);
+        }
+    }
+
+    // =========================================================
+    // Refund Context 조회
+    // =========================================================
+
+    @Nested
+    class GetRefundContextTest {
+
+        @Test
+        @DisplayName("refund-context 조회를 repository에 위임")
+        void getRefundContext_returns_context() {
+            // given
+            RefundContextResponse expected = new RefundContextResponse(
+                    PAYMENT_ID,
+                    "CAPTURED",
+                    500_000L,
+                    400_000L,
+                    "KRW",
+                    "MERCHANT_1",
+                    LocalDateTime.of(2026, 3, 13, 11, 3, 0)
+            );
+
+            when(paymentQueryRepository.findRefundContext(PAYMENT_ID))
+                    .thenReturn(expected);
+
+            // when
+            RefundContextResponse result = paymentQueryService.getRefundContext(PAYMENT_ID);
+
+            // then
+            assertThat(result).isEqualTo(expected);
+            verify(paymentQueryRepository).findRefundContext(PAYMENT_ID);
+        }
+
+        @Test
+        @DisplayName("refund-context 미존재 paymentId 조회 시 NotFoundException 발생")
+        void getRefundContext_throws_not_found_when_repository_returns_null() {
+            // given
+            when(paymentQueryRepository.findRefundContext(PAYMENT_ID_MISSING))
+                    .thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> paymentQueryService.getRefundContext(PAYMENT_ID_MISSING))
+                    .isInstanceOf(NotFoundException.class)
+                    .hasMessage("payment not found");
+
+            verify(paymentQueryRepository).findRefundContext(PAYMENT_ID_MISSING);
+        }
+    }
+}

--- a/server/src/test/java/com/settleops/domain/payment/infra/PaymentQueryRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/infra/PaymentQueryRepositoryTest.java
@@ -1,0 +1,517 @@
+package com.settleops.domain.payment.infra;
+
+import com.settleops.domain.payment.api.dto.MerchantPaymentListItemResponse;
+import com.settleops.domain.payment.api.dto.MerchantPaymentSearchCondition;
+import com.settleops.domain.payment.api.dto.PaymentDetailResponse;
+import com.settleops.domain.payment.api.dto.RefundContextResponse;
+import com.settleops.support.QuerydslTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PaymentQueryRepository 조회 테스트
+ *
+ * <p>검증 범위</p>
+ * <ul>
+ *   <li>U2 Merchant 결제 목록 조회</li>
+ *   <li>U3 결제 상세 조회</li>
+ *   <li>refund-context 조회</li>
+ * </ul>
+ *
+ * <p>검증 목적</p>
+ * <ul>
+ *   <li>QueryDSL projection 정합 검증</li>
+ *   <li>이벤트 기반 파생값(capturedAt, confirmedAt) 검증</li>
+ *   <li>검색 조건(status/confirmed/기간/keyword) 동작 검증</li>
+ *   <li>미존재 조회 및 빈 결과 처리 검증</li>
+ * </ul>
+ */
+@DataJpaTest
+@Import({PaymentQueryRepository.class, QuerydslTestConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@ActiveProfiles("test")
+class PaymentQueryRepositoryTest {
+
+    private static final String ORDER_ID_1 = "11111111-1111-1111-1111-111111111111";
+    private static final String ORDER_ID_2 = "22222222-2222-2222-2222-222222222222";
+    private static final String ORDER_ID_3 = "33333333-3333-3333-3333-333333333333";
+    private static final String ORDER_ID_DETAIL = "44444444-4444-4444-4444-444444444444";
+    private static final String ORDER_ID_REFUND = "55555555-5555-5555-5555-555555555555";
+
+    private static final String PAYMENT_ID_1 = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    private static final String PAYMENT_ID_2 = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    private static final String PAYMENT_ID_3 = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    private static final String PAYMENT_ID_DETAIL = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    private static final String PAYMENT_ID_REFUND = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    private static final String PAYMENT_ID_MISSING = "99999999-9999-9999-9999-999999999999";
+
+    private static final String REFUND_ID_1 = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+    private static final String REQUEST_ID_1 = "90000000-0000-0000-0000-000000000001";
+    private static final String REQUEST_ID_2 = "90000000-0000-0000-0000-000000000002";
+    private static final String REQUEST_ID_3 = "90000000-0000-0000-0000-000000000003";
+    private static final String REQUEST_ID_4 = "90000000-0000-0000-0000-000000000004";
+    private static final String REQUEST_ID_5 = "90000000-0000-0000-0000-000000000005";
+    private static final String REQUEST_ID_6 = "90000000-0000-0000-0000-000000000006";
+    private static final String REQUEST_ID_7 = "90000000-0000-0000-0000-000000000007";
+    private static final String REQUEST_ID_8 = "90000000-0000-0000-0000-000000000008";
+    private static final String REQUEST_ID_DETAIL_1 = "90000000-0000-0000-0000-000000000011";
+    private static final String REQUEST_ID_DETAIL_2 = "90000000-0000-0000-0000-000000000012";
+    private static final String REQUEST_ID_DETAIL_3 = "90000000-0000-0000-0000-000000000013";
+    private static final String REQUEST_ID_REFUND_1 = "90000000-0000-0000-0000-000000000021";
+    private static final String REQUEST_ID_REFUND_2 = "90000000-0000-0000-0000-000000000022";
+
+    @Autowired
+    private PaymentQueryRepository paymentQueryRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    // =========================================================
+    // U2. Merchant 결제 목록 조회
+    // =========================================================
+
+    @Test
+    @DisplayName("U2_merchantId/status/confirmed/keyword 조건과 파생값 조회")
+    void searchMerchantPayments_filters_and_derives_fields() {
+        // given
+        LocalDateTime base = LocalDateTime.of(2026, 3, 13, 10, 0, 0);
+
+        insertOrder(ORDER_ID_1, "MERCHANT_1", "BUYER_1", "아이폰 15", 100_000L, "PAID", base.minusDays(1), base.minusDays(1));
+        insertOrder(ORDER_ID_2, "MERCHANT_1", "BUYER_2", "갤럭시 S25", 200_000L, "PAID", base.minusDays(2), base.minusDays(2));
+        insertOrder(ORDER_ID_3, "MERCHANT_2", "BUYER_3", "맥북 프로", 300_000L, "PAID", base.minusDays(3), base.minusDays(3));
+
+        insertPayment(PAYMENT_ID_1, ORDER_ID_1, "MERCHANT_1", "BUYER_1", "KRW", 100_000L, 100_000L, "CAPTURED", base.minusDays(1), base.minusDays(1));
+        insertPayment(PAYMENT_ID_2, ORDER_ID_2, "MERCHANT_1", "BUYER_2", "KRW", 200_000L, 200_000L, "CAPTURED", base.minusDays(2), base.minusDays(2));
+        insertPayment(PAYMENT_ID_3, ORDER_ID_3, "MERCHANT_2", "BUYER_3", "KRW", 300_000L, 300_000L, "CAPTURED", base.minusDays(3), base.minusDays(3));
+
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CREATED", "CREATED", "CREATED", REQUEST_ID_1, base.minusDays(1).minusMinutes(10));
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_2, base.minusDays(1));
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CONFIRMED", "CAPTURED", "CAPTURED", REQUEST_ID_3, base.minusDays(1).plusHours(1));
+
+        insertPaymentEvent(PAYMENT_ID_2, "PAYMENT_CREATED", "CREATED", "CREATED", REQUEST_ID_4, base.minusDays(2).minusMinutes(10));
+        insertPaymentEvent(PAYMENT_ID_2, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_5, base.minusDays(2));
+
+        insertPaymentEvent(PAYMENT_ID_3, "PAYMENT_CREATED", "CREATED", "CREATED", REQUEST_ID_6, base.minusDays(3).minusMinutes(10));
+        insertPaymentEvent(PAYMENT_ID_3, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_7, base.minusDays(3));
+        insertPaymentEvent(PAYMENT_ID_3, "PAYMENT_CONFIRMED", "CAPTURED", "CAPTURED", REQUEST_ID_8, base.minusDays(3).plusHours(2));
+
+        MerchantPaymentSearchCondition condition = createSearchCondition(
+                "CAPTURED",
+                "CONFIRMED",
+                LocalDate.of(2026, 3, 10),
+                LocalDate.of(2026, 3, 13),
+                "아이폰"
+        );
+
+        // when
+        List<MerchantPaymentListItemResponse> result =
+                paymentQueryRepository.searchMerchantPayments("MERCHANT_1", condition);
+
+        // then
+        assertThat(result).hasSize(1);
+
+        MerchantPaymentListItemResponse item = result.get(0);
+        assertThat(item.getPaymentId().trim()).isEqualTo(PAYMENT_ID_1);
+        assertThat(item.getOrderId().trim()).isEqualTo(ORDER_ID_1);
+        assertThat(item.getStatus()).isEqualTo("CAPTURED");
+        assertThat(item.getRequestedAmount()).isEqualTo(100_000L);
+        assertThat(item.getCapturedAmount()).isEqualTo(100_000L);
+        assertThat(item.getCurrency()).isEqualTo("KRW");
+        assertThat(item.getBuyerId()).isEqualTo("BUYER_1");
+        assertThat(item.isConfirmed()).isTrue();
+        assertThat(item.getCapturedAt()).isEqualTo(base.minusDays(1));
+        assertThat(item.getConfirmedAt()).isEqualTo(base.minusDays(1).plusHours(1));
+    }
+
+    @Test
+    @DisplayName("U2_keyword가 paymentId에 대해 부분일치 검색된다")
+    void searchMerchantPayments_filters_by_payment_id_keyword() {
+        // given
+        LocalDateTime base = LocalDateTime.of(2026, 3, 13, 10, 0, 0);
+
+        insertOrder(ORDER_ID_1, "MERCHANT_1", "BUYER_1", "아이폰 15", 100_000L, "PAID", base, base);
+        insertOrder(ORDER_ID_2, "MERCHANT_1", "BUYER_2", "갤럭시 S25", 200_000L, "PAID", base.minusDays(1), base.minusDays(1));
+
+        insertPayment(PAYMENT_ID_1, ORDER_ID_1, "MERCHANT_1", "BUYER_1", "KRW", 100_000L, 100_000L, "CAPTURED", base, base);
+        insertPayment(PAYMENT_ID_2, ORDER_ID_2, "MERCHANT_1", "BUYER_2", "KRW", 200_000L, 200_000L, "CAPTURED", base.minusDays(1), base.minusDays(1));
+
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_1, base);
+        insertPaymentEvent(PAYMENT_ID_2, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_2, base.minusDays(1));
+
+        MerchantPaymentSearchCondition condition = createSearchCondition(null, null, null, null, "aaaaaaaa");
+
+        // when
+        List<MerchantPaymentListItemResponse> result =
+                paymentQueryRepository.searchMerchantPayments("MERCHANT_1", condition);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getPaymentId().trim()).isEqualTo(PAYMENT_ID_1);
+    }
+
+    @Test
+    @DisplayName("U2_keyword가 orderId에 대해 부분일치 검색된다")
+    void searchMerchantPayments_filters_by_order_id_keyword() {
+        // given
+        LocalDateTime base = LocalDateTime.of(2026, 3, 13, 10, 0, 0);
+
+        insertOrder(ORDER_ID_1, "MERCHANT_1", "BUYER_1", "아이폰 15", 100_000L, "PAID", base, base);
+        insertOrder(ORDER_ID_2, "MERCHANT_1", "BUYER_2", "갤럭시 S25", 200_000L, "PAID", base.minusDays(1), base.minusDays(1));
+
+        insertPayment(PAYMENT_ID_1, ORDER_ID_1, "MERCHANT_1", "BUYER_1", "KRW", 100_000L, 100_000L, "CAPTURED", base, base);
+        insertPayment(PAYMENT_ID_2, ORDER_ID_2, "MERCHANT_1", "BUYER_2", "KRW", 200_000L, 200_000L, "CAPTURED", base.minusDays(1), base.minusDays(1));
+
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_1, base);
+        insertPaymentEvent(PAYMENT_ID_2, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_2, base.minusDays(1));
+
+        MerchantPaymentSearchCondition condition = createSearchCondition(null, null, null, null, "22222222");
+
+        // when
+        List<MerchantPaymentListItemResponse> result =
+                paymentQueryRepository.searchMerchantPayments("MERCHANT_1", condition);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getOrderId().trim()).isEqualTo(ORDER_ID_2);
+    }
+
+    @Test
+    @DisplayName("U2_keyword가 itemName에 대해 부분일치 검색된다")
+    void searchMerchantPayments_filters_by_item_name_keyword() {
+        // given
+        LocalDateTime base = LocalDateTime.of(2026, 3, 13, 10, 0, 0);
+
+        insertOrder(ORDER_ID_1, "MERCHANT_1", "BUYER_1", "아이폰 15 프로", 100_000L, "PAID", base, base);
+        insertOrder(ORDER_ID_2, "MERCHANT_1", "BUYER_2", "갤럭시 S25", 200_000L, "PAID", base.minusDays(1), base.minusDays(1));
+
+        insertPayment(PAYMENT_ID_1, ORDER_ID_1, "MERCHANT_1", "BUYER_1", "KRW", 100_000L, 100_000L, "CAPTURED", base, base);
+        insertPayment(PAYMENT_ID_2, ORDER_ID_2, "MERCHANT_1", "BUYER_2", "KRW", 200_000L, 200_000L, "CAPTURED", base.minusDays(1), base.minusDays(1));
+
+        insertPaymentEvent(PAYMENT_ID_1, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_1, base);
+        insertPaymentEvent(PAYMENT_ID_2, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_2, base.minusDays(1));
+
+        MerchantPaymentSearchCondition condition = createSearchCondition(null, null, null, null, "아이폰");
+
+        // when
+        List<MerchantPaymentListItemResponse> result =
+                paymentQueryRepository.searchMerchantPayments("MERCHANT_1", condition);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getPaymentId().trim()).isEqualTo(PAYMENT_ID_1);
+    }
+
+    // =========================================================
+    // U3. 결제 상세 조회
+    // =========================================================
+
+    @Test
+    @DisplayName("U3_payment 상세 조회 시 이벤트 타임라인 오름차순 반환")
+    void findPaymentDetail_returns_detail_and_events_sorted() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 13, 9, 0, 0);
+        LocalDateTime capturedAt = createdAt.plusMinutes(5);
+        LocalDateTime confirmedAt = createdAt.plusHours(2);
+
+        insertOrder(ORDER_ID_DETAIL, "MERCHANT_1", "BUYER_1", "닌텐도 스위치", 350_000L, "PAID", createdAt, createdAt);
+        insertPayment(PAYMENT_ID_DETAIL, ORDER_ID_DETAIL, "MERCHANT_1", "BUYER_1", "KRW", 350_000L, 350_000L, "CAPTURED", createdAt, createdAt);
+
+        insertPaymentEvent(PAYMENT_ID_DETAIL, "PAYMENT_CREATED", "CREATED", "CREATED", REQUEST_ID_DETAIL_1, createdAt);
+        insertPaymentEvent(PAYMENT_ID_DETAIL, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_DETAIL_2, capturedAt);
+        insertPaymentEvent(PAYMENT_ID_DETAIL, "PAYMENT_CONFIRMED", "CAPTURED", "CAPTURED", REQUEST_ID_DETAIL_3, confirmedAt);
+
+        // when
+        PaymentDetailResponse result = paymentQueryRepository.findPaymentDetail(PAYMENT_ID_DETAIL);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getPaymentId().trim()).isEqualTo(PAYMENT_ID_DETAIL);
+        assertThat(result.getOrderId().trim()).isEqualTo(ORDER_ID_DETAIL);
+        assertThat(result.getMerchantId()).isEqualTo("MERCHANT_1");
+        assertThat(result.getBuyerId()).isEqualTo("BUYER_1");
+        assertThat(result.getStatus()).isEqualTo("CAPTURED");
+        assertThat(result.getRequestedAmount()).isEqualTo(350_000L);
+        assertThat(result.getCapturedAmount()).isEqualTo(350_000L);
+        assertThat(result.getCurrency()).isEqualTo("KRW");
+        assertThat(result.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(result.getCapturedAt()).isEqualTo(capturedAt);
+        assertThat(result.isConfirmed()).isTrue();
+        assertThat(result.getConfirmedAt()).isEqualTo(confirmedAt);
+
+        assertThat(result.getEvents()).hasSize(3);
+        assertThat(result.getEvents().get(0).getEventType()).isEqualTo("PAYMENT_CREATED");
+        assertThat(result.getEvents().get(0).getOccurredAt()).isEqualTo(createdAt);
+
+        assertThat(result.getEvents().get(1).getEventType()).isEqualTo("PAYMENT_CAPTURED");
+        assertThat(result.getEvents().get(1).getOccurredAt()).isEqualTo(capturedAt);
+
+        assertThat(result.getEvents().get(2).getEventType()).isEqualTo("PAYMENT_CONFIRMED");
+        assertThat(result.getEvents().get(2).getOccurredAt()).isEqualTo(confirmedAt);
+    }
+
+    @Test
+    @DisplayName("U3_이벤트가 없으면 빈 리스트를 반환한다")
+    void findPaymentDetail_returns_empty_events_when_no_event_exists() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 13, 9, 0, 0);
+
+        insertOrder(ORDER_ID_DETAIL, "MERCHANT_1", "BUYER_1", "닌텐도 스위치", 350_000L, "PAID", createdAt, createdAt);
+        insertPayment(PAYMENT_ID_DETAIL, ORDER_ID_DETAIL, "MERCHANT_1", "BUYER_1", "KRW", 350_000L, 350_000L, "CAPTURED", createdAt, createdAt);
+
+        // when
+        PaymentDetailResponse result = paymentQueryRepository.findPaymentDetail(PAYMENT_ID_DETAIL);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getEvents()).isNotNull();
+        assertThat(result.getEvents()).isEmpty();
+    }
+
+    // =========================================================
+    // refund-context 조회
+    // =========================================================
+
+    @Test
+    @DisplayName("refund-context는 APPROVED 환불 1건 기준 refundableAmount 계산")
+    void findRefundContext_calculates_refundable_amount() {
+        // given
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 13, 11, 0, 0);
+        LocalDateTime capturedAt = createdAt.plusMinutes(3);
+
+        insertOrder(ORDER_ID_REFUND, "MERCHANT_1", "BUYER_1", "에어팟 프로", 500_000L, "PAID", createdAt, createdAt);
+        insertPayment(PAYMENT_ID_REFUND, ORDER_ID_REFUND, "MERCHANT_1", "BUYER_1", "KRW", 500_000L, 500_000L, "CAPTURED", createdAt, createdAt);
+
+        insertPaymentEvent(PAYMENT_ID_REFUND, "PAYMENT_CREATED", "CREATED", "CREATED", REQUEST_ID_REFUND_1, createdAt);
+        insertPaymentEvent(PAYMENT_ID_REFUND, "PAYMENT_CAPTURED", "CREATED", "CAPTURED", REQUEST_ID_REFUND_2, capturedAt);
+
+        insertRefund(
+                REFUND_ID_1,
+                PAYMENT_ID_REFUND,
+                "MERCHANT_1",
+                "BUYER_1",
+                100_000L,
+                "KRW",
+                "APPROVED",
+                "사이즈 문제",
+                createdAt.plusHours(1),
+                createdAt.plusHours(2),
+                createdAt.plusHours(1),
+                createdAt.plusHours(2)
+        );
+
+        // when
+        RefundContextResponse result = paymentQueryRepository.findRefundContext(PAYMENT_ID_REFUND);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getRefundableAmount()).isEqualTo(400_000L);
+        assertThat(result.getCapturedAt()).isEqualTo(capturedAt);
+        assertThat(result.getPaymentId().trim()).isEqualTo(PAYMENT_ID_REFUND);
+        assertThat(result.getStatus()).isEqualTo("CAPTURED");
+        assertThat(result.getCapturedAmount()).isEqualTo(500_000L);
+        assertThat(result.getCurrency()).isEqualTo("KRW");
+        assertThat(result.getMerchantId()).isEqualTo("MERCHANT_1");
+    }
+
+    // =========================================================
+    // Not Found / Empty Result
+    // =========================================================
+
+    @Test
+    @DisplayName("미존재 paymentId 상세 조회 시 null 반환")
+    void findPaymentDetail_returns_null_when_payment_not_found() {
+        // when
+        PaymentDetailResponse result = paymentQueryRepository.findPaymentDetail(PAYMENT_ID_MISSING);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("미존재 paymentId refund-context 조회 시 null 반환")
+    void findRefundContext_returns_null_when_payment_not_found() {
+        // when
+        RefundContextResponse result = paymentQueryRepository.findRefundContext(PAYMENT_ID_MISSING);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    // =========================================================
+    // SearchCondition Helper
+    // =========================================================
+
+    /**
+     * 테스트 전용 검색 조건 생성 helper
+     * - 운영 DTO 변경 없이 필요한 필드만 세팅
+     * - QueryDSL 조건 테스트에서 반복 생성 코드 제거 목적
+     */
+    private MerchantPaymentSearchCondition createSearchCondition(
+            String status,
+            String confirmed,
+            LocalDate from,
+            LocalDate to,
+            String keyword
+    ) {
+        MerchantPaymentSearchCondition condition = new MerchantPaymentSearchCondition();
+        condition.setStatus(status);
+        condition.setConfirmed(confirmed);
+        condition.setFrom(from);
+        condition.setTo(to);
+        condition.setKeyword(keyword);
+        return condition;
+    }
+
+    // =========================================================
+    // Fixture Setup Helpers
+    // =========================================================
+
+    /**
+     * orders 테스트 fixture 적재
+     * - merchant/buyer/item/amount 기반 조회 조건 검증용
+     */
+    private void insertOrder(
+            String orderId,
+            String merchantId,
+            String buyerId,
+            String itemName,
+            long amount,
+            String status,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        jdbcTemplate.update(
+                """
+                insert into orders (
+                    order_id, merchant_id, buyer_id, item_name, amount, currency, status, created_at, updated_at
+                ) values (?, ?, ?, ?, ?, 'KRW', ?, ?, ?)
+                """,
+                orderId,
+                merchantId,
+                buyerId,
+                itemName,
+                amount,
+                status,
+                Timestamp.valueOf(createdAt),
+                Timestamp.valueOf(updatedAt)
+        );
+    }
+
+    /**
+     * payment 테스트 fixture 적재
+     * - payment/order/merchant/buyer 기반 목록/상세 조회 검증용
+     */
+    private void insertPayment(
+            String paymentId,
+            String orderId,
+            String merchantId,
+            String buyerId,
+            String currency,
+            long requestedAmount,
+            long capturedAmount,
+            String status,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        jdbcTemplate.update(
+                """
+                insert into payment (
+                    payment_id, order_id, merchant_id, buyer_id, currency,
+                    requested_amount, captured_amount, status, created_at, updated_at
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                paymentId,
+                orderId,
+                merchantId,
+                buyerId,
+                currency,
+                requestedAmount,
+                capturedAmount,
+                status,
+                Timestamp.valueOf(createdAt),
+                Timestamp.valueOf(updatedAt)
+        );
+    }
+
+    /**
+     * payment_event 테스트 fixture 적재
+     * - capturedAt/confirmedAt 파생값 및 이벤트 타임라인 검증용
+     */
+    private void insertPaymentEvent(
+            String paymentId,
+            String eventType,
+            String statusBefore,
+            String statusAfter,
+            String requestId,
+            LocalDateTime occurredAt
+    ) {
+        jdbcTemplate.update(
+                """
+                insert into payment_event (
+                    payment_id, event_type, status_before, status_after, request_id, occurred_at
+                ) values (?, ?, ?, ?, ?, ?)
+                """,
+                paymentId,
+                eventType,
+                statusBefore,
+                statusAfter,
+                requestId,
+                Timestamp.valueOf(occurredAt)
+        );
+    }
+
+    /**
+     * refund 테스트 fixture 적재
+     * - refundableAmount 계산 검증용
+     */
+    private void insertRefund(
+            String refundId,
+            String paymentId,
+            String merchantId,
+            String buyerId,
+            long amount,
+            String currency,
+            String status,
+            String reasonText,
+            LocalDateTime requestedAt,
+            LocalDateTime decidedAt,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        jdbcTemplate.update(
+                """
+                insert into refund (
+                    refund_id, payment_id, merchant_id, buyer_id, amount, currency,
+                    status, reason_text, requested_at, decided_at, created_at, updated_at
+                ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                refundId,
+                paymentId,
+                merchantId,
+                buyerId,
+                amount,
+                currency,
+                status,
+                reasonText,
+                Timestamp.valueOf(requestedAt),
+                decidedAt == null ? null : Timestamp.valueOf(decidedAt),
+                Timestamp.valueOf(createdAt),
+                Timestamp.valueOf(updatedAt)
+        );
+    }
+}

--- a/server/src/test/java/com/settleops/support/QuerydslTestConfig.java
+++ b/server/src/test/java/com/settleops/support/QuerydslTestConfig.java
@@ -1,0 +1,20 @@
+package com.settleops.support;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * - QueryDSL repository 테스트용 빈 등록 <br/>
+ * - JPAQueryFactory 생성 <br/>
+ * - PaymentQueryRepository 주입 가능 상태 만들기
+ * */
+@TestConfiguration
+public class QuerydslTestConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## what

### 조회 API 테스트 추가
- PaymentQueryRepositoryTest 추가/보강
- PaymentQueryServiceTest 추가
- PaymentQueryControllerTest 추가
- MerchantPaymentQueryControllerTest 추가

### Repository 테스트 보강
- U2 목록 조회 조건(status / confirmed / 기간 / keyword) 검증 추가
- keyword 대상 paymentId / orderId / itemName 검색 검증 추가
- U3 상세 조회 이벤트 타임라인 오름차순 검증 추가
- U3 상세 조회 시 이벤트 미존재 케이스(빈 리스트) 검증 추가
- refund-context refundableAmount 계산 검증 추가
- 미존재 paymentId 조회 시 null 반환 검증 추가

### Service 테스트 추가
- merchant 결제 목록 조회 위임 검증 추가
- 결제 상세 조회 위임 검증 추가
- refund-context 조회 위임 검증 추가
- repository null 반환 시 NotFoundException 수렴 검증 추가

### Controller 테스트 추가
- GET /api/payments/{paymentId} 정상 응답 검증 추가
- GET /api/payments/{paymentId} 미존재 404 응답 검증 추가
- GET /api/payments/{paymentId}/refund-context 정상 응답 검증 추가
- GET /api/payments/{paymentId}/refund-context 미존재 404 응답 검증 추가
- GET /api/merchants/{merchantId}/payments 정상 목록 응답 검증 추가
- GET /api/merchants/{merchantId}/payments 빈 결과 응답 검증 추가
- merchant 목록 조회 query param 바인딩(status / confirmed / from / to / keyword) 검증 추가

### 테스트 가독성 정리
- PaymentQueryRepositoryTest UUID 상수 추출
- 검색 조건 생성 helper 추가
- 테스트 섹션 주석 및 fixture helper 정리

## why
- U2 / U3 / refund-context 조회 API 동작을 계층별로 검증하기 위함
- QueryDSL projection / 파생값(capturedAt, confirmedAt) / 검색 조건 동작을 회귀 방지하기 위함
- 컨트롤러 레벨에서 응답 JSON 구조와 404 수렴 계약을 고정하기 위함
- 검색 조건 바인딩 누락 같은 웹 계층 버그를 조기에 탐지하기 위함

## how to test
- `PaymentQueryRepositoryTest` 실행
- `PaymentQueryServiceTest` 실행
- `PaymentQueryControllerTest` 실행
- `MerchantPaymentQueryControllerTest` 실행
- 전체 테스트 통과 확인

## note
- 조회 API 구현 PR 후속으로 테스트 코드 추가 작업 진행
- 컨트롤러 테스트는 필터 영향 제거 후 웹 계층 계약 중심으로 검증