### PR TITLE
feat(test): @ActiveProfiles("test") 추가로 테스트 부팅 환경 고정

### DIFF
--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 class AdminRefundControllerNoOpIT {

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
@@ -10,12 +10,14 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({com.settleops.global.config.QuerydslConfig.class, RefundReadRepositoryIT.TestConfig.class})

--- a/server/src/test/java/com/settleops/server/ServerApplicationTests.java
+++ b/server/src/test/java/com/settleops/server/ServerApplicationTests.java
@@ -2,7 +2,9 @@ package com.settleops.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ServerApplicationTests {
 


### PR DESCRIPTION
## What
테스트 클래스에 @ActiveProfiles("test") 적용
- AdminRefundControllerNoOpIT
- RefundReadRepositoryIT
- ServerApplicationTests

## Why
기본 profile로 부팅되면서 Flyway migration이 H2에서 실행되어 JdbcSQLSyntaxErrorException 발생
테스트는 application-test.yml 기준으로 실행되어야 하므로 profile 명시 필요
contextLoads 및 Repository/IT 테스트 부팅 실패 방지

## Scope
Test 코드만 수정
Refund(C 파트) 테스트 및 공통 테스트 부팅 안정화
비즈니스 로직 / API / 예외 정책 변경 없음