### PR TITLE
feat(dev-login): 개발용 역할별 세션 로그인 페이지 및 로그아웃 UI 추가

### DIFF
--- a/admin-web/src/App.jsx
+++ b/admin-web/src/App.jsx
@@ -3,6 +3,7 @@ import AppLayout from "./layouts/AppLayout";
 import AdminRoutes from "./app/router/AdminRoutes.jsx";
 import MerchantRoutes from "./app/router/MerchantRoutes.jsx";
 import ConsumerRoutes from "./app/router/ConsumerRoutes.jsx";
+import DevLoginPage from "./pages/auth/DevLoginPage.jsx";
 import CommonUiSamplePage from "./pages/_sample/CommonUiSamplePage.jsx";
 
 export default function App() {
@@ -23,6 +24,9 @@ export default function App() {
 
         {/* 공통 UI 샘플 미리보기 */}
         <Route path="/sample/ui" element={<CommonUiSamplePage />} />
+
+        {/* 개발용 로그인 페이지 이동 */}
+        <Route path="/auth/dev-login" element={<DevLoginPage />} />
       </Route>
 
       {/* 404 */}

--- a/admin-web/src/api/devSessionApi.js
+++ b/admin-web/src/api/devSessionApi.js
@@ -1,0 +1,27 @@
+// /admin-web/src/api/devSessionApi.js
+
+import { requestJson } from "./http.js";
+
+export function loginConsumerSession(buyerId) {
+  return requestJson(`/api/dev/login-consumer?buyerId=${encodeURIComponent(buyerId)}`, {
+    method: "POST",
+  });
+}
+
+export function loginMerchantSession(merchantId) {
+  return requestJson(`/api/dev/login-merchant?merchantId=${encodeURIComponent(merchantId)}`, {
+    method: "POST",
+  });
+}
+
+export function loginAdminSession(adminId) {
+  return requestJson(`/api/dev/login-admin?adminId=${encodeURIComponent(adminId)}`, {
+    method: "POST",
+  });
+}
+
+export function logoutSession() {
+  return requestJson(`/api/dev/logout`, {
+    method: "POST",
+  });
+}

--- a/admin-web/src/api/paymentApi.js
+++ b/admin-web/src/api/paymentApi.js
@@ -3,6 +3,13 @@
 import { requestJson } from "./http.js";
 
 // TODO: C2(B 담당)에서 구현
+
+// order detail page load
+export function getConsumerOrderDetail(orderId) {
+  return requestJson(`/api/consumer/orders/${orderId}`);
+}
+
+// 구매확정 pay 실행
 export function payOrder(orderId, idempotencyKey) {
     return requestJson(`/api/consumer/orders/${orderId}/pay`, {
         method: "POST",

--- a/admin-web/src/app/router/ConsumerRoutes.jsx
+++ b/admin-web/src/app/router/ConsumerRoutes.jsx
@@ -1,3 +1,5 @@
+// admin-web/src/app/router/ConsumerRoutes.jsx
+
 import { Routes, Route } from "react-router-dom";
 import OrderCreatePage from "../../pages/consumer/OrderCreatePage.jsx";
 import OrderDetailPage from "../../pages/consumer/OrderDetailPage.jsx";

--- a/admin-web/src/components/common/RequireLoginNotice.jsx
+++ b/admin-web/src/components/common/RequireLoginNotice.jsx
@@ -1,0 +1,43 @@
+import { useLocation, useNavigate } from "react-router-dom";
+
+export default function RequireLoginNotice({
+  title = "인증 필요",
+  message = "로그인이 필요합니다. 개발용 로그인 페이지에서 세션을 생성해주세요.",
+  buttonText = "개발용 로그인 페이지로 이동",
+  to = "/auth/dev-login",
+  replace = false,
+  className = "",
+}) {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  function handleMoveToLogin() {
+    navigate(to, {
+      replace,
+      state: {
+        from: location.pathname + location.search,
+      },
+    });
+  }
+
+  const rootClassName = ["guard-notice", className].filter(Boolean).join(" ");
+
+  return (
+    <div className={rootClassName} role="alert" aria-live="polite">
+      <div className="guard-notice__title">{title}</div>
+      <div className="guard-notice__description">{message}</div>
+
+      {to && (
+        <div className="action-panel" style={{ marginTop: "12px" }}>
+          <button
+            type="button"
+            className="btn btn--primary"
+            onClick={handleMoveToLogin}
+          >
+            {buttonText}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-web/src/pages/auth/DevLoginPage.jsx
+++ b/admin-web/src/pages/auth/DevLoginPage.jsx
@@ -1,0 +1,207 @@
+// /admin-web/src/pages/auth/DevLoginPage.jsx
+
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import {
+  loginConsumerSession,
+  loginMerchantSession,
+  loginAdminSession,
+  logoutSession,
+} from "../../api/devSessionApi.js";
+
+const CONSUMER_IDS = ["BUYER_1001", "BUYER_2001", "BUYER_3001"];
+const MERCHANT_IDS = ["MERCHANT_1001", "MERCHANT_2001", "MERCHANT_3001"];
+const ADMIN_IDS = ["ADMIN_1001", "ADMIN_2001", "ADMIN_3001"];
+
+export default function DevLoginPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const redirectTo = location.state?.from || "/";
+  const [loadingKey, setLoadingKey] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
+
+  async function handleLoginConsumer(buyerId) {
+    try {
+      setLoadingKey(`consumer:${buyerId}`);
+      setErrorMessage("");
+      setSuccessMessage("");
+
+      await loginConsumerSession(buyerId);
+      navigate(redirectTo, { replace: true });
+    } catch (error) {
+      setErrorMessage(error?.body?.message || "Consumer 세션 생성에 실패했습니다.");
+    } finally {
+      setLoadingKey("");
+    }
+  }
+
+  async function handleLoginMerchant(merchantId) {
+    try {
+      setLoadingKey(`merchant:${merchantId}`);
+      setErrorMessage("");
+      setSuccessMessage("");
+
+      await loginMerchantSession(merchantId);
+      navigate(redirectTo, { replace: true });
+    } catch (error) {
+      setErrorMessage(error?.body?.message || "Merchant 세션 생성에 실패했습니다.");
+    } finally {
+      setLoadingKey("");
+    }
+  }
+
+  async function handleLoginAdmin(adminId) {
+    try {
+      setLoadingKey(`admin:${adminId}`);
+      setErrorMessage("");
+      setSuccessMessage("");
+
+      await loginAdminSession(adminId);
+      navigate(redirectTo, { replace: true });
+    } catch (error) {
+      setErrorMessage(error?.body?.message || "Admin 세션 생성에 실패했습니다.");
+    } finally {
+      setLoadingKey("");
+    }
+  }
+
+  async function handleLogout() {
+    try {
+      setLoadingKey("logout");
+      setErrorMessage("");
+      setSuccessMessage("");
+
+      await logoutSession();
+      setSuccessMessage("세션이 정리되었습니다.");
+    } catch (error) {
+      setErrorMessage(error?.body?.message || "세션 종료에 실패했습니다.");
+    } finally {
+      setLoadingKey("");
+    }
+  }
+
+  return (
+    <PageLayout
+      title="개발용 로그인"
+      description="개발 환경에서 역할별 로그인 세션을 생성하거나 종료하는 페이지입니다."
+    >
+      {errorMessage && (
+        <div className="guard-notice" style={{ marginBottom: "16px" }}>
+          <div className="guard-notice__title">요청 실패</div>
+          <div className="guard-notice__description">{errorMessage}</div>
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="guard-notice" style={{ marginBottom: "16px" }}>
+          <div className="guard-notice__title">처리 완료</div>
+          <div className="guard-notice__description">{successMessage}</div>
+        </div>
+      )}
+
+      <div className="guard-notice" style={{ marginBottom: "16px" }}>
+        <div className="guard-notice__title">공통 안내</div>
+        <div className="guard-notice__description">
+          역할을 선택하면 해당 세션을 생성한 뒤, 접근을 시도했던 기존 페이지로 자동 이동합니다.
+          로그아웃은 현재 세션을 정리합니다.
+        </div>
+      </div>
+
+      <div className="page-grid-2">
+        <div className="card">
+          <div className="card__body">
+            <div className="table-toolbar" style={{ marginBottom: "16px" }}>
+              <div>Consumer</div>
+            </div>
+
+            <div className="action-panel" style={{ display: "grid", gap: "12px" , gridTemplateColumns: "repeat(3, 1fr)"}}>
+              {CONSUMER_IDS.map((buyerId) => (
+                <button
+                  key={buyerId}
+                  type="button"
+                  className="btn btn--primary"
+                  onClick={() => handleLoginConsumer(buyerId)}
+                  disabled={loadingKey !== ""}
+                >
+                  {loadingKey === `consumer:${buyerId}`
+                    ? "세션 생성 중..."
+                    : `${buyerId}`}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card__body">
+            <div className="table-toolbar" style={{ marginBottom: "16px" }}>
+              <div>Merchant</div>
+            </div>
+
+            <div className="action-panel" style={{ display: "grid", gap: "12px" , gridTemplateColumns: "repeat(3, 1fr)"}}>
+              {MERCHANT_IDS.map((merchantId) => (
+                <button
+                  key={merchantId}
+                  type="button"
+                  className="btn btn--primary"
+                  onClick={() => handleLoginMerchant(merchantId)}
+                  disabled={loadingKey !== ""}
+                >
+                  {loadingKey === `merchant:${merchantId}`
+                    ? "세션 생성 중..."
+                    : `${merchantId}`}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card__body">
+            <div className="table-toolbar" style={{ marginBottom: "16px" }}>
+              <div>Admin</div>
+            </div>
+
+            <div className="action-panel" style={{ display: "grid", gap: "12px" , gridTemplateColumns: "repeat(3, 1fr)"}}>
+              {ADMIN_IDS.map((adminId) => (
+                <button
+                  key={adminId}
+                  type="button"
+                  className="btn btn--primary"
+                  onClick={() => handleLoginAdmin(adminId)}
+                  disabled={loadingKey !== ""}
+                >
+                  {loadingKey === `admin:${adminId}`
+                    ? "세션 생성 중..."
+                    : `${adminId}`}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="card">
+          <div className="card__body">
+            <div className="table-toolbar" style={{ marginBottom: "16px" }}>
+              <div>Logout</div>
+            </div>
+
+            <div className="action-panel" style={{ display: "grid", gap: "12px" }}>
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleLogout}
+                disabled={loadingKey !== ""}
+              >
+                {loadingKey === "logout" ? "세션 종료 중..." : "현재 세션 로그아웃"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageLayout>
+  );
+}

--- a/admin-web/src/pages/consumer/OrderDetailPage.jsx
+++ b/admin-web/src/pages/consumer/OrderDetailPage.jsx
@@ -1,11 +1,105 @@
-// /admin-web/src/pages/consumer/OrderDetailPage.jsx
-
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getConsumerOrderDetail } from "../../api/paymentApi.js";
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
 import ActionButton from "../../components/layout/ActionButton.jsx";
 import StatusBadge from "../../components/display/StatusBadge.jsx";
+import RequireLoginNotice from "../../components/common/RequireLoginNotice.jsx";
 
 export default function OrderDetailPage() {
+  const { orderId } = useParams();
+
+  const [orderDetail, setOrderDetail] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [errorInfo, setErrorInfo] = useState(null);
+
+  useEffect(() => {
+    async function loadOrderDetail() {
+      try {
+        setLoading(true);
+        setErrorInfo(null);
+
+        const data = await getConsumerOrderDetail(orderId);
+        setOrderDetail(data);
+      } catch (error) {
+        setOrderDetail(null);
+        setErrorInfo({
+          status: error?.status ?? null,
+          message:
+            error?.body?.message ||
+            error?.body?.reason ||
+            "주문 정보를 불러오지 못했습니다.",
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    if (orderId) {
+      loadOrderDetail();
+    }
+  }, [orderId]);
+
+  if (loading) {
+    return (
+      <PageLayout
+        title="결제 상세"
+        description="C2 결제 상세(승인 버튼). orderId 기준 결제 승인과 멱등 UX가 들어갈 페이지입니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">로딩 중</div>
+          <div className="guard-notice__description">
+            주문 / 결제 정보를 불러오는 중입니다.
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (errorInfo?.status === 401) {
+    return (
+      <PageLayout
+        title="결제 상세"
+        description="C2 결제 상세(승인 버튼). orderId 기준 결제 승인과 멱등 UX가 들어갈 페이지입니다."
+      >
+        <RequireLoginNotice />
+      </PageLayout>
+    );
+  }
+
+  if (errorInfo?.status === 403) {
+    return (
+      <PageLayout
+        title="결제 상세"
+        description="C2 결제 상세(승인 버튼). orderId 기준 결제 승인과 멱등 UX가 들어갈 페이지입니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            {errorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (errorInfo) {
+    return (
+      <PageLayout
+        title="결제 상세"
+        description="C2 결제 상세(승인 버튼). orderId 기준 결제 승인과 멱등 UX가 들어갈 페이지입니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">조회 실패</div>
+          <div className="guard-notice__description">
+            {errorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
   return (
     <PageLayout
       title="결제 상세"
@@ -16,49 +110,53 @@ export default function OrderDetailPage() {
           <div className="kv-item">
             <div className="kv-item__label">orderId</div>
             <div className="kv-item__value">
-              <span className="display-field">ORD-20260318-0001</span>
+              <span className="display-field">{orderDetail?.orderId}</span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">paymentId</div>
             <div className="kv-item__value">
-              <span className="display-field copyable-id__text">PAY-20260318-0001</span>
+              <span className="display-field copyable-id__text">
+                {orderDetail?.paymentId ?? "-"}
+              </span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">merchantId</div>
             <div className="kv-item__value">
-              <span className="display-field">MRC_1001</span>
+              <span className="display-field">{orderDetail?.merchantId}</span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">buyerId</div>
             <div className="kv-item__value">
-              <span className="display-field">BUYER_2001</span>
+              <span className="display-field">{orderDetail?.buyerId}</span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">itemName</div>
             <div className="kv-item__value">
-              <span className="display-field">아이폰 14 프로</span>
+              <span className="display-field">{orderDetail?.itemName}</span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">amount</div>
             <div className="kv-item__value">
-              <span className="display-field amount-text">125,000원</span>
+              <span className="display-field amount-text">
+                {orderDetail?.amount?.toLocaleString()}원
+              </span>
             </div>
           </div>
 
           <div className="kv-item">
             <div className="kv-item__label">paymentStatus</div>
             <div className="kv-item__value">
-              <StatusBadge status="CAPTURED" />
+              <StatusBadge status={orderDetail?.paymentStatus} />
             </div>
           </div>
         </div>
@@ -85,132 +183,12 @@ export default function OrderDetailPage() {
 
           <div className="button-row action-panel">
             <ActionButton type="button">결제 승인</ActionButton>
-            <button type="button" className="btn btn--secondary">멱등 키 복사</button>
+            <button type="button" className="btn btn--secondary">
+              멱등 키 복사
+            </button>
           </div>
         </div>
       </SectionCard>
-
-      <SectionCard title="응답 예시">
-        <div className="guard-notice" style={{ marginBottom: "16px" }}>
-          <div className="guard-notice__title">응답 헤더</div>
-          <div className="guard-notice__description">
-            pay API의 requestId는 응답 바디가 아니라 <strong>X-Request-Id</strong> 응답 헤더로만 전달됩니다.
-          </div>
-        </div>
-
-        <div className="kv-list">
-          <div className="kv-item">
-            <div className="kv-item__label">httpStatus</div>
-            <div className="kv-item__value">
-              <div className="display-field">200</div>
-            </div>
-          </div>
-
-          <div className="kv-item">
-            <div className="kv-item__label">paymentId</div>
-            <div className="kv-item__value">
-              <div className="display-field">PAY-20260318-0001</div>
-            </div>
-          </div>
-
-          <div className="kv-item">
-            <div className="kv-item__label">status</div>
-            <div className="kv-item__value">
-              <div className="display-field display-field--badge">
-                <span className="status-badge status-captured">CAPTURED</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="kv-item">
-            <div className="kv-item__label">capturedAt</div>
-            <div className="kv-item__value">
-              <div className="display-field">2026-03-18 10:25:00</div>
-            </div>
-          </div>
-        </div>
-      </SectionCard>
-
-      <SectionCard title="예외 / no-op 예시">
-        <div className="page-section">
-          <div className="guard-notice">
-            <div className="guard-notice__title">400 BAD_REQUEST</div>
-            <div className="guard-notice__description">
-              X-Idempotency-Key 누락 시 400 처리
-            </div>
-          </div>
-
-          <div className="guard-notice">
-            <div className="guard-notice__title">409 IN_PROGRESS</div>
-            <div className="guard-notice__description">
-              성공 이력 저장 전 write 경합/중복 충돌 구간에서는 IN_PROGRESS 응답 가능
-            </div>
-          </div>
-
-          <div className="guard-notice">
-            <div className="guard-notice__title">409 ORDER_ALREADY_PAID</div>
-            <div className="guard-notice__description">
-              이미 PAID 상태인 order에 대해 pay 재요청 시 차단
-            </div>
-          </div>
-        </div>
-      </SectionCard>
-
-      <SectionCard title="결제 이벤트 미니 타임라인">
-        <div className="table-toolbar">
-          <div>Pay 실행 이벤트 흐름</div>
-          <div className="action-panel">
-            <span className="badge badge--default">목업</span>
-            <span className="badge badge--primary">replay 포함</span>
-          </div>
-        </div>
-
-        <div className="table-wrap">
-          <table className="data-table">
-            <thead>
-              <tr>
-                <th>실행일시</th>
-                <th>eventType</th>
-                <th>status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>2026-03-18 10:24:58</td>
-                <td>
-                  <span className="badge badge--default">PAYMENT_CREATED</span>
-                </td>
-                <td>CREATED</td>
-              </tr>
-
-              <tr>
-                <td>2026-03-18 10:25:00</td>
-                <td>
-                  <span className="badge badge--success">PAYMENT_CAPTURED</span>
-                </td>
-                <td>CAPTURED</td>
-              </tr>
-
-              <tr>
-                <td>2026-03-18 10:25:03</td>
-                <td>
-                  <span className="badge badge--primary">REPLAY</span>
-                </td>
-                <td>CAPTURED</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div className="guard-notice" style={{ marginTop: "16px" }}>
-          <div className="guard-notice__title">표시 규칙</div>
-          <div className="guard-notice__description">
-            최초 성공 시 PAYMENT_CREATED → PAYMENT_CAPTURED 흐름을 표시하고, 동일 멱등 키 재요청은
-            replay/no-op 형태로 현재 결과를 재표시합니다.
-          </div>
-        </div>
-      </SectionCard>
-
     </PageLayout>
   );
 }


### PR DESCRIPTION
## what

### C2 진입 및 인증 흐름 연결
- `/auth/dev-login` 페이지 추가
- consumer / merchant / admin dev session 생성 API 연동
- logout API 연동
- 미인증 사용자의 dev login 진입 동선 추가

### C2 초기 조회 연결
- `GET /api/consumer/orders/{orderId}` 호출 추가
- `OrderDetailPage`에서 `orderId` 기준 초기 조회 연결
- 401 응답 시 로그인 안내 노출
- 403 응답 시 접근 불가 안내 노출

### 공통 로그인 안내 컴포넌트 추가
- `RequireLoginNotice` 추가
- 로그인 필요 상황에서 dev login 페이지로 이동 가능하도록 구성

### C2 화면은 목업 단계로 유지
- 주문/결제 요약의 실제 조회 연결만 우선 반영
- 결제 승인 버튼 및 상세 예외/no-op/타임라인 영역은 후속 구현 대상
- 본 PR에서는 C2 전체 완성보다 공통 로그인/세션 진입과 초기 렌더링 연결에 범위 한정

## why

- 기획서 기준 C2 초기 렌더링 SoT인 `GET /api/consumer/orders/{orderId}` 연결 필요
- 세션 기반 공통 인증 흐름 점검을 위해 dev login 페이지 필요
- 미로그인(401) / 비소유 접근(403) 분기 확인 가능 상태 우선 확보 필요
- C2 상세 UX와 pay 실행부는 후속 PR에서 분리 구현 예정

## scope note

- 본 PR의 완료 기준은 "공통 로그인 동선 정상 동작 + C2 초기 조회 연결 + 401/403 분기 확인 가능" 상태 확보
- C2 상세 화면의 표시 항목, pay 액션, 예외/no-op/timeline 표현은 목업 또는 placeholder 상태 유지
- 로그인/세션 흐름에 문제 없고 `GET /api/consumer/orders/{orderId}` 초기 진입이 가능하면 본 PR 범위 내에서는 정상으로 판단

## out of scope

- pay 실행 연결
- X-Idempotency-Key 입력/복사 UX 완성
- no-op/409 예외 표시 고도화
- 결제 이벤트 타임라인 실데이터 연동
- C2 화면 최종 문구/레이아웃 확정

## note
- C2 화면 자체의 완성도보다, 공통 인증 흐름과 초기 조회 연결 정상화에 목적을 둔 PR