### PR TITLE
feat: align test baseline to mysql settleops_test

### DIFF
--- a/server/src/test/resources/application-test.example.yml
+++ b/server/src/test/resources/application-test.example.yml
@@ -1,29 +1,30 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:settleops_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    # Docker Compose MySQL 호스트 포트에 맞게 수정
+    url: jdbc:mysql://localhost:4406/settleops_test?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: your_username
+    password: your_password
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   sql:
     init:
-      mode: always
-      schema-locations: classpath:schema-test.sql
+      mode: never
 
   jpa:
-    defer-datasource-initialization: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: validate
+    open-in-view: false
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
-    open-in-view: false
 
   flyway:
-    enabled: false
+    enabled: true
+    locations: classpath:db/migration
+    clean-disabled: true
 
 logging:
   level:
     org.hibernate.SQL: debug
-    org.hibernate.type.descriptor.sql.BasicBinder: trace
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
## What
- `application-test.example.yml`을 H2/test-migration 기준에서 Docker Compose MySQL `settleops_test` + `classpath:db/migration` 기준 예시로 정리
- 테스트 DB 기준선을 기획서/팀 합의 기준과 맞춤

## Why
- 기존 테스트 기준 예시가 H2 + `db/test-migration` 방향이라 기획서 LOCKED Local Infra(MySQL + Compose)와 테스트 정합선이 달랐음
- 일부 테스트가 H2 문법 오류와 MySQL 접속 설정이 섞여 실행되며 팀원별 재현 결과가 달라질 수 있었음
- DB 정합성이 중요한 Repository/Integration 테스트는 공통 MySQL test DB 기준으로 맞추는 것이 더 적절함

## Scope
- 테스트 설정 예시 파일만 변경
  - `src/test/resources/application-test.example.yml`
- 실제 `application-test.yml` 반영은 각자 로컬 환경 기준으로 적용
- 개별 실패 테스트 수정은 포함하지 않음
- 테스트 클래스 내부 datasource 하드코딩 제거, 도메인별 실패 수정은 각 오너 후속 PR에서 진행

## Notes
- 이번 PR은 **test baseline 방향 정리**가 목적이며, 전체 테스트를 모두 green으로 만드는 PR은 아님
- 이후 각 오너가 공통 baseline 위에서 실패 테스트를 수정해야 함