### PR TITLE
fix(test): settlement batch history 테스트 격리

### DIFF
--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
@@ -263,16 +263,20 @@ class SettlementAdminApprovePaidConcurrencyIT {
 
     private Long createBatchAndReturnId(LocalDate baseDate) {
         return tx.execute(status -> {
-            SettlementBatch batch = SettlementBatch.started(
-                    baseDate,
-                    UUID.randomUUID().toString(), // runId
-                    "ADMIN:test",                 // triggeredBy
-                    UUID.randomUUID().toString()  // requestId
-            );
-            SettlementBatch saved = settlementBatchRepository.save(batch);
-            em.flush();
-            em.clear();
-            return saved.getBatchId();
+            return settlementBatchRepository.findByBatchKey(baseDate)
+                    .map(SettlementBatch::getBatchId)
+                    .orElseGet(() -> {
+                        SettlementBatch batch = SettlementBatch.started(
+                                baseDate,
+                                UUID.randomUUID().toString(),
+                                "ADMIN:test",
+                                UUID.randomUUID().toString()
+                        );
+                        SettlementBatch saved = settlementBatchRepository.save(batch);
+                        em.flush();
+                        em.clear();
+                        return saved.getBatchId();
+                    });
         });
     }
 

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryMetaJsonToleranceIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryMetaJsonToleranceIT.java
@@ -46,7 +46,7 @@ public class SettlementBatchHistoryMetaJsonToleranceIT {
     @DisplayName("A2: SKIP audit_log meta_json이 깨져도 history 조회는 깨지지 않고(운영 안정) OK/FAIL SoT는 보장된다")
     void history_should_not_fail_when_skip_meta_json_is_invalid() {
         // given
-        LocalDate baseDate = LocalDate.now(clock).minusDays(10);
+        LocalDate baseDate = LocalDate.now(clock).minusDays(137);
         String actorId = "adminA-" + UUID.randomUUID().toString().substring(0, 8);
 
         SecurityContextHolder.getContext().setAuthentication(


### PR DESCRIPTION
## What
SettlementBatchHistoryMetaJsonToleranceIT의 테스트 시드 격리 정리

## Why
동일 batch_key 충돌로 첫 runBatch 결과가 SKIP이 되며
history tolerance 테스트가 목적과 무관하게 불안정해짐

## Scope
batch history 테스트 given 정리
도메인/서비스 로직 변경 없음