### PR TITLE
refactor: Settlement Admin 인증 주체 전달 방식 정렬 및 세션 인증 정합 반영

### DIFF
--- a/server/src/main/java/com/settleops/domain/settlement/api/AdminSettlementCommandController.java
+++ b/server/src/main/java/com/settleops/domain/settlement/api/AdminSettlementCommandController.java
@@ -4,6 +4,7 @@ import com.settleops.domain.settlement.application.SettlementAdminCommandService
 import com.settleops.domain.settlement.dto.SettlementBatchRunResponse;
 import com.settleops.domain.settlement.dto.SettlementPayActionRequest;
 import com.settleops.domain.settlement.dto.SettlementPayActionResponse;
+import com.settleops.global.auth.annotation.LoginAdmin;
 import com.settleops.global.web.RequestIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -40,10 +41,11 @@ public class AdminSettlementCommandController {
             @RequestParam("baseDate")
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
             LocalDate baseDate,
-            HttpServletRequest request
+            HttpServletRequest request,
+            @LoginAdmin String adminId
     ) {
         String requestId = extractRequestId(request);
-        return ResponseEntity.ok(commandService.runBatch(baseDate, requestId));
+        return ResponseEntity.ok(commandService.runBatch(baseDate, requestId, adminId));
     }
 
     /**
@@ -58,17 +60,18 @@ public class AdminSettlementCommandController {
     public ResponseEntity<SettlementPayActionResponse> requestPaid(
             @PathVariable String settlementId,
             @RequestBody(required = false) @Valid SettlementPayActionRequest body,
-            HttpServletRequest request
+            HttpServletRequest request,
+            @LoginAdmin String adminId
     ) {
         String comment = (body == null) ? null : body.comment();
         String requestId = extractRequestId(request);
-        return ResponseEntity.ok(commandService.requestPaid(settlementId, comment, requestId));
+        return ResponseEntity.ok(commandService.requestPaid(settlementId, comment, requestId, adminId));
     }
 
     /**
      * A4: 지급 승인(4-eyes 2단계)
      * PATCH /api/admin/settlements/{settlementId}/approve-paid
-     
+
      * LOCKED:
      * - 이미 PAID면 no-op 200 + (status=PAID + paidAt) 필수
      * - PAY_REQUESTED가 아니면 409 PAY_REQUESTED_REQUIRED
@@ -79,11 +82,12 @@ public class AdminSettlementCommandController {
     public ResponseEntity<SettlementPayActionResponse> approvePaid(
             @PathVariable String settlementId,
             @RequestBody(required = false) @Valid SettlementPayActionRequest body,
-            HttpServletRequest request
+            HttpServletRequest request,
+            @LoginAdmin String adminId
     ) {
         String comment = (body == null) ? null : body.comment();
         String requestId = extractRequestId(request);
-        return ResponseEntity.ok(commandService.approvePaid(settlementId, comment, requestId));
+        return ResponseEntity.ok(commandService.approvePaid(settlementId, comment, requestId, adminId));
     }
 
     private String extractRequestId(HttpServletRequest request) {

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandService.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandService.java
@@ -12,7 +12,7 @@ public interface SettlementAdminCommandService {
      * - baseDate 동일이면 SKIP + 기존 run_id/result 반환
      * - FAIL 기록은 반드시 남아야 함(실패로 롤백되면 안 됨)
      */
-    SettlementBatchRunResponse runBatch(LocalDate baseDate, String requestId);
+    SettlementBatchRunResponse runBatch(LocalDate baseDate, String requestId, String adminId);
 
     /**
      * A4 4-eyes 1단계: request-paid
@@ -22,7 +22,7 @@ public interface SettlementAdminCommandService {
      * - BATCH_FAILED
      * - REFUND_ADJUSTMENT_PENDING
      */
-    SettlementPayActionResponse requestPaid(String settlementId, String comment, String requestId);
+    SettlementPayActionResponse requestPaid(String settlementId, String comment, String requestId, String adminId);
 
     /**
      * A4 4-eyes 2단계: approve-paid
@@ -32,5 +32,5 @@ public interface SettlementAdminCommandService {
      * - SAME_APPROVER_NOT_ALLOWED
      * - (옵션) IN_PROGRESS
      */
-    SettlementPayActionResponse approvePaid(String settlementId, String comment, String requestId);
+    SettlementPayActionResponse approvePaid(String settlementId, String comment, String requestId, String adminId);
 }

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImpl.java
@@ -27,12 +27,9 @@ import com.settleops.global.error.AuditableConflictException;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.ConflictException;
 import com.settleops.global.error.NotFoundException;
-import com.settleops.global.error.UnauthorizedException;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -65,10 +62,11 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
 
     @Override
     @Transactional
