### PR TITLE
test: 세션 기반 SecurityContext 인증 정합 통합 테스트 추가

### DIFF
--- a/server/src/main/java/com/settleops/domain/payment/api/ConsumerPaymentController.java
+++ b/server/src/main/java/com/settleops/domain/payment/api/ConsumerPaymentController.java
@@ -68,12 +68,7 @@ public class ConsumerPaymentController {
             HttpServletRequest request,
             @LoginConsumer String loginConsumerId
     ) {
-        if (loginConsumerId == null||loginConsumerId.isBlank()) {
-            throw new UnauthorizedException("인증이 필요합니다.");
-        }
-
         String requestId = requestIdResolver.resolve(request);
-
         return confirmService.confirm(paymentId, loginConsumerId, requestId);
     }
 

--- a/server/src/test/java/com/settleops/global/auth/SessionSecurityContextIntegrationTest.java
+++ b/server/src/test/java/com/settleops/global/auth/SessionSecurityContextIntegrationTest.java
@@ -1,0 +1,174 @@
+package com.settleops.global.auth;
+
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.auth.controller.MeController;
+import com.settleops.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.hamcrest.Matchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.settleops.global.auth.controller.MeController.SessionKeys.ADMIN_ID;
+import static com.settleops.global.auth.controller.MeController.SessionKeys.BUYER_ID;
+import static com.settleops.global.auth.controller.MeController.SessionKeys.MERCHANT_ID;
+import static com.settleops.global.auth.controller.MeController.SessionKeys.ROLE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {
+        MeController.class,
+        SessionSecurityContextIntegrationTest.TestProtectedController.class
+})
+@AutoConfigureMockMvc(addFilters = true)
+@Import({
+        SessionAuthenticationFilter.class,
+        SessionAuthProvider.class,
+        GlobalExceptionHandler.class,
+        SessionSecurityContextIntegrationTest.TestSecurityConfig.class,
+        SessionSecurityContextIntegrationTest.TestProtectedController.class
+})
+class SessionSecurityContextIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuditLogger auditLogger;
+
+    @Test
+    @DisplayName("동일 consumer 세션이면 /api/me 와 consumer 보호 API가 동일 principal/role 기준으로 동작")
+    void consumerSession_shouldBeResolvedConsistently_acrossMeAndProtectedApi() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(ROLE, "CONSUMER");
+        session.setAttribute(BUYER_ID, "BUYER_1001");
+
+        mockMvc.perform(get("/api/me").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("CONSUMER"))
+                .andExpect(jsonPath("$.buyerId").value("BUYER_1001"))
+                .andExpect(jsonPath("$.merchantId").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.adminId").value(Matchers.nullValue()));
+
+        mockMvc.perform(get("/api/test/consumer-only").session(session))
+                .andExpect(status().isOk())
+                .andExpect(content().string("BUYER_1001"));
+
+        mockMvc.perform(get("/api/test/merchant-only").session(session))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/test/admin-only").session(session))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("동일 merchant 세션이면 /api/me 와 merchant 보호 API가 동일 principal/role 기준으로 동작")
+    void merchantSession_shouldBeResolvedConsistently_acrossMeAndProtectedApi() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(ROLE, "MERCHANT");
+        session.setAttribute(MERCHANT_ID, "MERCHANT_1001");
+
+        mockMvc.perform(get("/api/me").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("MERCHANT"))
+                .andExpect(jsonPath("$.buyerId").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.merchantId").value("MERCHANT_1001"))
+                .andExpect(jsonPath("$.adminId").value(Matchers.nullValue()));
+
+        mockMvc.perform(get("/api/test/merchant-only").session(session))
+                .andExpect(status().isOk())
+                .andExpect(content().string("MERCHANT_1001"));
+    }
+
+    @Test
+    @DisplayName("동일 admin 세션이면 /api/me 와 admin 보호 API가 동일 principal/role 기준으로 동작")
+    void adminSession_shouldBeResolvedConsistently_acrossMeAndProtectedApi() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(ROLE, "ADMIN");
+        session.setAttribute(ADMIN_ID, "ADMIN_1001");
+
+        mockMvc.perform(get("/api/me").session(session))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.role").value("ADMIN"))
+                .andExpect(jsonPath("$.buyerId").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.merchantId").value(Matchers.nullValue()))
+                .andExpect(jsonPath("$.adminId").value("ADMIN_1001"));
+
+        mockMvc.perform(get("/api/test/admin-only").session(session))
+                .andExpect(status().isOk())
+                .andExpect(content().string("ADMIN_1001"));
+    }
+
+    @Test
+    @DisplayName("세션이 없으면 /api/me 와 보호 API 모두 401로 동작")
+    void noSession_shouldReturn401_acrossMeAndProtectedApi() throws Exception {
+        mockMvc.perform(get("/api/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+
+        mockMvc.perform(get("/api/test/consumer-only"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
+
+    @RestController
+    @RequestMapping("/api/test")
+    static class TestProtectedController {
+
+        private final SessionAuthProvider sessionAuthProvider;
+
+        TestProtectedController(SessionAuthProvider sessionAuthProvider) {
+            this.sessionAuthProvider = sessionAuthProvider;
+        }
+
+        @GetMapping("/consumer-only")
+        public String consumerOnly() {
+            return sessionAuthProvider.getCurrentConsumerId();
+        }
+
+        @GetMapping("/merchant-only")
+        public String merchantOnly() {
+            return sessionAuthProvider.getCurrentMerchantId();
+        }
+
+        @GetMapping("/admin-only")
+        public String adminOnly() {
+            return sessionAuthProvider.getCurrentAdminId();
+        }
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+
+        @Autowired
+        private SessionAuthenticationFilter sessionAuthenticationFilter;
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http.csrf(csrf -> csrf.disable());
+            http.formLogin(form -> form.disable());
+            http.httpBasic(basic -> basic.disable());
+
+            http.addFilterBefore(sessionAuthenticationFilter, AnonymousAuthenticationFilter.class);
+
+            http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+            return http.build();
+        }
+    }
+}


### PR DESCRIPTION
## what

### Session 해석 일관성 검증 테스트 추가 (https://github.com/ggeuri/SettleOps/pull/66 후속 PR)
- 동일 세션 기준 `/api/me` 응답과 `SessionAuthProvider` 기반 식별자 해석 결과가 일관되게 동작하는지 검증하는 `SessionSecurityContextIntegrationTest` 추가
- consumer / merchant / admin 세션 각각에 대해 `/api/me` 응답과 테스트용 API에서의 principal / role 해석 결과 일치 검증
- 무세션 요청 시 `/api/me`와 테스트용 API가 모두 401로 수렴하는지 검증

### confirm 컨트롤러 중복 인증 체크 제거
- `ConsumerPaymentController#confirm()`의 `loginConsumerId` null / blank 직접 검증 제거
- `@LoginConsumer` resolver와 `SessionAuthProvider` 기준으로 인증 책임 일원화

## why
- 현재 테스트 구성은 `anyRequest().permitAll()` 기반이므로, security matcher 수준의 실제 보호 API 인가 검증보다 세션 기반 principal / role 해석 일관성 확인에 목적이 더 가까운 상태
- `/api/me`와 `SessionAuthProvider`가 동일 세션을 같은 사용자 정보와 역할로 해석하는지 요청 흐름 기준 증빙 필요
- 세션 → `SessionAuthenticationFilter` → `SecurityContext` 주입 이후 principal / role 해석 일관성 보강 필요
- 컨트롤러 레벨 null / blank 체크와 resolver / provider 책임 중복 제거 필요
- 인증 없음 401, 역할 불일치 403 정책 중 이번 PR이 실제로 다루는 범위를 코드와 설명 수준에서 정합되게 맞출 필요

## how to test
- `./gradlew test --tests "com.settleops.global.auth.SessionSecurityContextIntegrationTest"`
- consumer 세션에서 `/api/me`는 `role=CONSUMER`, `buyerId=BUYER_1001` 반환 검증
- 동일 consumer 세션에서 `/api/test/consumer-only`는 `BUYER_1001` 반환 검증
- 동일 consumer 세션에서 `/api/test/merchant-only`, `/api/test/admin-only` 호출 시 `SessionAuthProvider` 해석 기준 403 반환 검증
- merchant 세션에서 `/api/me`는 `role=MERCHANT`, `merchantId=MERCHANT_1001` 반환 및 `/api/test/merchant-only`는 `MERCHANT_1001` 반환 검증
- admin 세션에서 `/api/me`는 `role=ADMIN`, `adminId=ADMIN_1001` 반환 및 `/api/test/admin-only`는 `ADMIN_1001` 반환 검증
- 무세션 요청에서 `/api/me`, `/api/test/consumer-only` 모두 401 반환 검증