### PR TITLE
feat: split admin-web layout and page shells into clean branch

### DIFF
--- a/admin-web/src/App.jsx
+++ b/admin-web/src/App.jsx
@@ -1,18 +1,29 @@
 import { Routes, Route, Navigate } from "react-router-dom";
+import AppLayout from "./layouts/AppLayout";
 import AdminRoutes from "./app/router/AdminRoutes.jsx";
+import MerchantRoutes from "./app/router/MerchantRoutes.jsx";
 import ConsumerRoutes from "./app/router/ConsumerRoutes.jsx";
+import CommonUiSamplePage from "./pages/_sample/CommonUiSamplePage.jsx";
 
 export default function App() {
   return (
     <Routes>
-      {/* /admin 아래는 AdminRoutes가 처리 */}
-      <Route path="/admin/*" element={<AdminRoutes />} />
+      <Route element={<AppLayout />}>
+        {/* 기본 진입 */}
+        <Route path="/" element={<Navigate to="/consumer/orders/new" replace />} />
 
-      {/* C1 */}
-      <Route path="/consumer/*" element={<ConsumerRoutes />} />
+        {/* /admin 아래는 AdminRoutes가 처리 */}
+        <Route path="/admin/*" element={<AdminRoutes />} />
 
-      {/* 기본 진입 */}
-      <Route path="/" element={<Navigate to="/consumer/orders/new" replace />} />
+        {/* /merchant 아래는 MerchantRoutes가 처리 */}
+        <Route path="/merchant/*" element={<MerchantRoutes />} />
+
+        {/* /consumer 아래는 ConsumerRoutes가 처리 */}
+        <Route path="/consumer/*" element={<ConsumerRoutes />} />
+
+        {/* 공통 UI 샘플 미리보기 */}
+        <Route path="/sample/ui" element={<CommonUiSamplePage />} />
+      </Route>
 
       {/* 404 */}
       <Route path="*" element={<div>Not Found</div>} />

--- a/admin-web/src/app/router/AdminRoutes.jsx
+++ b/admin-web/src/app/router/AdminRoutes.jsx
@@ -1,10 +1,19 @@
 import { Routes, Route } from "react-router-dom";
 import AdminAuditPage from "../../pages/AdminAuditPage.jsx";
+import BatchPage from "../../pages/admin/BatchPage.jsx"
+import SettlementManagePage from "../../pages/admin/SettlementManagePage.jsx"
+import SettlementDetailAdminPage from "../../pages/admin/SettlementDetailAdminPage.jsx"
 
 export default function AdminRoutes() {
   return (
     <Routes>
       <Route path="audit" element={<AdminAuditPage />} />
+      <Route path="settlement-batches" element={<BatchPage />}/>
+      <Route path="settlements" element={<SettlementManagePage />}/>
+      <Route
+        path="settlements/:settlementId"
+        element={<SettlementDetailAdminPage />}      
+      />
     </Routes>
   );
 }

--- a/admin-web/src/app/router/ConsumerRoutes.jsx
+++ b/admin-web/src/app/router/ConsumerRoutes.jsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from "react-router-dom";
 import OrderCreatePage from "../../pages/consumer/OrderCreatePage.jsx";
+import MyOrdersPage from "../../pages/consumer/MyOrdersPage.jsx";
 
 export default function ConsumerRoutes() {
     return (
         <Routes>
             <Route path="orders/new" element={<OrderCreatePage />} />
+            <Route path="orders" element={<MyOrdersPage />} />
         </Routes>
     );
 }

--- a/admin-web/src/app/router/MerchantRoutes.jsx
+++ b/admin-web/src/app/router/MerchantRoutes.jsx
@@ -1,0 +1,31 @@
+import { Routes, Route, Navigate } from "react-router-dom";
+import SettlementListPage from "../../pages/merchant/SettlementListPage.jsx";
+import SettlementDetailPage from "../../pages/merchant/SettlementDetailPage.jsx";
+
+function MerchantPaymentListPage() {
+  return <div>결제 조회 페이지</div>;
+}
+
+function MerchantPaymentDetailPage() {
+  return <div>결제 상세 페이지</div>;
+}
+
+function MerchantRefundPage() {
+  return <div>환불 현황 페이지</div>;
+}
+
+export default function MerchantRoutes() {
+  return (
+    <Routes>
+      <Route index element={<Navigate to="/merchant/payments" replace />} />
+      <Route path="payments" element={<MerchantPaymentListPage />} />
+      <Route path="payments/:paymentId" element={<MerchantPaymentDetailPage />} />
+      <Route path="settlements" element={<SettlementListPage />} />
+      <Route
+        path="settlements/:settlementId"
+        element={<SettlementDetailPage />}
+      />
+      <Route path="refunds" element={<MerchantRefundPage />} />
+    </Routes>
+  );
+}

--- a/admin-web/src/layouts/AppHeader.jsx
+++ b/admin-web/src/layouts/AppHeader.jsx
@@ -1,0 +1,42 @@
+// src/layouts/AppHeader.jsx
+import { useLocation } from "react-router-dom";
+
+function resolvePageTitle(pathname) {
+  if (pathname === "/consumer/orders/new") return "거래 생성";
+  if (pathname === "/consumer/payments") return "내 주문/결제 내역";
+
+  if (pathname === "/merchant/payments") return "결제 조회";
+  if (pathname.startsWith("/merchant/payments/")) return "결제 상세";
+  if (pathname === "/merchant/refunds") return "환불 현황";
+
+  if (pathname === "/admin/audit") return "Trace / Audit";
+  if (pathname === "/admin/batches") return "배치 실행";
+  if (pathname === "/admin/settlements") return "정산 관리";
+  if (pathname.startsWith("/admin/settlements/")) return "정산 상세";
+  if (pathname === "/admin/holds") return "Hold 큐";
+  if (pathname.startsWith("/admin/holds/")) return "Hold 상세";
+  if (pathname === "/admin/refunds") return "환불 큐";
+  if (pathname.startsWith("/admin/refunds/")) return "환불 상세";
+
+  if (pathname === "/sample/ui") return "공통 UI 샘플";
+
+  return "SettleOps Admin";
+}
+
+export default function AppHeader() {
+  const location = useLocation();
+  const pageTitle = resolvePageTitle(location.pathname);
+
+  return (
+    <div className="app-header">
+      <div className="app-header__left">
+        <h1 className="app-header__title">{pageTitle}</h1>
+        <p className="app-header__meta">{location.pathname}</p>
+      </div>
+
+      <div className="app-header__right">
+        <span className="app-header__badge">DEV</span>
+      </div>
+    </div>
+  );
+}

--- a/admin-web/src/layouts/AppLayout.jsx
+++ b/admin-web/src/layouts/AppLayout.jsx
@@ -1,0 +1,25 @@
+// src/layouts/AppLayout.jsx
+import { Outlet } from "react-router-dom";
+import Sidebar from "./Sidebar";
+import AppHeader from "./AppHeader";
+import "../style/layout.css";
+
+export default function AppLayout() {
+  return (
+    <div className="app-layout">
+      <aside className="app-layout__sidebar">
+        <Sidebar />
+      </aside>
+
+      <div className="app-layout__main">
+        <header className="app-layout__header">
+          <AppHeader />
+        </header>
+
+        <main className="app-layout__content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/admin-web/src/layouts/Sidebar.jsx
+++ b/admin-web/src/layouts/Sidebar.jsx
@@ -1,0 +1,59 @@
+// src/components/layout/Sidebar.jsx
+import { NavLink } from "react-router-dom";
+
+const menuGroups = [
+  {
+    title: "Consumer",
+    items: [
+      { label: "거래 생성", to: "/consumer/orders/new" },
+      { label: "내 주문/결제 내역", to: "/consumer/payments" },
+    ],
+  },
+  {
+    title: "Merchant",
+    items: [
+      { label: "결제 조회", to: "/merchant/payments" },
+      { label: "환불 현황", to: "/merchant/refunds" },
+    ],
+  },
+  {
+    title: "Admin",
+    items: [
+      { label: "Trace / Audit", to: "/admin/audit" },
+      { label: "배치 실행", to: "/admin/batches" },
+      { label: "정산 관리", to: "/admin/settlements" },
+      { label: "Hold 큐", to: "/admin/holds" },
+      { label: "환불 큐", to: "/admin/refunds" },
+    ],
+  },
+];
+
+export default function Sidebar() {
+  return (
+    <div className="sidebar">
+      <div className="sidebar__logo">SettleOps</div>
+
+      <nav className="sidebar__nav">
+        {menuGroups.map((group) => (
+          <div key={group.title} className="sidebar__group">
+            <p className="sidebar__group-title">{group.title}</p>
+
+            <div className="sidebar__menu">
+              {group.items.map((item) => (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  className={({ isActive }) =>
+                    isActive ? "sidebar__link sidebar__link--active" : "sidebar__link"
+                  }
+                >
+                  {item.label}
+                </NavLink>
+              ))}
+            </div>
+          </div>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/admin-web/src/main.jsx
+++ b/admin-web/src/main.jsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./index.css";
+import "./style/globals.css";
 import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(

--- a/admin-web/src/pages/_sample/CommonUiSamplePage.jsx
+++ b/admin-web/src/pages/_sample/CommonUiSamplePage.jsx
@@ -1,0 +1,403 @@
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import ActionButton from "../../components/layout/ActionButton.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+
+export default function CommonUiSamplePage() {
+  return (
+    <PageLayout
+      title="공통 UI 샘플"
+      description="타이틀, 버튼, 배지, 폼, 테이블, 메타 JSON, 타임라인, 상태 블록 예시"
+    >
+      {/* =========================
+          1. 상단 액션 버튼 샘플
+         ========================= */}
+      <SectionCard title="버튼 샘플">
+        <div className="action-panel">
+          <ActionButton>기본 버튼</ActionButton>
+          <button type="button" className="btn btn--primary">
+            Primary
+          </button>
+          <button type="button" className="btn btn--secondary">
+            Secondary
+          </button>
+          <button type="button" className="btn btn--danger">
+            Danger
+          </button>
+          <button type="button" className="btn btn--ghost">
+            Ghost
+          </button>
+          <button type="button" className="btn btn--primary" disabled>
+            Disabled
+          </button>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          2. 상태 배지 / 토큰 샘플
+         ========================= */}
+      <SectionCard title="상태 / 배지 샘플">
+        <div className="page-section">
+          <div className="btn-group">
+            <span className="badge badge--default">DEFAULT</span>
+            <span className="badge badge--primary">READY</span>
+            <span className="badge badge--success">PAID</span>
+            <span className="badge badge--warning">HOLD_ACTIVE</span>
+            <span className="badge badge--danger">FAILED</span>
+          </div>
+
+          <div className="btn-group">
+            <StatusBadge status="CREATED" />
+            <StatusBadge status="CAPTURED" />
+            <StatusBadge status="PAY_REQUESTED" />
+            <StatusBadge status="PAID" />
+            <StatusBadge status="REQUESTED" />
+            <StatusBadge status="APPROVED" />
+            <StatusBadge status="REJECTED" />
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          3. ID / 금액 / 텍스트 샘플
+         ========================= */}
+      <SectionCard title="ID / 금액 표시 샘플">
+        <div className="page-section">
+          <div className="copyable-id">
+            <span className="copyable-id__text copyable-id__text--short">
+              SET-20260318-8b4c1a29-cf7d-4f98-bdf1-5d4f9aa21872
+            </span>
+            <button type="button" className="copyable-id__button">
+              복사
+            </button>
+          </div>
+
+          <div className="copyable-id">
+            <span className="copyable-id__text">
+              req_20260318_1a2b3c4d5e6f
+            </span>
+            <button type="button" className="copyable-id__button">
+              복사
+            </button>
+          </div>
+
+          <div className="page-section">
+            <div>
+              정산액: <span className="amount-text">125,000원</span>
+            </div>
+            <div>
+              가산 항목:{" "}
+              <span className="amount-text amount-text--positive">+132,000원</span>
+            </div>
+            <div>
+              차감 항목:{" "}
+              <span className="amount-text amount-text--negative">-7,000원</span>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          4. Guard / 안내 문구 샘플
+         ========================= */}
+      <SectionCard title="가드레일 안내 샘플">
+        <div className="page-section">
+          <div className="guard-notice">
+            <div className="guard-notice__title">지급 요청 불가</div>
+            <div className="guard-notice__description">
+              Hold가 ACTIVE라 지급요청 불가입니다. Hold 큐(A5)에서 Release 후 다시 시도해야 합니다.
+            </div>
+          </div>
+
+          <div className="guard-notice">
+            <div className="guard-notice__title">차감정산 반영 대기</div>
+            <div className="guard-notice__description">
+              승인된 환불이 있어 차감정산 반영 전입니다. 다음 배치 실행 후 다시 시도해야 합니다.
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          5. 폼 샘플
+         ========================= */}
+      <SectionCard title="폼 샘플">
+        <div className="page-section">
+          <div className="filter-bar">
+            <div className="form-field">
+              <label className="form-field__label">merchantId</label>
+              <input className="input" placeholder="MRC_1234" />
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label">status</label>
+              <select className="select">
+                <option>전체</option>
+                <option>READY</option>
+                <option>HOLD_ACTIVE</option>
+                <option>PAY_REQUESTED</option>
+                <option>PAID</option>
+              </select>
+            </div>
+
+            <div className="form-field search-field">
+              <label className="form-field__label">keyword</label>
+              <input className="input" placeholder="settlementId / paymentId" />
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label">comment</label>
+              <textarea
+                className="textarea"
+                placeholder="운영 메모 입력"
+              />
+            </div>
+          </div>
+
+          <div className="button-row action-panel">
+            <button type="button" className="btn btn--primary">
+              조회
+            </button>
+            <button type="button" className="btn btn--secondary">
+              초기화
+            </button>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          6. 요약 카드 샘플
+         ========================= */}
+      <SectionCard title="요약 카드 샘플">
+        <div className="summary-card-grid">
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">총 정산 건수</div>
+              <div className="summary-card__value">128</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">READY</div>
+              <div className="summary-card__value">54</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">HOLD_ACTIVE</div>
+              <div className="summary-card__value">3</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">PAID</div>
+              <div className="summary-card__value">71</div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          7. 테이블 샘플
+         ========================= */}
+      <SectionCard title="테이블 샘플">
+        <div className="table-toolbar">
+          <div>결제 / 정산 목록</div>
+          <div className="action-panel">
+            <button type="button" className="btn btn--secondary">
+              CSV 다운로드
+            </button>
+            <button type="button" className="btn btn--primary">
+              새로고침
+            </button>
+          </div>
+        </div>
+
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>merchantId</th>
+                <th>status</th>
+                <th>amount</th>
+                <th>baseDate</th>
+                <th>createdAt</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0001
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1001</td>
+                <td>
+                  <span className="badge badge--primary">READY</span>
+                </td>
+                <td>
+                  <span className="amount-text">125,000원</span>
+                </td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 10:30:00</td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0002
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1002</td>
+                <td>
+                  <span className="badge badge--warning">HOLD_ACTIVE</span>
+                </td>
+                <td>
+                  <span className="amount-text">98,000원</span>
+                </td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 11:05:00</td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0003
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1003</td>
+                <td>
+                  <span className="badge badge--success">PAID</span>
+                </td>
+                <td>
+                  <span className="amount-text">301,000원</span>
+                </td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 12:20:00</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="pagination">
+          <button type="button" className="btn btn--secondary">
+            이전
+          </button>
+          <button type="button" className="btn btn--primary">
+            1
+          </button>
+          <button type="button" className="btn btn--secondary">
+            2
+          </button>
+          <button type="button" className="btn btn--secondary">
+            다음
+          </button>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          8. meta_json / audit 샘플
+         ========================= */}
+      <SectionCard title="meta_json 샘플">
+        <div className="page-section">
+          <div className="audit-meta-block">
+{`{
+  "requestId": "req_20260318_123456",
+  "comment": "환불 승인 처리",
+  "noOp": false,
+  "before": {
+    "status": "REQUESTED"
+  },
+  "after": {
+    "status": "APPROVED"
+  }
+}`}
+          </div>
+
+          <div className="audit-meta-block">
+{`{
+  "noOp": true,
+  "noOpReason": "ALREADY_APPROVED",
+  "comment": "이미 승인된 환불 재요청"
+}`}
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          9. 타임라인 샘플
+         ========================= */}
+      <SectionCard title="타임라인 샘플">
+        <div className="timeline">
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-18 10:20:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">PAYMENT_CAPTURED</div>
+              <div className="timeline-item__meta">
+                actor: CONSUMER / entity: PAYMENT / id: pay_1234
+              </div>
+            </div>
+          </div>
+
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-18 10:25:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">PAYMENT_CONFIRMED</div>
+              <div className="timeline-item__meta">
+                actor: CONSUMER / entity: PAYMENT / id: pay_1234
+              </div>
+            </div>
+          </div>
+
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-19 02:00:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">SETTLEMENT_CREATED</div>
+              <div className="timeline-item__meta">
+                actor: SYSTEM / entity: SETTLEMENT / id: set_5678
+              </div>
+              <div className="audit-meta-block">
+{`{
+  "baseDate": "2026-03-18",
+  "merchantId": "MRC_1001",
+  "net": 125000
+}`}
+              </div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      {/* =========================
+          10. 상태 블록 샘플
+         ========================= */}
+      <SectionCard title="상태 블록 샘플">
+        <div className="page-grid-2">
+          <div className="state-block">
+            <div className="state-block__title">조회 결과가 없습니다</div>
+            <div className="state-block__description">
+              검색 조건을 다시 확인하거나 기간을 넓혀서 조회해 주세요.
+            </div>
+          </div>
+
+          <div className="state-block">
+            <div className="state-block__title">로딩 중</div>
+            <div className="state-block__description">
+              데이터를 불러오고 있습니다.
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/_sample/SampleDetailPage.jsx
+++ b/admin-web/src/pages/_sample/SampleDetailPage.jsx
@@ -1,0 +1,130 @@
+// /admin-web/src/pages/_sample/SampleDetailPage.jsx
+
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+
+export default function SampleDetailPage() {
+  return (
+    <PageLayout
+      title="상세형 페이지 샘플"
+      description="요약 카드 + 상세 정보 + 관련 섹션 + 운영 액션 구조 예시"
+    >
+      <SectionCard title="상단 액션">
+        <div className="action-panel">
+          <button type="button" className="btn btn--primary">지급 요청</button>
+          <button type="button" className="btn btn--secondary">Trace로 보기</button>
+          <button type="button" className="btn btn--secondary">Hold 큐로 이동</button>
+          <button type="button" className="btn btn--secondary">Refund 큐로 이동</button>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="요약">
+        <div className="summary-card-grid">
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">settlementId</div>
+              <div className="summary-card__value">SET-20260318-0001</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">status</div>
+              <div className="summary-card__value">
+                <StatusBadge status="READY" />
+              </div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">merchantId</div>
+              <div className="summary-card__value">MRC_1001</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">net</div>
+              <div className="summary-card__value">125,000원</div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <div className="page-grid-2">
+        <SectionCard title="정산 상세">
+          <div className="info-list">
+            <div><strong>baseDate</strong> 2026-03-18</div>
+            <div><strong>gross</strong> 132,000원</div>
+            <div><strong>fee</strong> 5,000원</div>
+            <div><strong>vat</strong> 2,000원</div>
+            <div><strong>net</strong> 125,000원</div>
+          </div>
+        </SectionCard>
+
+        <SectionCard title="운영 가드레일">
+          <div className="guard-notice">
+            <div className="guard-notice__title">지급 요청 가능</div>
+            <div className="guard-notice__description">
+              현재 HOLD_ACTIVE 및 REFUND_ADJUSTMENT_PENDING 조건이 없어 지급 요청이 가능합니다.
+            </div>
+          </div>
+        </SectionCard>
+      </div>
+
+      <SectionCard title="정산 수식 뷰">
+        <div className="info-list">
+          <div>[+] gross: 132,000원</div>
+          <div>[-] fee: 5,000원</div>
+          <div>[-] vat: 2,000원</div>
+          <div>[-] refund: 0원</div>
+          <div><strong>[=] net: 125,000원</strong></div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="연결 정보">
+        <div className="info-list">
+          <div>
+            <strong>paymentId</strong>{" "}
+            <span className="copyable-id__text">PAY-3bb2d7e4-7b18-4df8</span>
+          </div>
+          <div>
+            <strong>requestId</strong>{" "}
+            <span className="copyable-id__text">req_20260318_abc123</span>
+          </div>
+          <div>
+            <strong>hold</strong> 없음
+          </div>
+          <div>
+            <strong>refund</strong> 없음
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="라인 목록">
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>type</th>
+                <th>paymentId</th>
+                <th>amount</th>
+                <th>createdAt</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>PAYMENT</td>
+                <td>PAY-20260318-0001</td>
+                <td>125,000원</td>
+                <td>2026-03-19 02:00:00</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/_sample/SampleFormPage.jsx
+++ b/admin-web/src/pages/_sample/SampleFormPage.jsx
@@ -1,0 +1,81 @@
+// /admin-web/src/pages/_sample/SampleFormPage.jsx
+
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+
+export default function SampleFormPage() {
+  return (
+    <PageLayout
+      title="폼형 페이지 샘플"
+      description="입력 필드 + 안내 문구 + 결과 카드 구조 예시"
+    >
+      <SectionCard title="입력 폼">
+        <form className="form-stack">
+          <div className="form-field">
+            <label className="form-field__label">merchantId</label>
+            <input className="input" placeholder="MRC_1001" />
+          </div>
+
+          <div className="form-field">
+            <label className="form-field__label">buyerId</label>
+            <input className="input" placeholder="BUYER_2001" />
+          </div>
+
+          <div className="form-field">
+            <label className="form-field__label">itemName</label>
+            <input className="input" placeholder="아이템명 입력" />
+          </div>
+
+          <div className="form-field">
+            <label className="form-field__label">amount</label>
+            <input
+              className="input"
+              type="number"
+              min="1"
+              step="1"
+              placeholder="10000"
+            />
+          </div>
+
+          <div className="form-field">
+            <label className="form-field__label">comment</label>
+            <textarea
+              className="textarea"
+              placeholder="운영 메모 또는 설명 입력"
+            />
+          </div>
+
+          <div className="button-row">
+            <button type="submit" className="btn btn--primary">
+              저장
+            </button>
+            <button type="button" className="btn btn--secondary">
+              취소
+            </button>
+          </div>
+        </form>
+      </SectionCard>
+
+      <SectionCard title="에러 메시지 샘플">
+        <div className="state-error">amount는 KRW 정수(원)만 입력 가능합니다.</div>
+      </SectionCard>
+
+      <SectionCard title="안내 문구 샘플">
+        <div className="guard-notice">
+          <div className="guard-notice__title">입력 규칙</div>
+          <div className="guard-notice__description">
+            금액은 KRW 정수만 허용하며, comment는 운영 액션에서 감사 추적용으로 사용될 수 있습니다.
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="결과 샘플">
+        <div className="info-list">
+          <div><strong>orderId</strong> ORD-20260318-0001</div>
+          <div><strong>status</strong> CREATED</div>
+          <div><strong>amount</strong> 10,000원</div>
+        </div>
+      </SectionCard>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/_sample/SampleListPage.jsx
+++ b/admin-web/src/pages/_sample/SampleListPage.jsx
@@ -1,0 +1,130 @@
+// /admin-web/src/pages/_sample/SampleListPage.jsx
+
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+
+export default function SampleListPage() {
+  return (
+    <PageLayout
+      title="리스트형 페이지 샘플"
+      description="검색 조건 + 테이블 + 페이지네이션 구조 예시"
+    >
+      <SectionCard title="검색 조건">
+        <div className="filter-bar">
+          <div className="form-field">
+            <label className="form-field__label">merchantId</label>
+            <input className="input" placeholder="MRC_1001" />
+          </div>
+
+          <div className="form-field">
+            <label className="form-field__label">status</label>
+            <select className="select">
+              <option>전체</option>
+              <option>READY</option>
+              <option>HOLD_ACTIVE</option>
+              <option>PAY_REQUESTED</option>
+              <option>PAID</option>
+            </select>
+          </div>
+
+          <div className="form-field search-field">
+            <label className="form-field__label">keyword</label>
+            <input className="input" placeholder="settlementId / paymentId" />
+          </div>
+        </div>
+
+        <div className="button-row action-panel" style={{ marginTop: "16px" }}>
+          <button type="button" className="btn btn--primary">
+            조회
+          </button>
+          <button type="button" className="btn btn--secondary">
+            초기화
+          </button>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="목록">
+        <div className="table-toolbar">
+          <div>정산 관리 목록</div>
+          <div className="action-panel">
+            <button type="button" className="btn btn--secondary">
+              CSV 다운로드
+            </button>
+            <button type="button" className="btn btn--primary">
+              새로고침
+            </button>
+          </div>
+        </div>
+
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>settlementId</th>
+                <th>merchantId</th>
+                <th>status</th>
+                <th>net</th>
+                <th>baseDate</th>
+                <th>createdAt</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0001
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1001</td>
+                <td><StatusBadge status="READY" /></td>
+                <td><span className="amount-text">125,000원</span></td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 10:30:00</td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0002
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1002</td>
+                <td><StatusBadge status="HOLD_ACTIVE" /></td>
+                <td><span className="amount-text">98,000원</span></td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 11:05:00</td>
+              </tr>
+
+              <tr>
+                <td>
+                  <div className="copyable-id">
+                    <span className="copyable-id__text copyable-id__text--short">
+                      SET-20260318-0003
+                    </span>
+                  </div>
+                </td>
+                <td>MRC_1003</td>
+                <td><StatusBadge status="PAID" /></td>
+                <td><span className="amount-text">301,000원</span></td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 12:20:00</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div className="pagination">
+          <button type="button" className="btn btn--secondary">이전</button>
+          <button type="button" className="btn btn--primary">1</button>
+          <button type="button" className="btn btn--secondary">2</button>
+          <button type="button" className="btn btn--secondary">다음</button>
+        </div>
+      </SectionCard>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/_sample/UiReferencePage.jsx
+++ b/admin-web/src/pages/_sample/UiReferencePage.jsx
@@ -1,0 +1,283 @@
+// /admin-web/src/pages/_sample/UiReferencePage.jsx
+
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import ActionButton from "../../components/layout/ActionButton.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+
+export default function UiReferencePage() {
+  return (
+    <PageLayout
+      title="공통 UI 샘플"
+      description="타이틀, 버튼, 배지, 폼, 테이블, 메타 JSON, 타임라인, 상태 블록 예시"
+    >
+      <SectionCard title="버튼 샘플">
+        <div className="action-panel">
+          <ActionButton>기본 버튼</ActionButton>
+          <button type="button" className="btn btn--primary">Primary</button>
+          <button type="button" className="btn btn--secondary">Secondary</button>
+          <button type="button" className="btn btn--danger">Danger</button>
+          <button type="button" className="btn btn--ghost">Ghost</button>
+          <button type="button" className="btn btn--primary" disabled>Disabled</button>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="상태 / 배지 샘플">
+        <div className="page-section">
+          <div className="btn-group">
+            <span className="badge badge--default">DEFAULT</span>
+            <span className="badge badge--primary">READY</span>
+            <span className="badge badge--success">PAID</span>
+            <span className="badge badge--warning">HOLD_ACTIVE</span>
+            <span className="badge badge--danger">FAILED</span>
+          </div>
+
+          <div className="btn-group">
+            <StatusBadge status="CREATED" />
+            <StatusBadge status="CAPTURED" />
+            <StatusBadge status="PAY_REQUESTED" />
+            <StatusBadge status="PAID" />
+            <StatusBadge status="REQUESTED" />
+            <StatusBadge status="APPROVED" />
+            <StatusBadge status="REJECTED" />
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="ID / 금액 표시 샘플">
+        <div className="page-section">
+          <div className="copyable-id">
+            <span className="copyable-id__text copyable-id__text--short">
+              SET-20260318-8b4c1a29-cf7d-4f98-bdf1-5d4f9aa21872
+            </span>
+            <button type="button" className="copyable-id__button">복사</button>
+          </div>
+
+          <div className="copyable-id">
+            <span className="copyable-id__text">req_20260318_1a2b3c4d5e6f</span>
+            <button type="button" className="copyable-id__button">복사</button>
+          </div>
+
+          <div className="page-section">
+            <div>정산액: <span className="amount-text">125,000원</span></div>
+            <div>가산 항목: <span className="amount-text amount-text--positive">+132,000원</span></div>
+            <div>차감 항목: <span className="amount-text amount-text--negative">-7,000원</span></div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="가드레일 안내 샘플">
+        <div className="page-section">
+          <div className="guard-notice">
+            <div className="guard-notice__title">지급 요청 불가</div>
+            <div className="guard-notice__description">
+              Hold가 ACTIVE라 지급요청 불가입니다. Hold 큐(A5)에서 Release 후 다시 시도해야 합니다.
+            </div>
+          </div>
+
+          <div className="guard-notice">
+            <div className="guard-notice__title">차감정산 반영 대기</div>
+            <div className="guard-notice__description">
+              승인된 환불이 있어 차감정산 반영 전입니다. 다음 배치 실행 후 다시 시도해야 합니다.
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="폼 샘플">
+        <div className="page-section">
+          <div className="filter-bar">
+            <div className="form-field">
+              <label className="form-field__label">merchantId</label>
+              <input className="input" placeholder="MRC_1234" />
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label">status</label>
+              <select className="select">
+                <option>전체</option>
+                <option>READY</option>
+                <option>HOLD_ACTIVE</option>
+                <option>PAY_REQUESTED</option>
+                <option>PAID</option>
+              </select>
+            </div>
+
+            <div className="form-field search-field">
+              <label className="form-field__label">keyword</label>
+              <input className="input" placeholder="settlementId / paymentId" />
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label">comment</label>
+              <textarea className="textarea" placeholder="운영 메모 입력" />
+            </div>
+          </div>
+
+          <div className="button-row action-panel">
+            <button type="button" className="btn btn--primary">조회</button>
+            <button type="button" className="btn btn--secondary">초기화</button>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="요약 카드 샘플">
+        <div className="summary-card-grid">
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">총 정산 건수</div>
+              <div className="summary-card__value">128</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">READY</div>
+              <div className="summary-card__value">54</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">HOLD_ACTIVE</div>
+              <div className="summary-card__value">3</div>
+            </div>
+          </div>
+
+          <div className="card">
+            <div className="card__body">
+              <div className="summary-card__label">PAID</div>
+              <div className="summary-card__value">71</div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="테이블 샘플">
+        <div className="table-toolbar">
+          <div>결제 / 정산 목록</div>
+          <div className="action-panel">
+            <button type="button" className="btn btn--secondary">CSV 다운로드</button>
+            <button type="button" className="btn btn--primary">새로고침</button>
+          </div>
+        </div>
+
+        <div className="table-wrap">
+          <table className="data-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>merchantId</th>
+                <th>status</th>
+                <th>amount</th>
+                <th>baseDate</th>
+                <th>createdAt</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>SET-20260318-0001</td>
+                <td>MRC_1001</td>
+                <td><span className="badge badge--primary">READY</span></td>
+                <td>125,000원</td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 10:30:00</td>
+              </tr>
+              <tr>
+                <td>SET-20260318-0002</td>
+                <td>MRC_1002</td>
+                <td><span className="badge badge--warning">HOLD_ACTIVE</span></td>
+                <td>98,000원</td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 11:05:00</td>
+              </tr>
+              <tr>
+                <td>SET-20260318-0003</td>
+                <td>MRC_1003</td>
+                <td><span className="badge badge--success">PAID</span></td>
+                <td>301,000원</td>
+                <td>2026-03-18</td>
+                <td>2026-03-18 12:20:00</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="meta_json 샘플">
+        <div className="page-section">
+          <div className="audit-meta-block">
+{`{
+  "requestId": "req_20260318_123456",
+  "comment": "환불 승인 처리",
+  "noOp": false,
+  "before": { "status": "REQUESTED" },
+  "after": { "status": "APPROVED" }
+}`}
+          </div>
+
+          <div className="audit-meta-block">
+{`{
+  "noOp": true,
+  "noOpReason": "ALREADY_APPROVED",
+  "comment": "이미 승인된 환불 재요청"
+}`}
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="타임라인 샘플">
+        <div className="timeline">
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-18 10:20:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">PAYMENT_CAPTURED</div>
+              <div className="timeline-item__meta">actor: CONSUMER / entity: PAYMENT / id: pay_1234</div>
+            </div>
+          </div>
+
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-18 10:25:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">PAYMENT_CONFIRMED</div>
+              <div className="timeline-item__meta">actor: CONSUMER / entity: PAYMENT / id: pay_1234</div>
+            </div>
+          </div>
+
+          <div className="timeline-item">
+            <div className="timeline-item__time">2026-03-19 02:00:00</div>
+            <div className="timeline-item__body">
+              <div className="timeline-item__title">SETTLEMENT_CREATED</div>
+              <div className="timeline-item__meta">actor: SYSTEM / entity: SETTLEMENT / id: set_5678</div>
+              <div className="audit-meta-block">
+{`{
+  "baseDate": "2026-03-18",
+  "merchantId": "MRC_1001",
+  "net": 125000
+}`}
+              </div>
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="상태 블록 샘플">
+        <div className="page-grid-2">
+          <div className="state-block">
+            <div className="state-block__title">조회 결과가 없습니다</div>
+            <div className="state-block__description">
+              검색 조건을 다시 확인하거나 기간을 넓혀서 조회해 주세요.
+            </div>
+          </div>
+
+          <div className="state-block">
+            <div className="state-block__title">로딩 중</div>
+            <div className="state-block__description">
+              데이터를 불러오고 있습니다.
+            </div>
+          </div>
+        </div>
+      </SectionCard>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -1,0 +1,3 @@
+export default function BatchPage() {
+  return <div>A2 BatchPage</div>;
+}

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -1,0 +1,3 @@
+export default function SettlementDeailAdminPage() {
+  return <div>A3 SettlementDetailAdminPage</div>;
+}

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -1,0 +1,3 @@
+export default function SettlementManagePage() {
+  return <div>A3 SettlementManagePage</div>;
+}

--- a/admin-web/src/pages/consumer/MyOrdersPage.jsx
+++ b/admin-web/src/pages/consumer/MyOrdersPage.jsx
@@ -1,0 +1,3 @@
+export default function MyOrdersPage() {
+  return <div>MyOrdersPage</div>;
+}

--- a/admin-web/src/pages/merchant/SettlementDetailPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementDetailPage.jsx
@@ -1,0 +1,3 @@
+export default function SettlementDetailPage() {
+  return <div>SettlementDetailPage</div>;
+}

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -1,0 +1,14 @@
+export default function SettlementListPage() {
+  return (
+    <div
+      style={{
+        color: "red",
+        backgroundColor: "yellow",
+        fontSize: "32px",
+        padding: "40px",
+      }}
+    >
+      U4 SettlementListPage
+    </div>
+  );
+}

--- a/admin-web/src/style/badge.css
+++ b/admin-web/src/style/badge.css
@@ -8,3 +8,38 @@
 .status-created {
     background: #eef2ff;
 }
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.badge--default {
+  background: #eef2f7;
+  color: #475467;
+}
+
+.badge--success {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.badge--warning {
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+}
+
+.badge--danger {
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
+
+.badge--primary {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+}

--- a/admin-web/src/style/button.css
+++ b/admin-web/src/style/button.css
@@ -14,3 +14,70 @@
     background: #111827;
     color: #fff;
 }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  transition: 0.2s ease;
+}
+
+.btn--primary {
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.btn--primary:hover {
+  opacity: 0.92;
+}
+
+.btn--secondary {
+  border-color: var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.btn--secondary:hover {
+  background: var(--color-surface-muted);
+}
+
+.btn--danger {
+  background: var(--color-danger);
+  color: #ffffff;
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+}
+
+.btn--ghost:hover {
+  background: var(--color-surface-muted);
+}
+
+.btn:disabled,
+.btn--disabled {
+  background: var(--color-disabled-bg);
+  border-color: var(--color-disabled-bg);
+  color: var(--color-disabled-text);
+  cursor: not-allowed;
+}
+
+.btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.action-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}

--- a/admin-web/src/style/card.css
+++ b/admin-web/src/style/card.css
@@ -4,3 +4,55 @@
     border-radius: 12px;
     padding: 20px;
 }
+
+.card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-5) var(--space-4);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card__title {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.card__body {
+  padding: var(--space-5);
+}
+
+.card__footer {
+  padding: var(--space-4) var(--space-5) var(--space-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.summary-card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+}
+
+.summary-card__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.summary-card__value {
+  margin-top: 6px;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+}
+
+@media (max-width: 1024px) {
+  .summary-card-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/admin-web/src/style/form.css
+++ b/admin-web/src/style/form.css
@@ -13,3 +13,82 @@
     border: 1px solid #d1d5db;
     border-radius: 8px;
 }
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.form-field {
+  display: flex;
+  min-width: 180px;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field__label {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.input,
+.select,
+.textarea {
+  width: 100%;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+}
+
+.textarea {
+  min-height: 96px;
+  padding: 12px;
+  resize: vertical;
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  outline: 0;
+  border-color: var(--color-primary);
+}
+
+.search-field {
+  min-width: 240px;
+}
+
+.date-range-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.form-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.button-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.info-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.state-error {
+  padding: 12px 14px;
+  border: 1px solid #fecaca;
+  border-radius: 12px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 14px;
+}

--- a/admin-web/src/style/globals.css
+++ b/admin-web/src/style/globals.css
@@ -1,0 +1,43 @@
+@import "./token.css";
+@import "./reset.css";
+@import "./layout.css";
+@import "./button.css";
+@import "./badge.css";
+@import "./card.css";
+@import "./state.css";
+@import "./id.css";
+@import "./table.css";
+@import "./form.css";
+@import "./timeline.css";
+
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-base);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/admin-web/src/style/id.css
+++ b/admin-web/src/style/id.css
@@ -1,0 +1,43 @@
+.copyable-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.copyable-id__text {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+}
+
+.copyable-id__text--short {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copyable-id__button {
+  padding: 6px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  font-size: var(--font-size-xs);
+}
+
+.copyable-id__button:hover {
+  background: var(--color-surface-muted);
+}
+
+.amount-text {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.amount-text--positive {
+  color: var(--color-success);
+}
+
+.amount-text--negative {
+  color: var(--color-danger);
+}

--- a/admin-web/src/style/layout.css
+++ b/admin-web/src/style/layout.css
@@ -12,3 +12,299 @@
     display: grid;
     gap: 16px;
 }
+/* =========================================================
+   AppLayout 전체 골격
+   - src/layouts/AppLayout.jsx
+   - .app-layout
+   - .app-layout__sidebar
+   - .app-layout__main
+   - .app-layout__header
+   - .app-layout__content
+   ========================================================= */
+
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.app-layout__sidebar {
+  width: 260px;
+  min-width: 260px;
+  border-right: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.app-layout__main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.app-layout__header {
+  height: 72px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.app-layout__content {
+  flex: 1;
+  min-width: 0;
+  padding: 24px;
+  background: var(--color-bg);
+  overflow-y: auto;
+}
+
+
+/* =========================================================
+   Sidebar 전체
+   - src/layouts/Sidebar.jsx
+   - .sidebar
+   - .sidebar__logo
+   - .sidebar__nav
+   - .sidebar__group
+   - .sidebar__group-title
+   - .sidebar__menu
+   - .sidebar__link
+   - .sidebar__link--active
+   ========================================================= */
+
+.sidebar {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  padding: 20px 16px;
+}
+
+.sidebar__logo {
+  margin-bottom: 24px;
+  color: var(--color-text-primary);
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.sidebar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sidebar__group-title {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar__link {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: var(--color-text-primary);
+  font-size: 14px;
+  line-height: 1.4;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar__link:hover {
+  background: var(--color-surface-muted);
+}
+
+.sidebar__link--active {
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+
+/* =========================================================
+   AppHeader 전체
+   - src/layouts/AppHeader.jsx
+   - .app-header
+   - .app-header__left
+   - .app-header__title
+   - .app-header__meta
+   - .app-header__right
+   - .app-header__badge
+   ========================================================= */
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+  padding: 0 24px;
+  background: var(--color-surface);
+}
+
+.app-header__left {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.app-header__title {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.app-header__meta {
+  margin: 4px 0 0;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.app-header__right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.app-header__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--color-primary-soft);
+  color: var(--color-primary);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+
+/* =========================================================
+   페이지 내부 공통 래퍼
+   - 본문 페이지에서 선택적으로 사용
+   - .page-layout
+   - .page-layout--narrow
+   - .page-layout__header
+   - .page-layout__body
+   ========================================================= */
+
+.page-layout {
+  width: 100%;
+  max-width: 1440px;
+  margin: 0 auto;
+}
+
+.page-layout--narrow {
+  max-width: 960px;
+}
+
+.page-layout__header {
+  margin-bottom: 24px;
+}
+
+.page-layout__body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+
+/* =========================================================
+   페이지 섹션/그리드 공통
+   - 선택 사용
+   - .page-section
+   - .page-grid-2
+   - .page-grid-3
+   ========================================================= */
+
+.page-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.page-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.page-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+
+/* =========================================================
+   반응형
+   ========================================================= */
+
+@media (max-width: 1024px) {
+  .app-layout__sidebar {
+    width: 220px;
+    min-width: 220px;
+  }
+
+  .page-grid-2,
+  .page-grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .app-layout {
+    flex-direction: column;
+  }
+
+  .app-layout__sidebar {
+    width: 100%;
+    min-width: 100%;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .app-layout__header {
+    height: auto;
+    min-height: 72px;
+  }
+
+  .app-layout__content {
+    padding: 16px;
+  }
+
+  .app-header {
+    padding: 16px;
+  }
+
+  .app-header__title {
+    font-size: 18px;
+  }
+
+  .app-header__meta {
+    font-size: 12px;
+  }
+
+  .sidebar {
+    padding: 16px;
+  }
+}

--- a/admin-web/src/style/reset.css
+++ b/admin-web/src/style/reset.css
@@ -1,0 +1,48 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+ul,
+ol,
+dl,
+dd,
+figure {
+  margin: 0;
+  padding: 0;
+}
+
+ul,
+ol {
+  list-style: none;
+}
+
+img,
+svg,
+video,
+canvas {
+  display: block;
+  max-width: 100%;
+}
+
+button {
+  border: 0;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/admin-web/src/style/state.css
+++ b/admin-web/src/style/state.css
@@ -1,3 +1,46 @@
 .state-error {
     color: #b42318;
 }
+.state-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  min-height: 180px;
+  padding: var(--space-6);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  text-align: center;
+}
+
+.state-block__title {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.state-block__description {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.guard-notice {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 1px solid #fed7aa;
+  border-radius: var(--radius-md);
+  background: #fff7ed;
+}
+
+.guard-notice__title {
+  color: #9a3412;
+  font-weight: 700;
+}
+
+.guard-notice__description {
+  color: #9a3412;
+  font-size: var(--font-size-sm);
+}

--- a/admin-web/src/style/table.css
+++ b/admin-web/src/style/table.css
@@ -1,0 +1,46 @@
+.table-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.data-table {
+  width: 100%;
+  min-width: 720px;
+}
+
+.data-table th,
+.data-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  font-size: var(--font-size-sm);
+  white-space: nowrap;
+}
+
+.data-table th {
+  background: #f8fafc;
+  color: var(--color-text-secondary);
+  font-weight: 700;
+}
+
+.data-table tbody tr:hover {
+  background: #f9fafb;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+}

--- a/admin-web/src/style/timeline.css
+++ b/admin-web/src/style/timeline.css
@@ -1,0 +1,47 @@
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.timeline-item {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+}
+
+.timeline-item__time {
+  min-width: 160px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.timeline-item__body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.timeline-item__title {
+  font-weight: 700;
+}
+
+.timeline-item__meta {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.audit-meta-block {
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: #f8fafc;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/admin-web/src/style/token.css
+++ b/admin-web/src/style/token.css
@@ -1,0 +1,52 @@
+:root {
+  --color-bg: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f8fafc;
+  --color-border: #e5e7eb;
+
+  --color-text-primary: #111827;
+  --color-text-secondary: #6b7280;
+  --color-text-muted: #9ca3af;
+
+  --color-primary: #2563eb;
+  --color-primary-soft: #eff6ff;
+  --color-danger: #dc2626;
+  --color-danger-soft: #fef2f2;
+  --color-success: #16a34a;
+  --color-success-soft: #f0fdf4;
+  --color-warning: #d97706;
+  --color-warning-soft: #fffbeb;
+
+  --color-disabled-bg: #f3f4f6;
+  --color-disabled-text: #9ca3af;
+
+  --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.05);
+  --shadow-md: 0 4px 12px rgba(16, 24, 40, 0.08);
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+
+  --font-size-xs: 12px;
+  --font-size-sm: 13px;
+  --font-size-md: 14px;
+  --font-size-lg: 16px;
+  --font-size-xl: 20px;
+  --font-size-2xl: 24px;
+
+  --font-family-base: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans KR",
+    sans-serif;
+  --font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+
+  --sidebar-width: 260px;
+  --header-height: 72px;
+  --content-max-width: 1440px;
+}


### PR DESCRIPTION
샘플 html 참고 경로 : 
http://localhost:5173/sample/ui 
/admin-web/src/pages/_sample/CommonUiSamplePage.jsx

## what

### admin-web 공통 레이아웃 구성
- AppLayout 추가
- Sidebar 추가
- AppHeader 추가
- 공통 레이아웃 하위에서 페이지가 렌더링되도록 Outlet 구조 적용

### 라우팅 구조 정리
- App 최상단에서 AppLayout으로 admin / consumer 라우트 공통 감싸기
- 기본 진입 시 `/consumer/orders/new` 리다이렉트 처리
- 404 fallback 라우트 추가
- AdminRoutes, ConsumerRoutes 분리 구조 유지

### 공통 스타일 기초 세팅
- layout.css 기준으로 AppLayout / Sidebar / AppHeader 통합 스타일 추가
- 레이아웃/헤더/사이드바 공통 클래스 정리
- 페이지 공통 래퍼, 섹션, 그리드 기본 스타일 추가
- 반응형 최소 대응 추가

### 공통 UI 샘플 페이지 추가
- 공통 컴포넌트 및 스타일 복붙용 샘플 페이지 추가
- 버튼 / 배지 / 폼 / 테이블 / meta_json / 타임라인 / 상태 블록 샘플 구성
- 팀원 페이지 작업 시 참고 가능한 기준 화면 확보