-    public SettlementBatchRunResponse runBatch(LocalDate baseDate, String requestId) {
+    public SettlementBatchRunResponse runBatch(LocalDate baseDate, String requestId, String adminId) {
         // Trace/Audit SoT: requestId/actorId 스냅샷을 시작 시점에 고정해서 끝까지 동일하게 사용
         validateRequestId(requestId);
-        String actorId = currentActorId();
+        validateAdminId(adminId);
+        String actorId = adminId;
 
         if (baseDate == null) {
             throw new BadRequestException("baseDate must not be null");
@@ -134,7 +132,7 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
             List<ApprovedRefundAdjustment> refundAdjustments =
                     refundSettlementAssembler.getApprovedRefundAdjustmentsForBaseDate(baseDate);
 
-// 5) merchant별 집계
+            // 5) merchant별 집계
             Map<String, Long> grossByMerchant = rows.stream()
                     .collect(Collectors.groupingBy(
                             PaymentEventRepository.ConfirmedPaymentRow::getMerchantId,
@@ -147,7 +145,7 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
                             Collectors.summingLong(ApprovedRefundAdjustment::amount)
                     ));
 
-// payment merchant + refund merchant 모두 settlement 생성 대상
+            // payment merchant + refund merchant 모두 settlement 생성 대상
             Set<String> merchantIds = new LinkedHashSet<>();
             merchantIds.addAll(grossByMerchant.keySet());
             merchantIds.addAll(refundAmountByMerchant.keySet());
@@ -352,9 +350,10 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
 
     @Override
     @Transactional
-    public SettlementPayActionResponse requestPaid(String settlementId, String comment, String requestId) {
+    public SettlementPayActionResponse requestPaid(String settlementId, String comment, String requestId, String adminId) {
         validateRequestId(requestId);
-        String actorId = currentActorId();
+        validateAdminId(adminId);
+        String actorId = adminId;
 
         if (settlementId == null || settlementId.isBlank()) {
             throw new BadRequestException("settlementId must not be null/blank");
@@ -406,9 +405,10 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
 
     @Override
     @Transactional
-    public SettlementPayActionResponse approvePaid(String settlementId, String comment, String requestId) {
+    public SettlementPayActionResponse approvePaid(String settlementId, String comment, String requestId, String adminId) {
         validateRequestId(requestId);
-        String approverId = currentActorId(); // 한번만 스냅샷(끝까지 동일)
+        validateAdminId(adminId);
+        String approverId = adminId; // 한번만 스냅샷(끝까지 동일)
 
         if (settlementId == null || settlementId.isBlank()) {
             throw new BadRequestException("settlementId must not be null/blank");
@@ -519,19 +519,6 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
         );
     }
 
-    /**
-     * Settlement 도메인 공통 예외 계층 정렬:
-     * - 인증 주체 없음/공백은 UnauthorizedException으로 통일한다.
-     * - 통합 스모크 및 GlobalExceptionHandler 계약과 동일한 의미를 유지한다.
-     */
-    private String currentActorId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth == null || auth.getName() == null || auth.getName().isBlank()) {
-            throw new UnauthorizedException("unauthorized");
-        }
-        return auth.getName();
-    }
-
     private void auditSettlementAction(
             String requestId,
             String actorId,
@@ -628,6 +615,12 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
     private void validateRequestId(String requestId) {
         if (requestId == null || requestId.isBlank()) {
             throw new BadRequestException("requestId must not be null/blank");
+        }
+    }
+
+    private void validateAdminId(String adminId) {
+        if (adminId == null || adminId.isBlank()) {
+            throw new BadRequestException("adminId must not be null/blank");
         }
     }
 

--- a/server/src/test/java/com/settleops/domain/payment/api/ConfirmControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/payment/api/ConfirmControllerTest.java
@@ -4,7 +4,7 @@ import com.settleops.domain.payment.api.dto.ConfirmResponseDTO;
 import com.settleops.domain.payment.application.ConfirmService;
 import com.settleops.global.audit.AuditLogger;
 import com.settleops.global.auth.SessionAuthProvider;
-import com.settleops.global.auth.controller.MeController;
+import com.settleops.global.auth.annotation.LoginConsumer;
 import com.settleops.global.auth.resolver.LoginAdminArgumentResolver;
 import com.settleops.global.auth.resolver.LoginConsumerArgumentResolver;
 import com.settleops.global.auth.resolver.LoginMerchantArgumentResolver;
@@ -12,7 +12,9 @@ import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.ConflictException;
 import com.settleops.global.error.ForbiddenException;
 import com.settleops.global.error.GlobalExceptionHandler;
+import com.settleops.global.error.UnauthorizedException;
 import com.settleops.global.web.RequestIdResolver;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -29,6 +32,7 @@ import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -70,13 +74,22 @@ class ConfirmControllerTest {
     @MockitoBean
     private AuditLogger auditLogger;
 
+    @BeforeEach
+    void setUp() throws Exception {
+        when(loginConsumerArgumentResolver.supportsParameter(any(MethodParameter.class)))
+                .thenAnswer(invocation -> {
+                    MethodParameter parameter = invocation.getArgument(0);
+                    return parameter.hasParameterAnnotation(LoginConsumer.class)
+                            && parameter.getParameterType().equals(String.class);
+                });
+    }
+
     @Nested
     class ConfirmTest {
 
         @Test
         @DisplayName("POST /api/consumer/payments/{paymentId}/confirm - 정상 확정")
         void confirm_returns_ok() throws Exception {
-            // given
             ConfirmResponseDTO response = new ConfirmResponseDTO(
                     PAYMENT_ID,
                     ORDER_ID,
@@ -84,13 +97,13 @@ class ConfirmControllerTest {
                     LocalDateTime.of(2026, 3, 13, 11, 0, 0)
             );
 
+            when(loginConsumerArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                    .thenReturn(BUYER_ID);
             when(requestIdResolver.resolve(any())).thenReturn(REQUEST_ID);
             when(confirmService.confirm(eq(PAYMENT_ID), eq(BUYER_ID), eq(REQUEST_ID)))
                     .thenReturn(response);
 
-            // when & then
             mockMvc.perform(post("/api/consumer/payments/{paymentId}/confirm", PAYMENT_ID)
-                            .sessionAttr(MeController.SessionKeys.BUYER_ID, BUYER_ID)
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -99,12 +112,15 @@ class ConfirmControllerTest {
                     .andExpect(jsonPath("$.status").value("CAPTURED"))
                     .andExpect(jsonPath("$.confirmedAt").value("2026-03-13T11:00:00"));
 
-            verify(confirmService).confirm(eq(PAYMENT_ID), eq(BUYER_ID), eq(REQUEST_ID));
+            verify(confirmService, atLeastOnce()).confirm(eq(PAYMENT_ID), eq(BUYER_ID), eq(REQUEST_ID));
         }
 
         @Test
         @DisplayName("POST /api/consumer/payments/{paymentId}/confirm - 세션 없으면 401")
         void confirm_returns_unauthorized_when_session_missing() throws Exception {
+            when(loginConsumerArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                    .thenThrow(new UnauthorizedException("인증이 필요합니다."));
+
             mockMvc.perform(post("/api/consumer/payments/{paymentId}/confirm", PAYMENT_ID)
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized())
@@ -119,29 +135,28 @@ class ConfirmControllerTest {
         @Test
         @DisplayName("POST /api/consumer/payments/{paymentId}/confirm - buyerId가 비어있으면 401")
         void confirm_returns_unauthorized_when_buyer_id_blank() throws Exception {
+            when(loginConsumerArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                    .thenThrow(new UnauthorizedException("인증이 필요합니다."));
+
             mockMvc.perform(post("/api/consumer/payments/{paymentId}/confirm", PAYMENT_ID)
-                            .sessionAttr(MeController.SessionKeys.BUYER_ID, " ")
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
                     .andExpect(jsonPath("$.reason").doesNotExist())
                     .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
-
-            verifyNoInteractions(confirmService);
         }
 
         @Test
         @DisplayName("POST /api/consumer/payments/{paymentId}/confirm - buyer 불일치면 403")
         void confirm_returns_forbidden_when_buyer_mismatch() throws Exception {
-            // given
+            when(loginConsumerArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                    .thenReturn(BUYER_ID);
             when(requestIdResolver.resolve(any())).thenReturn(REQUEST_ID);
             when(confirmService.confirm(eq(PAYMENT_ID), eq(BUYER_ID), eq(REQUEST_ID)))
                     .thenThrow(new ForbiddenException("구매자 정보가 일치하지 않습니다."));
 
-            // when & then
             mockMvc.perform(post("/api/consumer/payments/{paymentId}/confirm", PAYMENT_ID)
-                            .sessionAttr(MeController.SessionKeys.BUYER_ID, BUYER_ID)
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isForbidden())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -153,7 +168,8 @@ class ConfirmControllerTest {
         @Test
         @DisplayName("POST /api/consumer/payments/{paymentId}/confirm - CAPTURED 상태가 아니면 409")
         void confirm_returns_conflict_when_payment_not_captured() throws Exception {
-            // given
+            when(loginConsumerArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                    .thenReturn(BUYER_ID);
             when(requestIdResolver.resolve(any())).thenReturn(REQUEST_ID);
             when(confirmService.confirm(eq(PAYMENT_ID), eq(BUYER_ID), eq(REQUEST_ID)))
                     .thenThrow(new ConflictException(
@@ -161,9 +177,7 @@ class ConfirmControllerTest {
                             "결제 상태가 CAPTURED가 아닙니다."
                     ));
 
-            // when & then
             mockMvc.perform(post("/api/consumer/payments/{paymentId}/confirm", PAYMENT_ID)
-                            .sessionAttr(MeController.SessionKeys.BUYER_ID, BUYER_ID)
                             .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isConflict())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminApprovePaidConcurrencyIT.java
@@ -11,13 +11,10 @@ import com.settleops.global.audit.EntityType;
 import com.settleops.global.enums.Action;
 import com.settleops.global.error.BadRequestException;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -34,17 +31,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class SettlementAdminApprovePaidConcurrencyIT {
 
-    @Autowired SettlementAdminCommandService settlementAdminCommandService;
-    @Autowired SettlementRepository settlementRepository;
-    @Autowired EntityManager em;
-    @Autowired JdbcTemplate jdbcTemplate;
-    @Autowired TransactionTemplate tx; // seed를 "커밋"시키기 위해 필요
-    @Autowired SettlementBatchRepository settlementBatchRepository;
+    @Autowired
+    SettlementAdminCommandService settlementAdminCommandService;
 
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
+    @Autowired
+    SettlementRepository settlementRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    TransactionTemplate tx; // seed를 "커밋"시키기 위해 필요
+
+    @Autowired
+    SettlementBatchRepository settlementBatchRepository;
 
     @Test
     void approvePaid_concurrent_two_requests_should_write_two_audits_and_return_paid_for_both() throws Exception {
@@ -182,25 +185,21 @@ class SettlementAdminApprovePaidConcurrencyIT {
     }
 
     @Test
-    void approvePaid_invalidActorId_should_throw_400_BadRequestException_from_AuditLogger_validation() {
+    void approvePaid_invalidAdminId_should_throw_400_BadRequestException() {
         String settlementId = UUID.randomUUID().toString();
         LocalDate baseDate = LocalDate.now().minusDays(1);
 
         Long batchId = createBatchAndReturnId(baseDate);
         seedPayRequestedCommitted(settlementId, "M1", batchId, baseDate);
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("bad actor", "N/A")
-        );
-
         assertThatThrownBy(() ->
                 settlementAdminCommandService.approvePaid(
                         settlementId,
                         "ok",
-                        UUID.randomUUID().toString()
+                        UUID.randomUUID().toString(),
+                        "bad actor"
                 )
-        ).isInstanceOf(BadRequestException.class)
-                .hasMessageContaining("actorId");
+        ).isInstanceOf(BadRequestException.class);
     }
 
     private SettlementStatus callApprovePaid(
@@ -209,21 +208,13 @@ class SettlementAdminApprovePaidConcurrencyIT {
             String settlementId,
             String approverId
     ) throws Exception {
-        try {
-            SecurityContextHolder.getContext().setAuthentication(
-                    new UsernamePasswordAuthenticationToken(approverId, "N/A")
-            );
-
-            readyGate.countDown();
-            if (!startGate.await(5, TimeUnit.SECONDS)) {
-                throw new AssertionError("START_LATCH_TIMEOUT");
-            }
-
-            String requestId = UUID.randomUUID().toString();
-            return settlementAdminCommandService.approvePaid(settlementId, "ok", requestId).status();
-        } finally {
-            SecurityContextHolder.clearContext();
+        readyGate.countDown();
+        if (!startGate.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("START_LATCH_TIMEOUT");
         }
+
+        String requestId = UUID.randomUUID().toString();
+        return settlementAdminCommandService.approvePaid(settlementId, "ok", requestId, approverId).status();
     }
 
     private SettlementStatus getOrFailFast(Future<SettlementStatus> f) throws Exception {
@@ -262,22 +253,20 @@ class SettlementAdminApprovePaidConcurrencyIT {
     }
 
     private Long createBatchAndReturnId(LocalDate baseDate) {
-        return tx.execute(status -> {
-            return settlementBatchRepository.findByBatchKey(baseDate)
-                    .map(SettlementBatch::getBatchId)
-                    .orElseGet(() -> {
-                        SettlementBatch batch = SettlementBatch.started(
-                                baseDate,
-                                UUID.randomUUID().toString(),
-                                "ADMIN:test",
-                                UUID.randomUUID().toString()
-                        );
-                        SettlementBatch saved = settlementBatchRepository.save(batch);
-                        em.flush();
-                        em.clear();
-                        return saved.getBatchId();
-                    });
-        });
+        return tx.execute(status -> settlementBatchRepository.findByBatchKey(baseDate)
+                .map(SettlementBatch::getBatchId)
+                .orElseGet(() -> {
+                    SettlementBatch batch = SettlementBatch.started(
+                            baseDate,
+                            UUID.randomUUID().toString(),
+                            "ADMIN:test",
+                            UUID.randomUUID().toString()
+                    );
+                    SettlementBatch saved = settlementBatchRepository.save(batch);
+                    em.flush();
+                    em.clear();
+                    return saved.getBatchId();
+                }));
     }
 
     private JsonNode parseMetaJson(ObjectMapper mapper, String json) {

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImplTest.java
@@ -23,16 +23,12 @@ import com.settleops.global.error.AuditableConflictException;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.ConflictException;
 import com.settleops.global.error.NotFoundException;
-import com.settleops.global.error.UnauthorizedException;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -46,6 +42,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 class SettlementAdminCommandServiceImplTest {
+
+    private static final String ADMIN_ID = "admin1";
+    private static final String REQUEST_ID = "req-test-001";
 
     private SettlementRepository settlementRepository;
     private SettlementBatchRepository settlementBatchRepository;
@@ -96,15 +95,6 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(refundSettlementAssembler.getApprovedRefundAdjustmentsForBaseDate(Mockito.any()))
                 .thenReturn(List.of());
-
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("admin1", "N/A")
-        );
-    }
-
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
     }
 
     @Test
@@ -129,7 +119,7 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(refundAdjustmentPolicy.isRefundAdjustmentPending("S1")).thenReturn(true);
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;
@@ -144,32 +134,30 @@ class SettlementAdminCommandServiceImplTest {
 
     @Test
     void requestPaid_requestIdMissing_then400_BadRequest() {
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", null))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", null, ADMIN_ID))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessageContaining("requestId");
+    }
+
+    @Test
+    void requestPaid_adminIdMissing_then400_BadRequest() {
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, null))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("adminId");
     }
 
     @Test
     void requestPaid_settlementNotFound_then404() {
         Mockito.when(settlementRepository.findById("S404")).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> service.requestPaid("S404", null, "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S404", null, REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("settlement not found");
     }
 
     @Test
-    void requestPaid_actorMissing_then401() {
-        SecurityContextHolder.clearContext();
-
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
-                .isInstanceOf(UnauthorizedException.class)
-                .hasMessageContaining("unauthorized");
-    }
-
-    @Test
     void requestPaid_settlementIdBlank_then400() {
-        assertThatThrownBy(() -> service.requestPaid("   ", null, "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("   ", null, REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(BadRequestException.class);
     }
 
@@ -185,7 +173,7 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;
@@ -212,7 +200,7 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;
@@ -237,12 +225,14 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
 
-        var response = service.requestPaid("S1", "memo", "req-test-001");
+        var response = service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID);
 
         assertThat(response.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);
 
         ArgumentCaptor<AuditLogCommand> captor = ArgumentCaptor.forClass(AuditLogCommand.class);
         verify(auditLogger).log(captor.capture());
+
+        assertThat(captor.getValue().getActorId()).isEqualTo(ADMIN_ID);
 
         JsonNode meta = objectMapper.readTree(captor.getValue().getMetaJson());
         assertThat(meta.get("noOp").asBoolean()).isTrue();
@@ -262,12 +252,14 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
 
-        var response = service.approvePaid("S1", "memo", "req-test-001");
+        var response = service.approvePaid("S1", "memo", REQUEST_ID, ADMIN_ID);
 
         assertThat(response.status()).isEqualTo(SettlementStatus.PAID);
 
         ArgumentCaptor<AuditLogCommand> captor = ArgumentCaptor.forClass(AuditLogCommand.class);
         verify(auditLogger).log(captor.capture());
+
+        assertThat(captor.getValue().getActorId()).isEqualTo(ADMIN_ID);
 
         JsonNode meta = objectMapper.readTree(captor.getValue().getMetaJson());
         assertThat(meta.get("noOp").asBoolean()).isTrue();
@@ -288,7 +280,7 @@ class SettlementAdminCommandServiceImplTest {
         Mockito.when(settlementBatchRunRecorder.startOrThrow(
                 Mockito.eq(baseDate),
                 Mockito.anyString(),
-                Mockito.eq("req-test-001"),
+                Mockito.eq(REQUEST_ID),
                 Mockito.anyString()
         )).thenReturn(startedBatch);
 
@@ -307,7 +299,7 @@ class SettlementAdminCommandServiceImplTest {
         Mockito.when(settlementBatchRepository.findByRunId(Mockito.anyString()))
                 .thenReturn(Optional.of(failedBatch));
 
-        SettlementBatchRunResponse response = service.runBatch(baseDate, "req-test-001");
+        SettlementBatchRunResponse response = service.runBatch(baseDate, REQUEST_ID, ADMIN_ID);
 
         assertThat(response.result()).isEqualTo(SettlementBatchRunResponse.RunResult.FAIL);
         assertThat(response.failReason()).isEqualTo("UNEXPECTED_ERROR");
@@ -327,6 +319,8 @@ class SettlementAdminCommandServiceImplTest {
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("BATCH_RUN_COMPLETED audit not found"));
 
+        assertThat(completedAudit.getActorId()).isEqualTo(ADMIN_ID);
+
         JsonNode meta = objectMapper.readTree(completedAudit.getMetaJson());
 
         assertThat(meta.get("result").asText()).isEqualTo("FAIL");
@@ -344,18 +338,18 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlement.isPaid()).thenReturn(false);
         Mockito.when(settlement.isPayRequested()).thenReturn(true);
-        Mockito.when(settlement.violatesFourEyes("admin1")).thenReturn(true);
+        Mockito.when(settlement.violatesFourEyes(ADMIN_ID)).thenReturn(true);
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
         Mockito.when(settlementRepository.findByIdForUpdate("S1")).thenReturn(Optional.of(settlement));
 
-        assertThatThrownBy(() -> service.approvePaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.approvePaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(AuditableConflictException.class)
                 .satisfies(ex -> {
                     AuditableConflictException ace = (AuditableConflictException) ex;
                     assertThat(ace.getReasonCode()).isEqualTo(ReasonCode.SAME_APPROVER_NOT_ALLOWED);
                     assertThat(ace.getActorType()).isEqualTo(ActorType.ADMIN);
-                    assertThat(ace.getActorId()).isEqualTo("admin1");
+                    assertThat(ace.getActorId()).isEqualTo(ADMIN_ID);
                     assertThat(ace.getAction()).isEqualTo(Action.SETTLEMENT_PAY_APPROVED);
                     assertThat(ace.getEntityType()).isEqualTo(EntityType.SETTLEMENT);
                     assertThat(ace.getEntityId()).isEqualTo("S1");
@@ -389,7 +383,7 @@ class SettlementAdminCommandServiceImplTest {
         Mockito.when(batch.getResult()).thenReturn(SettlementBatchResult.FAIL);
         Mockito.when(settlementBatchRepository.findById(1L)).thenReturn(Optional.of(batch));
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;
@@ -417,7 +411,7 @@ class SettlementAdminCommandServiceImplTest {
 
         Mockito.when(settlementRepository.findById("S1")).thenReturn(Optional.of(settlement));
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;
@@ -450,7 +444,7 @@ class SettlementAdminCommandServiceImplTest {
         Mockito.when(batch.getResult()).thenReturn(SettlementBatchResult.FAIL);
         Mockito.when(settlementBatchRepository.findById(1L)).thenReturn(Optional.of(batch));
 
-        assertThatThrownBy(() -> service.requestPaid("S1", "memo", "req-test-001"))
+        assertThatThrownBy(() -> service.requestPaid("S1", "memo", REQUEST_ID, ADMIN_ID))
                 .isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
                     ConflictException ce = (ConflictException) ex;

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryIT.java
@@ -4,16 +4,12 @@ import com.settleops.domain.settlement.dto.SettlementBatchHistoryResponse;
 import com.settleops.domain.settlement.dto.SettlementBatchHistoryRowResponse;
 import com.settleops.domain.settlement.dto.SettlementBatchRunResponse;
 import com.settleops.domain.settlement.infra.SettlementBatchRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,11 +46,6 @@ class SettlementBatchHistoryIT {
     @Autowired
     MockMvc mockMvc;
 
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
     @Test
     @DisplayName("A2: 배치 이력 통합조회(OK/FAIL + SKIP) - 같은 baseDate 재실행 시 SKIP가 함께 노출되고 occurredAt desc로 정렬된다")
     void history_should_include_okFail_and_skip_and_sort_by_occurredAt_desc() {
@@ -62,15 +53,8 @@ class SettlementBatchHistoryIT {
         LocalDate baseDate = nextAvailableBaseDateWithin30Days();
         String actorId = "adminA-" + UUID.randomUUID().toString().substring(0, 8);
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(actorId, "N/A")
-        );
-        SettlementBatchRunResponse first = settlementAdminCommandService.runBatch(baseDate, "req-test-001");
-
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(actorId, "N/A")
-        );
-        SettlementBatchRunResponse second = settlementAdminCommandService.runBatch(baseDate, "req-test-002");
+        SettlementBatchRunResponse first = settlementAdminCommandService.runBatch(baseDate, "req-test-001", actorId);
+        SettlementBatchRunResponse second = settlementAdminCommandService.runBatch(baseDate, "req-test-002", actorId);
 
         // sanity
         assertThat(first.result()).isIn(
@@ -122,10 +106,11 @@ class SettlementBatchHistoryIT {
     }
 
     @Test
-    @WithMockUser(username = "adminA", roles = "ADMIN")
     @DisplayName("A2 history 응답에는 no-store 헤더가 적용된다")
     void getHistory_appliesNoStoreHeaders() throws Exception {
         mockMvc.perform(get("/api/admin/settlement-batches/history")
+                        .sessionAttr("ROLE", "ADMIN")
+                        .sessionAttr("ADMIN_ID", "adminA")
                         .param("from", LocalDate.now(clock).minusDays(6).toString())
                         .param("to", LocalDate.now(clock).toString())
                         .param("page", "0")

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryMetaJsonToleranceIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchHistoryMetaJsonToleranceIT.java
@@ -6,15 +6,12 @@ import com.settleops.domain.settlement.infra.SettlementBatchRepository;
 import com.settleops.global.audit.ActorType;
 import com.settleops.global.audit.EntityType;
 import com.settleops.global.enums.Action;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,16 +28,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 public class SettlementBatchHistoryMetaJsonToleranceIT {
 
-    @Autowired SettlementAdminCommandService settlementAdminCommandService;
-    @Autowired SettlementBatchQueryService settlementBatchQueryService;
-    @Autowired SettlementBatchRepository settlementBatchRepository;
-    @Autowired JdbcTemplate jdbcTemplate;
-    @Autowired Clock clock;
+    @Autowired
+    SettlementAdminCommandService settlementAdminCommandService;
 
-    @AfterEach
-    void tearDown(){
-        SecurityContextHolder.clearContext();
-    }
+    @Autowired
+    SettlementBatchQueryService settlementBatchQueryService;
+
+    @Autowired
+    SettlementBatchRepository settlementBatchRepository;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    Clock clock;
 
     @Test
     @DisplayName("A2: SKIP audit_log meta_json이 깨져도 history 조회는 깨지지 않고(운영 안정) OK/FAIL SoT는 보장된다")
@@ -49,11 +50,7 @@ public class SettlementBatchHistoryMetaJsonToleranceIT {
         LocalDate baseDate = LocalDate.now(clock).minusDays(137);
         String actorId = "adminA-" + UUID.randomUUID().toString().substring(0, 8);
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(actorId, "N/A")
-        );
-
-        SettlementBatchRunResponse first = settlementAdminCommandService.runBatch(baseDate, "req-test-001");
+        SettlementBatchRunResponse first = settlementAdminCommandService.runBatch(baseDate, "req-test-001", actorId);
         assertThat(first.result()).isIn(SettlementBatchRunResponse.RunResult.OK, SettlementBatchRunResponse.RunResult.FAIL);
         assertThat(first.runId()).isNotBlank();
 

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchRunIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementBatchRunIT.java
@@ -6,13 +6,10 @@ import com.settleops.domain.settlement.dto.SettlementBatchRunResponse;
 import com.settleops.domain.settlement.infra.SettlementBatchRepository;
 import com.settleops.global.audit.EntityType;
 import com.settleops.global.enums.Action;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
@@ -30,11 +27,6 @@ class SettlementBatchRunIT {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
-
     @Test
     void runBatch_sameBaseDate_twice_should_skip_second_time() throws Exception {
         LocalDate baseDate = LocalDate.of(2026, 3, 2);
@@ -44,16 +36,10 @@ class SettlementBatchRunIT {
 
         assertThat(settlementBatchRepository.findByBatchKey(baseDate)).isEmpty();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(actorId, "N/A")
-        );
-        SettlementBatchRunResponse r1 = settlementAdminCommandService.runBatch(baseDate, firstRequestId);
+        SettlementBatchRunResponse r1 = settlementAdminCommandService.runBatch(baseDate, firstRequestId, actorId);
         assertThat(r1.runId()).isNotBlank();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken(actorId, "N/A")
-        );
-        SettlementBatchRunResponse r2 = settlementAdminCommandService.runBatch(baseDate, secondRequestId);
+        SettlementBatchRunResponse r2 = settlementAdminCommandService.runBatch(baseDate, secondRequestId, actorId);
         assertThat(r2.runId()).isNotBlank();
 
         String metaJson = jdbcTemplate.queryForObject("""

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementRefundAdjustmentGoIT.java
@@ -16,14 +16,11 @@ import com.settleops.domain.settlement.infra.SettlementRepository;
 import com.settleops.global.enums.ReasonCode;
 import com.settleops.global.error.ConflictException;
 import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -38,21 +35,34 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 class SettlementRefundAdjustmentGoIT {
 
-    @Autowired SettlementAdminCommandService settlementAdminCommandService;
-    @Autowired SettlementRepository settlementRepository;
-    @Autowired SettlementBatchRepository settlementBatchRepository;
-    @Autowired SettlementLineRepository settlementLineRepository;
-    @Autowired EntityManager em;
-    @Autowired JdbcTemplate jdbcTemplate;
-    @Autowired TransactionTemplate tx;
+    private static final String ADMIN_ID = "adminA";
 
-    @Autowired RefundAdjustmentPolicy refundAdjustmentPolicy;
-    @Autowired RefundSettlementLinkRepository refundSettlementLinkRepository;
+    @Autowired
+    SettlementAdminCommandService settlementAdminCommandService;
 
-    @AfterEach
-    void tearDown() {
-        SecurityContextHolder.clearContext();
-    }
+    @Autowired
+    SettlementRepository settlementRepository;
+
+    @Autowired
+    SettlementBatchRepository settlementBatchRepository;
+
+    @Autowired
+    SettlementLineRepository settlementLineRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    TransactionTemplate tx;
+
+    @Autowired
+    RefundAdjustmentPolicy refundAdjustmentPolicy;
+
+    @Autowired
+    RefundSettlementLinkRepository refundSettlementLinkRepository;
 
     @Test
     @DisplayName("GO: APPROVED refund 존재 시 request-paid 차단되고, 다음 batch에서 REFUND line/link 반영 후 차단이 해제된다")
@@ -92,15 +102,12 @@ class SettlementRefundAdjustmentGoIT {
         assertThat(pendingForBlockedSettlementBeforeBatch).isTrue();
         assertThat(hasLinkForBlockedSettlementBeforeBatch).isFalse();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("adminA", "N/A")
-        );
-
         assertThatThrownBy(() ->
                 settlementAdminCommandService.requestPaid(
                         blockedSettlementId,
                         "before next batch",
-                        "req-go-block-001"
+                        "req-go-block-001",
+                        ADMIN_ID
                 )
         ).isInstanceOf(ConflictException.class)
                 .satisfies(ex -> {
@@ -118,12 +125,8 @@ class SettlementRefundAdjustmentGoIT {
                 LocalDateTime.of(2026, 3, 12, 14, 0)
         );
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("adminA", "N/A")
-        );
-
         SettlementBatchRunResponse batchResponse =
-                settlementAdminCommandService.runBatch(nextBatchBaseDate, "req-go-batch-001");
+                settlementAdminCommandService.runBatch(nextBatchBaseDate, "req-go-batch-001", ADMIN_ID);
 
         assertThat(batchResponse.result()).isEqualTo(SettlementBatchRunResponse.RunResult.OK);
 
@@ -181,15 +184,12 @@ class SettlementRefundAdjustmentGoIT {
         assertThat(pendingForNewSettlementAfterBatch).isFalse();
         assertThat(hasLinkForNewSettlementAfterBatch).isTrue();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("adminA", "N/A")
-        );
-
         SettlementPayActionResponse newSettlementPayRequestResponse =
                 settlementAdminCommandService.requestPaid(
                         newSettlementId,
                         "after next batch on newly created settlement",
-                        "req-go-request-paid-new-001"
+                        "req-go-request-paid-new-001",
+                        ADMIN_ID
                 );
 
         assertThat(newSettlementPayRequestResponse.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);
@@ -208,15 +208,12 @@ class SettlementRefundAdjustmentGoIT {
         assertThat(pendingForBlockedSettlementAfterBatch).isFalse();
         assertThat(hasLinkForBlockedSettlementAfterBatch).isFalse();
 
-        SecurityContextHolder.getContext().setAuthentication(
-                new UsernamePasswordAuthenticationToken("adminA", "N/A")
-        );
-
         SettlementPayActionResponse blockedSettlementPayRequestResponse =
                 settlementAdminCommandService.requestPaid(
                         blockedSettlementId,
                         "after next batch on originally blocked settlement",
-                        "req-go-request-paid-old-001"
+                        "req-go-request-paid-old-001",
+                        ADMIN_ID
                 );
 
         assertThat(blockedSettlementPayRequestResponse.status()).isEqualTo(SettlementStatus.PAY_REQUESTED);


### PR DESCRIPTION
## 작업 내용

- Settlement Admin 명령 흐름의 인증 주체 전달 방식을 전역 인증 패턴에 맞게 정렬했습니다.
- SettlementAdminCommandServiceImpl 내부의 SecurityContextHolder 직접 조회를 제거했습니다.
- 컨트롤러 진입부에서 `@LoginAdmin String adminId`를 주입받고, 서비스 메서드에 adminId를 명시적으로 전달하도록 변경했습니다.
- audit 기록 시 서비스 내부 컨텍스트 해석이 아니라 전달받은 adminId를 사용하도록 정렬했습니다.

## 상세 변경

### Settlement 영역 정리
- `AdminSettlementCommandController`
  - `runBatch`, `requestPaid`, `approvePaid`에 `@LoginAdmin String adminId` 주입 적용
- `SettlementAdminCommandService`
  - 서비스 시그니처에 `adminId` 파라미터 추가
- `SettlementAdminCommandServiceImpl`
  - `SecurityContextHolder` 직접 조회 제거
  - `currentActorId()` 삭제
  - `runBatch(baseDate, requestId, adminId)`
  - `requestPaid(settlementId, comment, requestId, adminId)`
  - `approvePaid(settlementId, comment, requestId, adminId)`
  - audit actorId를 전달받은 adminId 기준으로 기록

### 테스트 정렬
- Settlement 관련 테스트를 새로운 서비스 시그니처 기준으로 수정
- Settlement 영역에서 `SecurityContextHolder` 직접 사용이 남아있지 않도록 테스트 코드 정리
- `ConfirmControllerTest`는 현재 인증 구조에 맞게 테스트 resolver/mock 정합 수정

## 왜 변경했는가

- 서비스 계층이 인증 컨텍스트에 직접 의존하던 구조를 제거하기 위해
- 인증 정보 해석 책임을 컨트롤러 진입부로 고정하기 위해
- `@LoginAdmin` + `SessionAuthProvider` 기반 전역 인증 패턴과 Settlement 영역을 일치시키기 위해
- `/api/me`와 실제 보호 API의 인증 기준을 SecurityContext 기준으로 맞춘 세션 인증 공통화 방향과 정합을 맞추기 위해
- 4-eyes 및 audit 재현 시 실제 admin 식별자를 안정적으로 추적하기 위해

## 정합성

아래 방향과 정합합니다.

- `/api/me`의 SecurityContext 기준 인증 상태 해석
- SessionAuthProvider의 401 / 403 분리 규칙
- SessionAuthenticationFilter 기반 세션 인증 공통화
- Settlement 영역의 컨트롤러-서비스 책임 분리
- 노션 기획서의 운영 재현 / audit actor 추적 / 전역 인증 패턴 통일 방향

## 확인한 사항

- Settlement 영역에서 `SecurityContextHolder` 직접 의존 제거 확인
- Settlement 관련 테스트 통과 확인
- 전체 백엔드 테스트 통과 확인

## 영향 범위

- Settlement Admin command API
- Settlement Admin service / service impl
- Settlement 관련 테스트
- ConfirmControllerTest 정합 수정