### PR TITLE
fix(test): settlement_batch batch_key duplicate in helper

### DIFF
--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
@@ -263,16 +263,20 @@ class SettlementAdminApprovePaidConcurrencyIT {
 
     private Long createBatchAndReturnId(LocalDate baseDate) {
         return tx.execute(status -> {
-            SettlementBatch batch = SettlementBatch.started(
-                    baseDate,
-                    UUID.randomUUID().toString(), // runId
-                    "ADMIN:test",                 // triggeredBy
-                    UUID.randomUUID().toString()  // requestId
-            );
-            SettlementBatch saved = settlementBatchRepository.save(batch);
-            em.flush();
-            em.clear();
-            return saved.getBatchId();
+            return settlementBatchRepository.findByBatchKey(baseDate)
+                    .map(SettlementBatch::getBatchId)
+                    .orElseGet(() -> {
+                        SettlementBatch batch = SettlementBatch.started(
+                                baseDate,
+                                UUID.randomUUID().toString(),
+                                "ADMIN:test",
+                                UUID.randomUUID().toString()
+                        );
+                        SettlementBatch saved = settlementBatchRepository.save(batch);
+                        em.flush();
+                        em.clear();
+                        return saved.getBatchId();
+                    });
         });
     }
 


### PR DESCRIPTION
## What
test helper에서 settlement_batch batch_key UNIQUE 충돌 발생 수정

## Why
동일 baseDate batch 재생성 시 UNIQUE 위반
문서 계약상 기존 batch 재사용이 맞음

## Scope
createBatchAndReturnId helper 수정
테스트 시드 로직만 변경