### PR TITLE
test/payment-mysql-integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ dist/
 # pnpm-lock.yaml
 # yarn.lock.env
 server/src/test/resources/application-test.yml
+server/src/test/resources/application-test-db.yml

--- a/server/src/test/java/com/settleops/domain/payment/application/ConfirmServiceIdempotencyTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/application/ConfirmServiceIdempotencyTest.java
@@ -8,6 +8,7 @@ import com.settleops.domain.payment.infra.PaymentRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -16,7 +17,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest
 class ConfirmServiceIdempotencyTest {
 

--- a/server/src/test/java/com/settleops/domain/payment/application/ConfirmServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/application/ConfirmServiceTest.java
@@ -11,6 +11,7 @@ import com.settleops.global.error.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -20,7 +21,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest
 class ConfirmServiceTest {
 

--- a/server/src/test/java/com/settleops/domain/payment/application/PayServiceIdempotencyTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/application/PayServiceIdempotencyTest.java
@@ -14,6 +14,7 @@ import com.settleops.global.error.ConflictException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -24,7 +25,8 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest
 class PayServiceIdempotencyTest {
 

--- a/server/src/test/java/com/settleops/domain/payment/infra/PaymentQueryRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/infra/PaymentQueryRepositoryTest.java
@@ -43,8 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @DataJpaTest
 @Import({PaymentQueryRepository.class, QuerydslTestConfig.class})
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
-@ActiveProfiles("test")
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class PaymentQueryRepositoryTest {
 
     private static final String ORDER_ID_1 = "11111111-1111-1111-1111-111111111111";

--- a/server/src/test/resources/application-test-db.example.yml
+++ b/server/src/test/resources/application-test-db.example.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    # Docker Compose MySQL 호스트 포트에 맞게 수정
+    url: jdbc:mysql://localhost:4406/settleops_test?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: your_username
+    password: your_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  sql:
+    init:
+      mode: never
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    clean-disabled: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace

--- a/server/src/test/resources/application-test.example.yml
+++ b/server/src/test/resources/application-test.example.yml
@@ -1,30 +1,23 @@
 spring:
-  datasource:
-    # Docker Compose MySQL 호스트 포트에 맞게 수정
-    url: jdbc:mysql://localhost:4406/settleops_test?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
-    username: your_username
-    password: your_password
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
   sql:
     init:
-      mode: never
+      mode: never   # ✅ schema-test.sql 실행 완전 중단
 
   jpa:
     hibernate:
       ddl-auto: validate
-    open-in-view: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    open-in-view: false
 
   flyway:
     enabled: true
-    locations: classpath:db/migration
+    locations: classpath:db/test-migration
+    # clean 금지 권장(실수 방지)
     clean-disabled: true
 
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.orm.jdbc.bind: trace
+    org.hibernate.type.descriptor.sql.BasicBinder: trace


### PR DESCRIPTION
## what

### payment confirm 테스트 프로필 분리
- `PayServiceIdempotencyTest`를 `test-db` 프로필 대상으로 유지/적용
- `ConfirmServiceTest`를 `test-db` 프로필 대상으로 변경
- `ConfirmServiceIdempotencyTest`를 `test-db` 프로필 대상으로 변경
- `PaymentQueryRepositoryTest`를 `test-db` 프로필 대상으로 변경
- 실제 MySQL 테스트 DB(`settleops_test`) 기준으로 confirm 관련 통합 테스트가 수행되도록 설정

### 실제 MySQL 테스트 DB 기반 검증 정렬
- 실제 MySQL 테스트 DB(`settleops_test`) 기준으로 payment 통합 테스트가 수행되도록 설정
- H2 기반 테스트 환경과 분리하여 DB 제약, 상태 전이, 이벤트 적재, QueryDSL 조회 결과를 실제 DB 기준으로 검증하도록 조정
- `@ActiveProfiles("test-db")` 적용
- `@AutoConfigureTestDatabase(replace = NONE)` 적용을 통한 임베디드 DB 대체 방지

## why

- payment 영역 일부 테스트는 단순 단위 테스트가 아니라 실제 DB 저장 결과와 제약조건을 함께 검증하는 통합 테스트 성격
- H2 기반 테스트만으로는 MySQL 실제 동작과의 차이 검증에 한계 존재
- 특히 멱등 처리, unique 제약, 상태 전이, 이벤트 기반 파생값 조회, QueryDSL projection 정합은 실제 DB 기준 검증 필요
- mock 기반 단위 테스트와 실제 DB 검증 테스트를 분리하여 테스트 목적과 실행 프로필을 명확히 하기 위함

## note

- 현재 `test-db`는 payment 영역 중 실제 DB 제약과 저장 결과 검증이 필요한 통합 테스트를 기존 테스트와 분리하기 위한 임시/명시적 프로필입니다.
- 적용 기준은 멱등 처리, unique 제약, 이벤트 적재, QueryDSL projection 및 파생값 등 실제 MySQL 정합에 직접 의존하는 테스트입니다.
- mock 기반 단위 테스트와 컨트롤러 응답 검증 테스트는 기존 `test` 프로필을 유지합니다.
- 다만 최근 baseline이 `application-test.yml (MySQL settleops_test + db/migration)`로 정리된 만큼, 후속 작업에서는 `test-db` 유지 여부를 재검토하고 `test` 기준선으로 수렴할 수 있도록 정리 예정입니다.