### PR TITLE
feat: C2 주문 상세 조회 API 추가 및 consumer order detail 테스트 보강

### DIFF
--- a/server/src/main/java/com/settleops/domain/order/api/ConsumerOrderQueryController.java
+++ b/server/src/main/java/com/settleops/domain/order/api/ConsumerOrderQueryController.java
@@ -1,0 +1,26 @@
+package com.settleops.domain.order.api;
+
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.order.application.ConsumerOrderQueryService;
+import com.settleops.global.auth.annotation.LoginConsumer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/consumer/orders")
+public class ConsumerOrderQueryController {
+
+    private final ConsumerOrderQueryService consumerOrderQueryService;
+
+    /**
+     * Consumer 주문 상세 조회
+     */
+    @GetMapping("/{orderId}")
+    public ConsumerOrderDetailResponse getOrderDetail(
+            @PathVariable String orderId,
+            @LoginConsumer String loginConsumerId
+    ) {
+        return consumerOrderQueryService.getOrderDetail(orderId, loginConsumerId);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/api/dto/ConsumerOrderDetailResponse.java
+++ b/server/src/main/java/com/settleops/domain/order/api/dto/ConsumerOrderDetailResponse.java
@@ -1,0 +1,26 @@
+package com.settleops.domain.order.api.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ConsumerOrderDetailResponse(
+        String orderId,
+        String merchantId,
+        String buyerId,
+        String itemName,
+        long amount,
+        String orderStatus,
+        String paymentId,
+        String paymentStatus,
+        LocalDateTime capturedAt,
+        LocalDateTime confirmedAt,
+        List<PaymentEventItem> events
+) {
+    public record PaymentEventItem(
+            String eventType,
+            String statusBefore,
+            String statusAfter,
+            LocalDateTime occurredAt
+    ) {
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/application/ConsumerOrderQueryService.java
+++ b/server/src/main/java/com/settleops/domain/order/application/ConsumerOrderQueryService.java
@@ -1,0 +1,43 @@
+package com.settleops.domain.order.application;
+
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.order.infra.ConsumerOrderQueryRepository;
+import com.settleops.global.error.ForbiddenException;
+import com.settleops.global.error.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ConsumerOrderQueryService {
+
+    private final ConsumerOrderQueryRepository consumerOrderQueryRepository;
+
+    /**
+     * Consumer 주문 상세 조회
+     *
+     * <p>IDOR 방지 정책:
+     * <br>- 존재하지 않는 orderId는 먼저 404로 수렴한다.
+     * <br>- 존재가 확인된 이후 owner(buyerId) 일치 여부를 검증한다.
+     * <br>- 이를 통해 미존재 자원과 권한 불일치 자원의 응답 기준을 분리한다.
+     * </p>
+     */
+    public ConsumerOrderDetailResponse getOrderDetail(String orderId, String loginConsumer) {
+        ConsumerOrderDetailResponse detail = consumerOrderQueryRepository.findConsumerOrderDetail(orderId);
+
+        if (detail == null) {
+            throw new NotFoundException("order not found");
+        }
+
+        validateConsumerAccess(detail.buyerId(), loginConsumer);
+        return detail;
+    }
+
+    private void validateConsumerAccess(String buyerId, String loginConsumer) {
+        if (!buyerId.equals(loginConsumer)) {
+            throw new ForbiddenException("다른 구매자의 주문은 조회할 수 없습니다.");
+        }
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderFlatRow.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderFlatRow.java
@@ -1,0 +1,17 @@
+package com.settleops.domain.order.infra;
+
+import java.time.LocalDateTime;
+
+public record ConsumerOrderFlatRow(
+        String orderId,
+        String merchantId,
+        String buyerId,
+        String itemName,
+        Long amount,
+        String orderStatus,
+        String paymentId,
+        String paymentStatus,
+        LocalDateTime capturedAt,
+        LocalDateTime confirmedAt
+) {
+}

--- a/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
@@ -1,0 +1,105 @@
+package com.settleops.domain.order.infra;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.payment.domain.QPaymentEvent;
+import com.settleops.domain.payment.domain.PaymentEventType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.settleops.domain.order.domain.QOrders.orders;
+import static com.settleops.domain.payment.domain.QPayment.payment;
+import static com.settleops.domain.payment.domain.QPaymentEvent.paymentEvent;
+
+@Repository
+@RequiredArgsConstructor
+public class ConsumerOrderQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ConsumerOrderDetailResponse findConsumerOrderDetail(String orderId) {
+        QPaymentEvent capturedEvent = new QPaymentEvent("capturedEvent");
+        QPaymentEvent confirmedEvent = new QPaymentEvent("confirmedEvent");
+
+        ConsumerOrderFlatRow row = queryFactory
+                .select(Projections.constructor(
+                        ConsumerOrderFlatRow.class,
+                        orders.orderId,
+                        orders.merchantId,
+                        orders.buyerId,
+                        orders.itemName,
+                        orders.amount,
+                        orders.status.stringValue(),
+                        payment.paymentId,
+                        payment.status.stringValue(),
+                        capturedEvent.occurredAt,
+                        confirmedEvent.occurredAt
+                ))
+                .from(orders)
+                .leftJoin(payment).on(payment.orderId.eq(orders.orderId))
+                .leftJoin(capturedEvent).on(
+                        capturedEvent.paymentId.eq(payment.paymentId)
+                                .and(capturedEvent.eventType.eq(PaymentEventType.PAYMENT_CAPTURED))
+                )
+                .leftJoin(confirmedEvent).on(
+                        confirmedEvent.paymentId.eq(payment.paymentId)
+                                .and(confirmedEvent.eventType.eq(PaymentEventType.PAYMENT_CONFIRMED))
+                )
+                .where(orders.orderId.eq(orderId))
+                .fetchOne();
+
+        if (row == null) {
+            return null;
+        }
+
+        List<ConsumerOrderDetailResponse.PaymentEventItem> events =
+                row.paymentId() == null ? List.of() : findPaymentEvents(row.paymentId());
+
+        return new ConsumerOrderDetailResponse(
+                row.orderId(),
+                row.merchantId(),
+                row.buyerId(),
+                row.itemName(),
+                row.amount(),
+                row.orderStatus(),
+                row.paymentId(),
+                row.paymentStatus(),
+                row.capturedAt(),
+                row.confirmedAt(),
+                events
+        );
+    }
+
+    private List<ConsumerOrderDetailResponse.PaymentEventItem> findPaymentEvents(String paymentId) {
+        return queryFactory
+                .select(Projections.constructor(
+                        ConsumerOrderDetailResponse.PaymentEventItem.class,
+                        paymentEvent.eventType.stringValue(),
+                        paymentEvent.statusBefore.stringValue(),
+                        paymentEvent.statusAfter.stringValue(),
+                        paymentEvent.occurredAt
+                ))
+                .from(paymentEvent)
+                .where(paymentEvent.paymentId.eq(paymentId))
+                .orderBy(paymentEvent.occurredAt.asc(), paymentEvent.paymentEventId.asc())
+                .fetch();
+    }
+
+    private record ConsumerOrderFlatRow(
+            String orderId,
+            String merchantId,
+            String buyerId,
+            String itemName,
+            long amount,
+            String orderStatus,
+            String paymentId,
+            String paymentStatus,
+            LocalDateTime capturedAt,
+            LocalDateTime confirmedAt
+    ) {
+    }
+}

--- a/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
@@ -88,18 +88,4 @@ public class ConsumerOrderQueryRepository {
                 .orderBy(paymentEvent.occurredAt.asc(), paymentEvent.paymentEventId.asc())
                 .fetch();
     }
-
-    private record ConsumerOrderFlatRow(
-            String orderId,
-            String merchantId,
-            String buyerId,
-            String itemName,
-            long amount,
-            String orderStatus,
-            String paymentId,
-            String paymentStatus,
-            LocalDateTime capturedAt,
-            LocalDateTime confirmedAt
-    ) {
-    }
 }

--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPayController.java
@@ -18,15 +18,6 @@ public class ConsumerPayController {
     private final PayService payService;
     private final RequestIdResolver requestIdResolver;
 
-    /** 주문 상세 조회 */
-    @GetMapping("/{orderId}")
-    public ResponseEntity<?> getOrderDetail( // <OrderDetailResponseDTO>
-            @PathVariable String orderId
-    ){
-        // payService.findOrderDetail();
-        return ResponseEntity.status(501).build();
-    }
-
     /**
      * 결제 실행 API
      *

--- a/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
+++ b/server/src/main/java/com/settleops/domain/payment/domain/Payment.java
@@ -1,13 +1,10 @@
 package com.settleops.domain.payment.domain;
 
-import com.settleops.domain.order.domain.OrderStatus;
 import com.settleops.global.entity.BaseEntity;
-import com.settleops.global.enums.Action;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 /*
@@ -16,7 +13,7 @@ import java.util.UUID;
     | Field            | Type        | Null | Key | Default | Extra |
     +------------------+-------------+------+-----+---------+-------+
     | payment_id       | char(36)    | NO   | PRI | NULL    |       |
-    | order_id         | varchar(64) | NO   | MUL | NULL    |       |
+    | order_id         | char(36)    | NO   | MUL | NULL    |       |
     | merchant_id      | varchar(32) | NO   | MUL | NULL    |       |
     | buyer_id         | varchar(32) | NO   | MUL | NULL    |       |
     | currency         | char(3)     | NO   |     | KRW     |       |
@@ -33,6 +30,9 @@ import java.util.UUID;
 @Entity
 @Table(
         name = "payment",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")
+        },
         indexes = {
                 @Index(name = "idx_payment_status", columnList = "status"),
                 @Index(name = "idx_payment_created_at", columnList = "created_at"),

--- a/server/src/test/java/com/settleops/domain/order/api/ConsumerOrderQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/order/api/ConsumerOrderQueryControllerTest.java
@@ -1,0 +1,142 @@
+package com.settleops.domain.order.api;
+
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.order.application.ConsumerOrderQueryService;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.auth.SessionAuthProvider;
+import com.settleops.global.auth.resolver.LoginAdminArgumentResolver;
+import com.settleops.global.auth.resolver.LoginConsumerArgumentResolver;
+import com.settleops.global.auth.resolver.LoginMerchantArgumentResolver;
+import com.settleops.global.error.ForbiddenException;
+import com.settleops.global.error.GlobalExceptionHandler;
+import com.settleops.global.error.NotFoundException;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ConsumerOrderQueryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, LoginConsumerArgumentResolver.class})
+class ConsumerOrderQueryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ConsumerOrderQueryService consumerOrderQueryService;
+
+    @MockitoBean
+    private SessionAuthProvider sessionAuthProvider;
+
+    @MockitoBean
+    private LoginAdminArgumentResolver loginAdminArgumentResolver;
+
+    @MockitoBean
+    private AuditLogger auditLogger;
+
+    @Test
+    @DisplayName("주문 상세 조회 성공 시 200을 반환한다")
+    void getOrderDetail_success() throws Exception {
+        String orderId = "11111111-1111-1111-1111-111111111111";
+        String loginConsumerId = "buyer-1";
+
+        ConsumerOrderDetailResponse response = new ConsumerOrderDetailResponse(
+                orderId,
+                "merchant-1",
+                "buyer-1",
+                "아이템",
+                1000L,
+                "CREATED",
+                "44444444-4444-4444-4444-444444444444",
+                "CAPTURED",
+                LocalDateTime.of(2026, 3, 19, 12, 0, 0),
+                LocalDateTime.of(2026, 3, 19, 12, 5, 0),
+                List.of(
+                        new ConsumerOrderDetailResponse.PaymentEventItem(
+                                "PAYMENT_CREATED",
+                                null,
+                                "CREATED",
+                                LocalDateTime.of(2026, 3, 19, 11, 59, 0)
+                        ),
+                        new ConsumerOrderDetailResponse.PaymentEventItem(
+                                "PAYMENT_CAPTURED",
+                                "CREATED",
+                                "CAPTURED",
+                                LocalDateTime.of(2026, 3, 19, 12, 0, 0)
+                        ),
+                        new ConsumerOrderDetailResponse.PaymentEventItem(
+                                "PAYMENT_CONFIRMED",
+                                null,
+                                null,
+                                LocalDateTime.of(2026, 3, 19, 12, 5, 0)
+                        )
+                )
+        );
+
+        BDDMockito.given(sessionAuthProvider.getRequiredBuyerId(ArgumentMatchers.any(HttpSession.class)))
+                .willReturn(loginConsumerId);
+
+        BDDMockito.given(consumerOrderQueryService.getOrderDetail(orderId, loginConsumerId))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/consumer/orders/{orderId}", orderId).sessionAttr("LOGIN_CONSUMER", "dummy"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.orderId").value(orderId))
+                .andExpect(jsonPath("$.merchantId").value("merchant-1"))
+                .andExpect(jsonPath("$.buyerId").value("buyer-1"))
+                .andExpect(jsonPath("$.itemName").value("아이템"))
+                .andExpect(jsonPath("$.amount").value(1000))
+                .andExpect(jsonPath("$.orderStatus").value("CREATED"))
+                .andExpect(jsonPath("$.paymentId").value("44444444-4444-4444-4444-444444444444"))
+                .andExpect(jsonPath("$.paymentStatus").value("CAPTURED"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 orderId면 404를 반환한다")
+    void getOrderDetail_notFound_then404() throws Exception {
+        String orderId = "22222222-2222-2222-2222-222222222222";
+        String loginConsumerId = "buyer-1";
+
+        BDDMockito.given(sessionAuthProvider.getRequiredBuyerId(ArgumentMatchers.any(HttpSession.class)))
+                .willReturn(loginConsumerId);
+
+        BDDMockito.given(consumerOrderQueryService.getOrderDetail(orderId, loginConsumerId))
+                .willThrow(new NotFoundException("order not found"));
+
+        mockMvc.perform(get("/api/consumer/orders/{orderId}", orderId).sessionAttr("LOGIN_CONSUMER", "dummy"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("order not found"));
+    }
+
+    @Test
+    @DisplayName("다른 구매자의 주문이면 403을 반환한다")
+    void getOrderDetail_forbidden_then403() throws Exception {
+        String orderId = "33333333-3333-3333-3333-333333333333";
+        String loginConsumerId = "buyer-2";
+
+        BDDMockito.given(sessionAuthProvider.getRequiredBuyerId(ArgumentMatchers.any(HttpSession.class)))
+                .willReturn(loginConsumerId);
+
+        BDDMockito.given(consumerOrderQueryService.getOrderDetail(orderId, loginConsumerId))
+                .willThrow(new ForbiddenException("다른 구매자의 주문은 조회할 수 없습니다."));
+
+        mockMvc.perform(get("/api/consumer/orders/{orderId}", orderId).sessionAttr("LOGIN_CONSUMER", "dummy"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("다른 구매자의 주문은 조회할 수 없습니다."));
+    }
+}

--- a/server/src/test/java/com/settleops/domain/order/application/ConsumerOrderQueryServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/order/application/ConsumerOrderQueryServiceTest.java
@@ -1,0 +1,124 @@
+package com.settleops.domain.order.application;
+
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.order.infra.ConsumerOrderQueryRepository;
+import com.settleops.global.error.ForbiddenException;
+import com.settleops.global.error.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ConsumerOrderQueryServiceTest {
+
+    @Mock
+    private ConsumerOrderQueryRepository consumerOrderQueryRepository;
+
+    @InjectMocks
+    private ConsumerOrderQueryService consumerOrderQueryService;
+
+    @Test
+    @DisplayName("본인 주문이면 상세 조회에 성공한다")
+    void getOrderDetail_success() {
+        // given
+        String orderId = "550e8400-e29b-41d4-a716-446655440010";
+        String loginConsumer = "buyer_2001";
+
+        ConsumerOrderDetailResponse detail = new ConsumerOrderDetailResponse(
+                orderId,
+                "m_1001",
+                "buyer_2001",
+                "아이폰 14 프로",
+                125000L,
+                "CREATED",
+                "550e8400-e29b-41d4-a716-446655440001",
+                "CAPTURED",
+                LocalDateTime.of(2026, 3, 18, 10, 25, 0),
+                LocalDateTime.of(2026, 3, 18, 10, 30, 0),
+                List.of(
+                        new ConsumerOrderDetailResponse.PaymentEventItem(
+                                "PAYMENT_CREATED",
+                                null,
+                                "CREATED",
+                                LocalDateTime.of(2026, 3, 18, 10, 24, 58)
+                        ),
+                        new ConsumerOrderDetailResponse.PaymentEventItem(
+                                "PAYMENT_CAPTURED",
+                                "CREATED",
+                                "CAPTURED",
+                                LocalDateTime.of(2026, 3, 18, 10, 25, 0)
+                        )
+                )
+        );
+
+        given(consumerOrderQueryRepository.findConsumerOrderDetail(orderId))
+                .willReturn(detail);
+
+        // when
+        ConsumerOrderDetailResponse result =
+                consumerOrderQueryService.getOrderDetail(orderId, loginConsumer);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(orderId);
+        assertThat(result.buyerId()).isEqualTo("buyer_2001");
+        assertThat(result.itemName()).isEqualTo("아이폰 14 프로");
+        assertThat(result.paymentId()).isEqualTo("550e8400-e29b-41d4-a716-446655440001");
+        assertThat(result.paymentStatus()).isEqualTo("CAPTURED");
+        assertThat(result.events()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 주문이면 404 예외를 던진다")
+    void getOrderDetail_notFound() {
+        // given
+        String orderId = "550e8400-e29b-41d4-a716-446655449999";
+        String loginConsumer = "buyer_2001";
+
+        given(consumerOrderQueryRepository.findConsumerOrderDetail(orderId))
+                .willReturn(null);
+
+        // when // then
+        assertThatThrownBy(() -> consumerOrderQueryService.getOrderDetail(orderId, loginConsumer))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("order not found");
+    }
+
+    @Test
+    @DisplayName("다른 구매자의 주문이면 403 예외를 던진다")
+    void getOrderDetail_forbidden() {
+        // given
+        String orderId = "550e8400-e29b-41d4-a716-446655440010";
+        String loginConsumer = "buyer_9999";
+
+        ConsumerOrderDetailResponse detail = new ConsumerOrderDetailResponse(
+                orderId,
+                "m_1001",
+                "buyer_2001",
+                "아이폰 14 프로",
+                125000L,
+                "CREATED",
+                null,
+                null,
+                null,
+                null,
+                List.of()
+        );
+
+        given(consumerOrderQueryRepository.findConsumerOrderDetail(orderId))
+                .willReturn(detail);
+
+        // when // then
+        assertThatThrownBy(() -> consumerOrderQueryService.getOrderDetail(orderId, loginConsumer))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("다른 구매자의 주문은 조회할 수 없습니다.");
+    }
+}

--- a/server/src/test/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepositoryTest.java
@@ -1,0 +1,126 @@
+package com.settleops.domain.order.infra;
+
+import com.settleops.domain.order.api.dto.ConsumerOrderDetailResponse;
+import com.settleops.domain.order.domain.Orders;
+import com.settleops.domain.payment.domain.Payment;
+import com.settleops.domain.payment.domain.PaymentEvent;
+import com.settleops.domain.payment.infra.PaymentEventRepository;
+import com.settleops.domain.payment.infra.PaymentRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import jakarta.transaction.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test-db")
+@Transactional
+class ConsumerOrderQueryRepositoryTest {
+
+    @Autowired
+    private ConsumerOrderQueryRepository consumerOrderQueryRepository;
+
+    @Autowired
+    private OrdersRepository ordersRepository;
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Autowired
+    private PaymentEventRepository paymentEventRepository;
+
+    @Test
+    @DisplayName("payment가 없는 주문도 상세 조회할 수 있다")
+    void findConsumerOrderDetail_withoutPayment() {
+        // given
+        Orders order = Orders.create(
+                "m_1001",
+                "buyer_2001",
+                "아이폰 14 프로",
+                125000L
+        );
+        ordersRepository.save(order);
+
+        // when
+        ConsumerOrderDetailResponse result =
+                consumerOrderQueryRepository.findConsumerOrderDetail(order.getOrderId());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.orderId()).isEqualTo(order.getOrderId());
+        assertThat(result.merchantId()).isEqualTo("m_1001");
+        assertThat(result.buyerId()).isEqualTo("buyer_2001");
+        assertThat(result.itemName()).isEqualTo("아이폰 14 프로");
+        assertThat(result.amount()).isEqualTo(125000L);
+        assertThat(result.orderStatus()).isEqualTo("CREATED");
+        assertThat(result.paymentId()).isNull();
+        assertThat(result.paymentStatus()).isNull();
+        assertThat(result.capturedAt()).isNull();
+        assertThat(result.confirmedAt()).isNull();
+        assertThat(result.events()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("payment와 captured/confirmed event가 있으면 상세 조회에 반영된다")
+    void findConsumerOrderDetail_withPaymentAndEvents() {
+        // given
+        Orders order = Orders.create(
+                "m_1001",
+                "buyer_2001",
+                "아이폰 14 프로",
+                125000L
+        );
+        ordersRepository.save(order);
+
+        Payment payment = Payment.create(
+                order.getOrderId(),
+                order.getMerchantId(),
+                order.getBuyerId(),
+                order.getAmount()
+        );
+        payment.capture();
+        paymentRepository.save(payment);
+
+        paymentEventRepository.save(PaymentEvent.created(payment.getPaymentId(), "11111111-1111-1111-1111-111111111111"));
+        paymentEventRepository.save(PaymentEvent.captured(payment.getPaymentId(), "11111111-1111-1111-1111-111111111111"));
+        paymentEventRepository.save(PaymentEvent.confirmed(payment.getPaymentId(), "22222222-2222-2222-2222-222222222222"));
+
+        // when
+        ConsumerOrderDetailResponse result =
+                consumerOrderQueryRepository.findConsumerOrderDetail(order.getOrderId());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.orderId()).isEqualTo(order.getOrderId());
+        assertThat(result.paymentId()).isEqualTo(payment.getPaymentId());
+        assertThat(result.paymentStatus()).isEqualTo("CAPTURED");
+        assertThat(result.capturedAt()).isNotNull();
+        assertThat(result.confirmedAt()).isNotNull();
+
+        assertThat(result.events())
+                .extracting(ConsumerOrderDetailResponse.PaymentEventItem::eventType)
+                .containsExactly("PAYMENT_CREATED", "PAYMENT_CAPTURED", "PAYMENT_CONFIRMED");
+
+        assertThat(result.events().get(0).statusBefore()).isNull();
+        assertThat(result.events().get(0).statusAfter()).isEqualTo("CREATED");
+        assertThat(result.events().get(1).statusBefore()).isEqualTo("CREATED");
+        assertThat(result.events().get(1).statusAfter()).isEqualTo("CAPTURED");
+        assertThat(result.events().get(2).statusBefore()).isEqualTo("CAPTURED");
+        assertThat(result.events().get(2).statusAfter()).isEqualTo("CAPTURED");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 orderId면 null을 반환한다")
+    void findConsumerOrderDetail_notFound() {
+        // when
+        ConsumerOrderDetailResponse result =
+                consumerOrderQueryRepository.findConsumerOrderDetail("550e8400-e29b-41d4-a716-446655449999");
+
+        // then
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## what

### C2 주문 상세 조회 API 추가
- `GET /api/consumer/orders/{orderId}` 추가
- `ConsumerOrderQueryController` 추가
- `ConsumerOrderQueryService` 추가
- `ConsumerOrderQueryRepository` 추가

### C2 상세 조회 모델 구성
- `order`를 앵커로 주문 상세 조회 구성
- `payment` left join으로 결제 전/후 상태 모두 조회 가능하도록 구성
- `payment_event` 기반으로 `capturedAt`, `confirmedAt` 조회 구성
- payment event 목록을 함께 반환하도록 `events` 필드 구성

### 권한/응답 정책 반영
- 존재하지 않는 `orderId`는 404로 수렴
- 존재 확인 후 `buyerId`와 로그인 사용자 일치 여부 검증
- 타인 주문 조회 시 403 처리
- `CONFIRMED`는 `payment.status`가 아니라 `PAYMENT_CONFIRMED` 이벤트 기준으로 표현

### 조회 projection 정리
- QueryDSL constructor projection 전용 `ConsumerOrderFlatRow` 분리
- constructor 매핑 타입 정합 보정

### 테스트 추가
- `ConsumerOrderQueryServiceTest` 추가
- `ConsumerOrderQueryRepositoryTest` 추가

## why
- C2 결제 상세 화면은 `PayResponseDTO`만으로 초기 렌더링이 불가
- 주문/결제/이벤트 정보를 한 번에 조회하는 상세 API가 필요
- pay 성공 후 동일 상세 조회 API를 재호출해 화면을 서버 SoT 기준으로 갱신하기 위함
- 상세 조회의 권한 정책(404/403)과 QueryDSL projection 정합을 테스트로 고정하기 위함

## how to test
- 존재하는 주문 `orderId` 조회 시 주문 상세가 정상 반환되는지 확인
- payment 없는 주문 조회 시 `paymentId`, `paymentStatus`, `capturedAt`, `confirmedAt` 가 null 로 반환되는지 확인
- payment 있는 주문 조회 시 `paymentId`, `paymentStatus`, `capturedAt` 가 정상 반환되는지 확인
- `PAYMENT_CONFIRMED` 이벤트 존재 시 `confirmedAt` 이 정상 반환되는지 확인
- payment event 목록이 시간순으로 정상 반환되는지 확인
- 존재하지 않는 `orderId` 조회 시 404 반환 확인
- 다른 consumer의 주문 조회 시 403 반환 확인