### PR TITLE
Feat/refund c test fix

### DIFF
--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
@@ -7,6 +7,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
 class AdminRefundControllerNoOpIT {

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
@@ -3,6 +3,7 @@ package com.settleops.domain.refund.api;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -18,7 +19,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@ActiveProfiles("test")
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest
 @AutoConfigureMockMvc
 class AdminRefundControllerNoOpIT {

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundEventRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundEventRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.UUID;
@@ -19,16 +20,9 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
+@ActiveProfiles("test-db")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(RefundEventRepositoryTest.QuerydslTestConfig.class)
-@TestPropertySource(properties = {
-        "spring.datasource.url=jdbc:mysql://127.0.0.1:3307/settleops?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul",
-        "spring.datasource.username=root",
-        "spring.datasource.password=1234",
-        "spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver",
-        "spring.flyway.enabled=false",
-        "spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect"
-})
 class RefundEventRepositoryTest {
 
     //“refund_event는 insert-only 이벤트로, request_id와 occurredAt이 항상 채워져 저장된다”

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
@@ -17,9 +17,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
-@DataJpaTest
+@ActiveProfiles("test-db")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
 @Import({com.settleops.global.config.QuerydslConfig.class, RefundReadRepositoryIT.TestConfig.class})
 @Rollback(true) // 테스트 끝나면 true로 수정
 class RefundReadRepositoryIT {

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryIT.java
@@ -10,12 +10,14 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({com.settleops.global.config.QuerydslConfig.class, RefundReadRepositoryIT.TestConfig.class})

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
@@ -17,9 +17,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@ActiveProfiles("test")
-class RefundSettlementReadRepositoryTest {
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)class RefundSettlementReadRepositoryTest {
 
     @jakarta.annotation.Resource
     private EntityManager em;

--- a/server/src/test/java/com/settleops/server/ServerApplicationTests.java
+++ b/server/src/test/java/com/settleops/server/ServerApplicationTests.java
@@ -2,7 +2,9 @@ package com.settleops.server;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ServerApplicationTests {
 


### PR DESCRIPTION
## What
테스트 클래스에서 test profile 및 datasource 설정을 test-db 기준으로 통일
@TestPropertySource로 지정된 MySQL URL/계정 하드코딩 제거
@ActiveProfiles("test") → test-db로 변경
AutoConfigureTestDatabase.Replace.NONE 유지

## Why
테스트에서 개별 datasource override 사용 시 Compose MySQL / 공통 profile과 충돌 발생
127.0.0.1:3307 고정 설정으로 CommunicationsException 재현됨
RnR 기준상 테스트도 단일 DB / 공통 profile 사용이 원칙
테스트 환경을 test-db profile 기준으로 통일하여 실행 환경 일관성 확보

## Scope
Refund 도메인 테스트 코드 범위
AdminRefundControllerNoOpIT
RefundEventRepositoryTest
RefundReadRepositoryIT
RefundSettlementReadRepositoryTest

기능 로직 변경 없음
예외 정책 / API 스펙 변경 없음
테스트 설정 정리만 포함