### PR TITLE
test: strengthen refund adjustment integration proof and A4 detail tests

### DIFF
--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImplTest.java
@@ -36,7 +36,7 @@ public class SettlementDetailQueryServiceImplTest {
     @Test
     @DisplayName("관리자 정산 상세 조회 시 존재하지 않는 settlementId면 404를 반환한다")
     void getAdminSettlementDetail_notFound_then404() {
-        assertThatThrownBy(() -> settlementDetailQueryService.getAdminSettlementDetail("not-exists-id"))
+        assertThatThrownBy(() -> settlementDetailQueryService.getAdminSettlementDetail(UUID.randomUUID().toString()))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("settlement not found");
     }
@@ -46,6 +46,8 @@ public class SettlementDetailQueryServiceImplTest {
     void getAdminSettlementDetail_success() {
         // given
         String settlementId = UUID.randomUUID().toString();
+        String paymentId1 = UUID.randomUUID().toString();
+        String paymentId2 = UUID.randomUUID().toString();
 
         Settlement settlement = Settlement.createReady(
                 settlementId,
@@ -62,21 +64,22 @@ public class SettlementDetailQueryServiceImplTest {
 
         SettlementLine line1 = SettlementLine.of(
                 settlementId,
-                "payment-1",
+                paymentId1,
                 SettlementLineType.PAYMENT,
                 7000L
         );
         SettlementLine line2 = SettlementLine.of(
                 settlementId,
-                "payment-2",
+                paymentId2,
                 SettlementLineType.PAYMENT,
                 3000L
         );
         settlementLineRepository.saveAll(List.of(line1, line2));
 
-        //when
+        // when
         AdminSettlementDetailResponse response =
                 settlementDetailQueryService.getAdminSettlementDetail(settlementId);
+
         // then
         assertThat(response).isNotNull();
         assertThat(response.settlementId()).isEqualTo(settlementId);
@@ -91,7 +94,7 @@ public class SettlementDetailQueryServiceImplTest {
         assertThat(response.lines()).hasSize(2);
         assertThat(response.lines())
                 .extracting(line -> line.paymentId())
-                .containsExactly("payment-1", "payment-2");
+                .containsExactly(paymentId1, paymentId2);
 
         assertThat(response.lines())
                 .extracting(line -> line.type())

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
@@ -185,19 +185,46 @@ class SettlementRefundAdjustmentGoIT {
                 new UsernamePasswordAuthenticationToken("adminA", "N/A")
         );
 
-        SettlementPayActionResponse payRequestResponse =
+        SettlementPayActionResponse newSettlementPayRequestResponse =
                 settlementAdminCommandService.requestPaid(
                         newSettlementId,
-                        "after next batch",
-                        "req-go-request-paid-001"
+                        "after next batch on newly created settlement",
+                        "req-go-request-paid-new-001"
                 );
 
-        assertThat(payRequestResponse.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);
+        assertThat(newSettlementPayRequestResponse.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);
 
         em.clear();
-        Settlement saved = settlementRepository.findById(newSettlementId).orElseThrow();
-        assertThat(saved.getStatus()).isEqualTo(SettlementStatus.PAY_REQUESTED);
-        assertThat(saved.getPaidRequestedAt()).isNotNull();
+        Settlement newSettlementSaved = settlementRepository.findById(newSettlementId).orElseThrow();
+        assertThat(newSettlementSaved.getStatus()).isEqualTo(SettlementStatus.PAY_REQUESTED);
+        assertThat(newSettlementSaved.getPaidRequestedAt()).isNotNull();
+
+        boolean pendingForBlockedSettlementAfterBatch =
+                refundAdjustmentPolicy.isRefundAdjustmentPending(blockedSettlementId);
+
+        boolean hasLinkForBlockedSettlementAfterBatch =
+                refundSettlementLinkRepository.existsBySettlementId(blockedSettlementId);
+
+        assertThat(pendingForBlockedSettlementAfterBatch).isFalse();
+        assertThat(hasLinkForBlockedSettlementAfterBatch).isFalse();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("adminA", "N/A")
+        );
+
+        SettlementPayActionResponse blockedSettlementPayRequestResponse =
+                settlementAdminCommandService.requestPaid(
+                        blockedSettlementId,
+                        "after next batch on originally blocked settlement",
+                        "req-go-request-paid-old-001"
+                );
+
+        assertThat(blockedSettlementPayRequestResponse.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);
+
+        em.clear();
+        Settlement blockedSettlementSaved = settlementRepository.findById(blockedSettlementId).orElseThrow();
+        assertThat(blockedSettlementSaved.getStatus()).isEqualTo(SettlementStatus.PAY_REQUESTED);
+        assertThat(blockedSettlementSaved.getPaidRequestedAt()).isNotNull();
     }
 
     private String seedReadySettlementWithPaymentLine(

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
@@ -55,8 +55,8 @@ class SettlementRefundAdjustmentGoIT {
     }
 
     @Test
-    @DisplayName("GO: APPROVED refund -> next batch REFUND line/link 생성 -> request-paid 차단 해제")
-    void approved_refund_next_batch_refund_line_and_link_then_request_paid_unblocked() {
+    @DisplayName("GO: APPROVED refund 존재 시 request-paid 차단되고, 다음 batch에서 REFUND line/link 반영 후 차단이 해제된다")
+    void approved_refund_blocks_request_paid_then_next_batch_applies_refund_line_and_link_and_unblocks() {
         String merchantId = "M-GO-" + UUID.randomUUID().toString().substring(0, 8);
         String buyerId = "B-GO-1";
 
@@ -83,14 +83,14 @@ class SettlementRefundAdjustmentGoIT {
                 LocalDateTime.of(2026, 3, 11, 10, 0)
         );
 
-        boolean pendingBeforeNextBatch =
+        boolean pendingForBlockedSettlementBeforeBatch =
                 refundAdjustmentPolicy.isRefundAdjustmentPending(blockedSettlementId);
 
-        boolean hasLinkBeforeNextBatch =
+        boolean hasLinkForBlockedSettlementBeforeBatch =
                 refundSettlementLinkRepository.existsBySettlementId(blockedSettlementId);
 
-        assertThat(pendingBeforeNextBatch).isTrue();
-        assertThat(hasLinkBeforeNextBatch).isFalse();
+        assertThat(pendingForBlockedSettlementBeforeBatch).isTrue();
+        assertThat(hasLinkForBlockedSettlementBeforeBatch).isFalse();
 
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("adminA", "N/A")
@@ -141,7 +141,7 @@ class SettlementRefundAdjustmentGoIT {
 
         assertThat(newSettlementId).isNotBlank();
 
-        Long refundLineCount = jdbcTemplate.queryForObject(
+        Long refundLineCountForApprovedOldPayment = jdbcTemplate.queryForObject(
                 """
                 select count(*)
                 from settlement_line
@@ -156,9 +156,9 @@ class SettlementRefundAdjustmentGoIT {
                 3000L
         );
 
-        assertThat(refundLineCount).isEqualTo(1L);
+        assertThat(refundLineCountForApprovedOldPayment).isEqualTo(1L);
 
-        Long refundLinkCount = jdbcTemplate.queryForObject(
+        Long refundLinkCountForApprovedRefund = jdbcTemplate.queryForObject(
                 """
                 select count(*)
                 from refund_settlement_link
@@ -170,16 +170,16 @@ class SettlementRefundAdjustmentGoIT {
                 newSettlementId
         );
 
-        assertThat(refundLinkCount).isEqualTo(1L);
+        assertThat(refundLinkCountForApprovedRefund).isEqualTo(1L);
 
-        boolean pendingAfterNextBatch =
+        boolean pendingForNewSettlementAfterBatch =
                 refundAdjustmentPolicy.isRefundAdjustmentPending(newSettlementId);
 
-        boolean hasLinkAfterNextBatch =
+        boolean hasLinkForNewSettlementAfterBatch =
                 refundSettlementLinkRepository.existsBySettlementId(newSettlementId);
 
-        assertThat(pendingAfterNextBatch).isFalse();
-        assertThat(hasLinkAfterNextBatch).isTrue();
+        assertThat(pendingForNewSettlementAfterBatch).isFalse();
+        assertThat(hasLinkForNewSettlementAfterBatch).isTrue();
 
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken("adminA", "N/A")

--- a/server/src/test/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImplTest.java
@@ -60,6 +60,8 @@ public class SettlementDetailQueryRepositoryImplTest {
     void findSettlementLines_ordersByCreatedAtAsc() {
         // given
         String settlementId = UUID.randomUUID().toString();
+        String paymentId1 = UUID.randomUUID().toString();
+        String paymentId2 = UUID.randomUUID().toString();
 
         Settlement settlement = createSettlement(
                 settlementId,
@@ -71,13 +73,13 @@ public class SettlementDetailQueryRepositoryImplTest {
 
         SettlementLine laterLine = SettlementLine.of(
                 settlementId,
-                "payment-2",
+                paymentId2,
                 SettlementLineType.PAYMENT,
                 3000L
         );
         SettlementLine earlierLine = SettlementLine.of(
                 settlementId,
-                "payment-1",
+                paymentId1,
                 SettlementLineType.PAYMENT,
                 7000L
         );
@@ -95,8 +97,8 @@ public class SettlementDetailQueryRepositoryImplTest {
 
         // then
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).paymentId()).isEqualTo("payment-1");
-        assertThat(result.get(1).paymentId()).isEqualTo("payment-2");
+        assertThat(result.get(0).paymentId()).isEqualTo(paymentId1);
+        assertThat(result.get(1).paymentId()).isEqualTo(paymentId2);
     }
 
     @Test
@@ -144,6 +146,8 @@ public class SettlementDetailQueryRepositoryImplTest {
     void hasApprovedRefund_returnsTrueWhenApprovedRefundExists() {
         // given
         String settlementId = UUID.randomUUID().toString();
+        String paymentId = UUID.randomUUID().toString();
+        String refundId = UUID.randomUUID().toString();
 
         Settlement settlement = createSettlement(
                 settlementId,
@@ -155,15 +159,15 @@ public class SettlementDetailQueryRepositoryImplTest {
 
         SettlementLine line = SettlementLine.of(
                 settlementId,
-                "payment-1",
+                paymentId,
                 SettlementLineType.PAYMENT,
                 10000L
         );
         settlementLineRepository.save(line);
 
         Refund refund = createRefund(
-                "refund-1",
-                "payment-1",
+                refundId,
+                paymentId,
                 RefundStatus.APPROVED
         );
         refundRepository.save(refund);
@@ -183,6 +187,7 @@ public class SettlementDetailQueryRepositoryImplTest {
     void hasApprovedRefund_returnsFalseWhenApprovedRefundDoesNotExist() {
         // given
         String settlementId = UUID.randomUUID().toString();
+        String paymentId = UUID.randomUUID().toString();
 
         Settlement settlement = createSettlement(
                 settlementId,
@@ -194,7 +199,7 @@ public class SettlementDetailQueryRepositoryImplTest {
 
         SettlementLine line = SettlementLine.of(
                 settlementId,
-                "payment-1",
+                paymentId,
                 SettlementLineType.PAYMENT,
                 10000L
         );


### PR DESCRIPTION
What
- SettlementRefundAdjustmentGoIT 전 구간 검증을 보강했습니다.
- APPROVED refund 존재 시 request-paid 차단을 검증합니다.
- 다음 batch 실행 후 REFUND line 생성과 refund_settlement_link insert를 검증합니다.
- 반영 이후 새 settlement에서 request-paid 차단이 해제되는 흐름까지 검증합니다.

- SettlementDetailQueryRepositoryImplTest를 보강했습니다.
- A4 상세 조회용 line 목록의 createdAt asc 정렬을 검증합니다.
- hold summary가 실제 hold 데이터를 반환하는지 검증합니다.
- approved refund 존재/부재에 따른 조회 결과를 검증합니다.

- SettlementDetailQueryServiceImplTest를 보강했습니다.
- 존재하지 않는 settlementId에 대한 404를 검증합니다.
- 관리자 정산 상세 조회 시 settlement 요약, line 목록, hold/refund 기본 응답을 검증합니다.

Why
- Freeze 기준 증빙을 강화하기 위함입니다.
- REFUND_ADJUSTMENT_PENDING 정책이 read 경로 수준이 아니라
  request-paid 차단 → batch 반영 → 차단 해제까지 end-to-end로 일치함을 증명하기 위함입니다.
- A4 상세 조회가 line 정렬, hold/refund 요약까지 포함해 안정적으로 동작하는지 테스트로 고정하기 위함입니다.

Scope
- SettlementRefundAdjustmentGoIT 보강
- SettlementDetailQueryRepositoryImplTest 보강
- SettlementDetailQueryServiceImplTest 보강
- 운영 정책/도메인 로직 변경 없음
- 테스트 증빙 강화 및 조회 테스트 안정화 목적의 후속 PR

Validation
- ./gradlew test --tests "*SettlementRefundAdjustmentGoIT" --rerun-tasks
- ./gradlew test --tests "*SettlementDetailQueryRepositoryImplTest" --rerun-tasks
- ./gradlew test --tests "*SettlementDetailQueryServiceImplTest" --rerun-tasks
- ./gradlew clean test

이번 PR은 정책 변경이 아니라 Freeze 기준 증빙 강화와 A4 상세 조회 테스트 안정화에 초점을 둡니다.