### PR TITLE
feat(refund): U6/A6 환불 화면 연결 및 admin requestId 접근 정리

### DIFF
--- a/admin-web/src/api/refundApi.js
+++ b/admin-web/src/api/refundApi.js
@@ -1,0 +1,43 @@
+import { requestJson } from "./http.js";
+
+export function getRefundContext(paymentId) {
+    return requestJson(`/api/payments/${paymentId}/refund-context`);
+}
+
+export function createRefund(payload) {
+    return requestJson("/api/refunds", {
+        method: "POST",
+        body: JSON.stringify(payload),
+    });
+}
+
+export function getMyRefunds() {
+    return requestJson("/api/me/refunds");
+}
+
+export function getAdminRefunds(params = {}) {
+    const searchParams = new URLSearchParams();
+
+    if (params.status) searchParams.set("status", params.status);
+    if (params.from) searchParams.set("from", params.from);
+    if (params.to) searchParams.set("to", params.to);
+
+    const query = searchParams.toString();
+    const url = query ? `/api/admin/refunds?${query}` : "/api/admin/refunds";
+
+    return requestJson(url);
+}
+
+export function approveRefund(refundId, comment) {
+    return requestJson(`/api/admin/refunds/${refundId}/approve`, {
+        method: "PATCH",
+        body: JSON.stringify({ comment }),
+    });
+}
+
+export function rejectRefund(refundId, comment) {
+    return requestJson(`/api/admin/refunds/${refundId}/reject`, {
+        method: "PATCH",
+        body: JSON.stringify({ comment }),
+    });
+}

--- a/admin-web/src/app/router/AdminRoutes.jsx
+++ b/admin-web/src/app/router/AdminRoutes.jsx
@@ -4,6 +4,7 @@ import BatchPage from "../../pages/admin/BatchPage.jsx"
 import SettlementManagePage from "../../pages/admin/SettlementManagePage.jsx"
 import SettlementDetailAdminPage from "../../pages/admin/SettlementDetailAdminPage.jsx"
 import HoldQueuePage from "../../pages/admin/HoldQueuePage.jsx";
+import RefundQueuePage from "../../pages/admin/RefundQueuePage.jsx";
 
 export default function AdminRoutes() {
   return (
@@ -12,6 +13,7 @@ export default function AdminRoutes() {
       <Route path="settlement-batches" element={<BatchPage />}/>
       <Route path="settlements" element={<SettlementManagePage />}/>
       <Route path="holds" element={<HoldQueuePage />} />
+      <Route path="refunds" element={<RefundQueuePage />} />
       <Route
         path="settlements/:settlementId"
         element={<SettlementDetailAdminPage />}

--- a/admin-web/src/app/router/MerchantRoutes.jsx
+++ b/admin-web/src/app/router/MerchantRoutes.jsx
@@ -5,6 +5,7 @@ import PaymentListPage from "../../pages/merchant/PaymentListPage.jsx";
 import PaymentDetailPage from "../../pages/merchant/PaymentDetailPage.jsx";
 import SettlementListPage from "../../pages/merchant/SettlementListPage.jsx";
 import SettlementDetailPage from "../../pages/merchant/SettlementDetailPage.jsx";
+import RefundPage from "../../pages/merchant/RefundPage.jsx";
 
 function MerchantPaymentListPage() {
   return <div>결제 조회 페이지</div>;
@@ -26,7 +27,7 @@ export default function MerchantRoutes() {
       <Route path="payments/:paymentId" element={<PaymentDetailPage />} />
       <Route path="settlements" element={<SettlementListPage />} />
       <Route path="settlements/:settlementId" element={<SettlementDetailPage />} />
-      <Route path="refunds" element={<MerchantRefundPage />} />
+      <Route path="refunds" element={<RefundPage />} />
     </Routes>
   );
 }

--- a/admin-web/src/components/layout/ActionButton.jsx
+++ b/admin-web/src/components/layout/ActionButton.jsx
@@ -8,7 +8,7 @@ export default function ActionButton({
     return (
         <button
             type={type}
-            className={`btn btn-${variant}`}
+            className={`btn btn--${variant}`}
             disabled={disabled}
             onClick={onClick}
         >

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -1,0 +1,320 @@
+import { useEffect, useState } from "react";
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import ActionButton from "../../components/layout/ActionButton.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+import { useNavigate } from "react-router-dom";
+import {
+    getAdminRefunds,
+    approveRefund,
+    rejectRefund,
+} from "../../api/refundApi.js";
+
+const INITIAL_FILTERS = {
+    status: "",
+    from: "",
+    to: "",
+};
+
+export default function RefundQueuePage() {
+    const [filters, setFilters] = useState(INITIAL_FILTERS);
+    const [refunds, setRefunds] = useState([]);
+    const [comments, setComments] = useState({});
+    const [loading, setLoading] = useState(false);
+    const [actingId, setActingId] = useState("");
+    const [errorMessage, setErrorMessage] = useState("");
+    const [lastResult, setLastResult] = useState(null);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        loadRefunds();
+    }, []);
+
+    function handleFilterChange(event) {
+        const { name, value } = event.target;
+        setFilters((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    }
+
+    function handleCommentChange(refundId, value) {
+        setComments((prev) => ({
+            ...prev,
+            [refundId]: value,
+        }));
+    }
+
+    async function loadRefunds() {
+        setLoading(true);
+        setErrorMessage("");
+
+        try {
+            const response = await getAdminRefunds(filters);
+            setRefunds(Array.isArray(response) ? response : []);
+        } catch (error) {
+            setErrorMessage(error?.body?.message || "환불 큐 조회에 실패했습니다.");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function handleSearch(event) {
+        event.preventDefault();
+        await loadRefunds();
+    }
+
+    async function handleAction(refundId, actionType) {
+        const comment = (comments[refundId] || "").trim();
+        const target = refunds.find((row) => row.refundId === refundId);
+        if (!target || target.status !== "REQUESTED") {
+            setErrorMessage("REQUESTED 상태에서만 승인/거절할 수 있습니다.");
+            return;
+        }
+        setErrorMessage("");
+        setLastResult(null);
+
+        if (!comment) {
+            setErrorMessage("approve/reject에는 comment가 필수입니다.");
+            return;
+        }
+
+        setActingId(refundId);
+
+        try {
+            const result =
+                actionType === "approve"
+                    ? await approveRefund(refundId, comment)
+                    : await rejectRefund(refundId, comment);
+
+            setRefunds((prev) =>
+                prev.map((row) =>
+                    row.refundId === refundId
+                        ? {
+                            ...row,
+                            status: result.status,
+                            decidedAt: result.decidedAt,
+                        }
+                        : row
+                )
+            );
+
+            setLastResult({
+                refundId,
+                actionType,
+                status: result.status,
+                decidedAt: result.decidedAt,
+                requestId: result.requestId,
+                comment,
+            });
+        } catch (error) {
+            if (error?.body?.reason) {
+                setErrorMessage(`환불 처리 실패: ${error.body.reason}`);
+            } else {
+                setErrorMessage(error?.body?.message || "환불 처리에 실패했습니다.");
+            }
+        } finally {
+            setActingId("");
+        }
+    }
+
+    function handleMoveToTrace(requestId) {
+        if (!requestId) return;
+        navigate(`/admin/audit?requestId=${encodeURIComponent(requestId)}`);
+    }
+
+    return (
+        <PageLayout
+            title="환불 큐"
+            description="관리자 환불 승인/거절 처리 화면입니다."
+        >
+            <SectionCard>
+                <form className="form-stack" onSubmit={handleSearch}>
+                    <div className="filter-bar">
+                        <div className="form-field">
+                            <label className="form-field__label">status</label>
+                            <select
+                                className="select"
+                                name="status"
+                                value={filters.status}
+                                onChange={handleFilterChange}
+                            >
+                                <option value="">전체</option>
+                                <option value="REQUESTED">REQUESTED</option>
+                                <option value="APPROVED">APPROVED</option>
+                                <option value="REJECTED">REJECTED</option>
+                            </select>
+                        </div>
+
+                        <div className="form-field">
+                            <label className="form-field__label">from</label>
+                            <input
+                                className="input"
+                                type="date"
+                                name="from"
+                                value={filters.from}
+                                onChange={handleFilterChange}
+                            />
+                        </div>
+
+                        <div className="form-field">
+                            <label className="form-field__label">to</label>
+                            <input
+                                className="input"
+                                type="date"
+                                name="to"
+                                value={filters.to}
+                                onChange={handleFilterChange}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="button-row">
+                        <ActionButton type="submit" disabled={loading}>
+                            {loading ? "조회 중..." : "조회"}
+                        </ActionButton>
+                    </div>
+                </form>
+            </SectionCard>
+
+            {lastResult ? (
+                <SectionCard>
+                    <div className="info-list">
+                        <div><strong>refundId</strong> {lastResult.refundId}</div>
+                        <div><strong>action</strong> {lastResult.actionType}</div>
+                        <div><strong>status</strong> <StatusBadge status={lastResult.status} /></div>
+                        <div><strong>decidedAt</strong> {lastResult.decidedAt || "-"}</div>
+                        <div><strong>comment</strong> {lastResult.comment || "-"}</div>
+                        <div>
+                            <strong>requestId</strong>{" "}
+                            {lastResult.requestId ? (
+                                <span className="copyable-id">
+                                    <span className="copyable-id__text">{lastResult.requestId}</span>
+                                </span>
+                            ) : ("-")}
+                        </div>
+                    </div>
+
+                    {lastResult.requestId ? (
+                        <div className="button-row">
+                            <ActionButton
+                                type="button"
+                                variant="secondary"
+                                onClick={() => handleMoveToTrace(lastResult.requestId)}
+                            >
+                                Trace로 보기
+                            </ActionButton>
+                        </div>
+                    ) : null}
+                </SectionCard>
+            ) : null}
+
+            <SectionCard>
+                {loading ? (
+                    <div className="state-block">
+                        <div className="state-block__title">로딩 중</div>
+                        <div className="state-block__description">
+                            환불 큐를 불러오고 있습니다.
+                        </div>
+                    </div>
+                ) : refunds.length === 0 ? (
+                    <div className="state-block">
+                        <div className="state-block__title">조회 결과 없음</div>
+                        <div className="state-block__description">
+                            조건에 맞는 환불이 없습니다.
+                        </div>
+                    </div>
+                ) : (
+                    <div className="table-wrap">
+                        <table className="data-table">
+                            <thead>
+                            <tr>
+                                <th>refundId</th>
+                                <th>paymentId</th>
+                                <th>merchantId</th>
+                                <th>amount</th>
+                                <th>status</th>
+                                <th>requestedAt</th>
+                                <th>decidedAt</th>
+                                <th>comment</th>
+                                <th>action</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {refunds.map((row) => {
+                                const isRequested = row.status === "REQUESTED";
+                                const disabled = actingId === row.refundId;
+                                const actionDisabled = disabled || !isRequested;
+
+                                return (
+                                    <tr key={row.refundId}>
+                                        <td>
+                                          <span className="copyable-id">
+                                            <span className="copyable-id__text copyable-id__text--short">
+                                              {row.refundId}
+                                            </span>
+                                          </span>
+                                        </td>
+
+                                        <td>
+                                          <span className="copyable-id">
+                                            <span className="copyable-id__text copyable-id__text--short">
+                                              {row.paymentId}
+                                            </span>
+                                          </span>
+                                        </td>
+
+                                        <td>{row.merchantId}</td>
+                                        <td>{row.amount}</td>
+                                        <td>
+                                            <StatusBadge status={row.status} />
+                                        </td>
+                                        <td>{row.requestedAt || "-"}</td>
+                                        <td>{row.decidedAt || "-"}</td>
+
+                                        <td style={{ minWidth: "220px" }}>
+                                          <textarea
+                                              className="textarea"
+                                              value={comments[row.refundId] || ""}
+                                              onChange={(event) =>
+                                                  handleCommentChange(row.refundId, event.target.value)
+                                              }
+                                              placeholder={isRequested ? "comment 입력" : "처리 완료 상태"}
+                                              disabled={!isRequested}
+                                          />
+                                        </td>
+
+                                        <td>
+                                            {isRequested ? (
+                                                <div className="button-row">
+                                                    <ActionButton
+                                                        type="button"
+                                                        disabled={actionDisabled}
+                                                        onClick={() => handleAction(row.refundId, "approve")}
+                                                    >
+                                                        {disabled ? "처리 중..." : "승인"}
+                                                    </ActionButton>
+                                                    <ActionButton
+                                                        type="button"
+                                                        variant="danger"
+                                                        disabled={actionDisabled}
+                                                        onClick={() => handleAction(row.refundId, "reject")}
+                                                    >
+                                                        {disabled ? "처리 중..." : "거절"}
+                                                    </ActionButton>
+                                                </div>
+                                            ) : (
+                                                <span>처리 완료</span>
+                                            )}
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </SectionCard>
+        </PageLayout>
+    );
+}

--- a/admin-web/src/pages/merchant/PaymentDetailPage.jsx
+++ b/admin-web/src/pages/merchant/PaymentDetailPage.jsx
@@ -4,8 +4,17 @@ import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
 import StatusBadge from "../../components/display/StatusBadge.jsx";
 import "../../style/payment-detail.css";
+import { useNavigate, useParams } from "react-router-dom";
 
 export default function PaymentDetailPage() {
+  const navigate = useNavigate();
+  const { paymentId } = useParams();
+
+  function moveToRefundPage() {
+    if (!paymentId) return;
+    navigate(`/merchant/refunds?paymentId=${encodeURIComponent(paymentId)}`);
+  }
+
   return (
     <PageLayout
       title="결제 상세"
@@ -107,7 +116,7 @@ export default function PaymentDetailPage() {
               </div>
 
               <div className="action-panel">
-                <button type="button" className="btn btn--primary">환불 요청하기</button>
+                <button type="button" className="btn btn--primary" onClick={moveToRefundPage}>환불 요청하기</button>
                 <button type="button" className="btn btn--secondary">refund-context 확인</button>
               </div>
             </div>

--- a/admin-web/src/pages/merchant/RefundPage.jsx
+++ b/admin-web/src/pages/merchant/RefundPage.jsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import PageLayout from "../../components/layout/PageLayout.jsx";
+import SectionCard from "../../components/layout/SectionCard.jsx";
+import ActionButton from "../../components/layout/ActionButton.jsx";
+import StatusBadge from "../../components/display/StatusBadge.jsx";
+import {
+    getRefundContext,
+    createRefund,
+    getMyRefunds,
+} from "../../api/refundApi.js";
+
+const INITIAL_FORM = {
+    paymentId: "",
+    amount: "",
+    reasonText: "",
+};
+
+export default function RefundPage() {
+    const [form, setForm] = useState(INITIAL_FORM);
+    const [refundContext, setRefundContext] = useState(null);
+    const [refunds, setRefunds] = useState([]);
+    const [loadingContext, setLoadingContext] = useState(false);
+    const [loadingRefunds, setLoadingRefunds] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState("");
+    const [successMessage, setSuccessMessage] = useState("");
+    const [searchParams] = useSearchParams();
+
+    useEffect(() => {
+        loadMyRefunds();
+    }, []);
+
+    useEffect(() => {
+        const initialPaymentId = searchParams.get("paymentId")?.trim() || "";
+        if (!initialPaymentId) return;
+
+        setForm((prev) => ({
+            ...prev,
+            paymentId: initialPaymentId,
+        }));
+    }, [searchParams]);
+
+    useEffect(() => {
+        const initialPaymentId = searchParams.get("paymentId")?.trim() || "";
+        if (!initialPaymentId) return;
+
+        async function bootstrap() {
+            setLoadingContext(true);
+            setErrorMessage("");
+            setSuccessMessage("");
+            try {
+                const response = await getRefundContext(initialPaymentId);
+                setRefundContext(response);
+            } catch (error) {
+                setRefundContext(null);
+                setErrorMessage(
+                    error?.body?.message || "refund-context 조회에 실패했습니다."
+                );
+            } finally {
+                setLoadingContext(false);
+            }
+        }
+
+        bootstrap();
+    }, [searchParams]);
+
+    function handleChange(event) {
+        const { name, value } = event.target;
+        setForm((prev) => ({
+            ...prev,
+            [name]: value,
+        }));
+    }
+
+    async function loadRefundContext() {
+        const paymentId = form.paymentId.trim();
+
+        if (!paymentId) {
+            setErrorMessage("paymentId를 입력해 주세요.");
+            setSuccessMessage("");
+            setRefundContext(null);
+            return;
+        }
+
+        setLoadingContext(true);
+        setErrorMessage("");
+        setSuccessMessage("");
+
+        try {
+            const response = await getRefundContext(paymentId);
+            setRefundContext(response);
+        } catch (error) {
+            setRefundContext(null);
+            setErrorMessage(
+                error?.body?.message || "refund-context 조회에 실패했습니다."
+            );
+        } finally {
+            setLoadingContext(false);
+        }
+    }
+
+    async function loadMyRefunds() {
+        setLoadingRefunds(true);
+
+        try {
+            const response = await getMyRefunds();
+            setRefunds(Array.isArray(response) ? response : []);
+        } catch (error) {
+            setErrorMessage(
+                error?.body?.message || "내 환불 내역 조회에 실패했습니다."
+            );
+        } finally {
+            setLoadingRefunds(false);
+        }
+    }
+
+    async function handleSubmit(event) {
+        event.preventDefault();
+
+        const paymentId = form.paymentId.trim();
+        const reasonText = form.reasonText.trim();
+        const rawAmount = form.amount.trim();
+
+        setErrorMessage("");
+        setSuccessMessage("");
+
+        if (!paymentId || !reasonText || !rawAmount) {
+            setErrorMessage("paymentId, amount, reasonText는 모두 필수입니다.");
+            return;
+        }
+
+        if (!/^\d+$/.test(rawAmount)) {
+            setErrorMessage("amount는 KRW 정수만 입력 가능합니다.");
+            return;
+        }
+
+        const amount = Number(rawAmount);
+
+        if (!Number.isSafeInteger(amount) || amount <= 0) {
+            setErrorMessage("amount는 1 이상의 정수여야 합니다.");
+            return;
+        }
+
+        if (!refundContext) {
+            setErrorMessage("먼저 refund-context를 조회해 주세요.");
+            return;
+        }
+
+        if (refundContext.currency !== "KRW") {
+            setErrorMessage("현재 KRW 환불만 지원합니다.");
+            return;
+        }
+
+        if (amount > refundContext.refundableAmount) {
+            setErrorMessage("refundableAmount를 초과할 수 없습니다.");
+            return;
+        }
+
+        setSubmitting(true);
+
+        try {
+            await createRefund({
+                paymentId,
+                amount,
+                reasonText,
+            });
+
+            setSuccessMessage("환불 요청이 등록되었습니다.");
+            setForm((prev) => ({
+                ...prev,
+                amount: "",
+                reasonText: "",
+            }));
+            await loadMyRefunds();
+        } catch (error) {
+            if (error?.body?.reason) {
+                setErrorMessage(`환불 요청 실패: ${error.body.reason}`);
+            } else {
+                setErrorMessage(
+                    error?.body?.message || "환불 요청 등록에 실패했습니다."
+                );
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <PageLayout
+            title="환불 요청 · 현황"
+            description="refund-context를 확인한 뒤 환불 요청을 등록하고, 내 환불 상태를 조회합니다."
+        >
+            <SectionCard title="환불 요청">
+                <form className="form-stack" onSubmit={handleSubmit}>
+                    <div className="form-field">
+                        <label className="form-field__label">paymentId</label>
+                        <input
+                            className="input"
+                            name="paymentId"
+                            value={form.paymentId}
+                            onChange={handleChange}
+                            placeholder="결제 ID 입력"
+                        />
+                    </div>
+
+                    <div className="button-row">
+                        <ActionButton
+                            type="button"
+                            variant="secondary"
+                            disabled={loadingContext}
+                            onClick={loadRefundContext}
+                        >
+                            {loadingContext ? "조회 중..." : "refund-context 조회"}
+                        </ActionButton>
+                    </div>
+
+                    {refundContext ? (
+                        <div className="info-list">
+                            <div>
+                                <strong>paymentId</strong>{" "}
+                                <span className="copyable-id">
+                  <span className="copyable-id__text">
+                    {refundContext.paymentId}
+                  </span>
+                </span>
+                            </div>
+
+                            <div>
+                                <strong>status</strong>{" "}
+                                <StatusBadge status={refundContext.status} />
+                            </div>
+
+                            <div>
+                                <strong>capturedAmount</strong> {refundContext.capturedAmount}
+                            </div>
+
+                            <div>
+                                <strong>refundableAmount</strong>{" "}
+                                {refundContext.refundableAmount}
+                            </div>
+
+                            <div>
+                                <strong>currency</strong> {refundContext.currency}
+                            </div>
+
+                            <div>
+                                <strong>merchantId</strong> {refundContext.merchantId}
+                            </div>
+
+                            <div>
+                                <strong>capturedAt</strong> {refundContext.capturedAt || "-"}
+                            </div>
+                        </div>
+                    ) : null}
+
+                    <div className="form-field">
+                        <label className="form-field__label">amount</label>
+                        <input
+                            className="input"
+                            type="text"
+                            name="amount"
+                            value={form.amount}
+                            onChange={handleChange}
+                            placeholder="환불 금액"
+                            inputMode="numeric"
+                        />
+                    </div>
+
+                    <div className="form-field">
+                        <label className="form-field__label">reasonText</label>
+                        <textarea
+                            className="textarea"
+                            name="reasonText"
+                            value={form.reasonText}
+                            onChange={handleChange}
+                            placeholder="환불 사유 입력"
+                        />
+                    </div>
+
+                    <div className="button-row">
+                        <ActionButton type="submit" disabled={submitting}>
+                            {submitting ? "요청 중..." : "환불 요청"}
+                        </ActionButton>
+                    </div>
+                </form>
+            </SectionCard>
+
+            {errorMessage ? <div className="state-error">{errorMessage}</div> : null}
+
+            {successMessage ? (
+                <div className="state-success">{successMessage}</div>
+            ) : null}
+
+            <SectionCard title="내 환불 현황">
+                {loadingRefunds ? (
+                    <div className="state-block">
+                        <div className="state-block__title">로딩 중</div>
+                        <div className="state-block__description">
+                            환불 내역을 불러오고 있습니다.
+                        </div>
+                    </div>
+                ) : refunds.length === 0 ? (
+                    <div className="state-block">
+                        <div className="state-block__title">환불 내역 없음</div>
+                        <div className="state-block__description">
+                            현재 조회되는 환불 요청이 없습니다.
+                        </div>
+                    </div>
+                ) : (
+                    <div className="table-wrap">
+                        <table className="data-table">
+                            <thead>
+                            <tr>
+                                <th>refundId</th>
+                                <th>paymentId</th>
+                                <th>amount</th>
+                                <th>status</th>
+                                <th>requestedAt</th>
+                                <th>decidedAt</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            {refunds.map((row) => (
+                                <tr key={row.refundId}>
+                                    <td>
+                      <span className="copyable-id">
+                        <span className="copyable-id__text copyable-id__text--short">
+                          {row.refundId}
+                        </span>
+                      </span>
+                                    </td>
+
+                                    <td>
+                      <span className="copyable-id">
+                        <span className="copyable-id__text copyable-id__text--short">
+                          {row.paymentId}
+                        </span>
+                      </span>
+                                    </td>
+
+                                    <td>{row.amount}</td>
+
+                                    <td>
+                                        <StatusBadge status={row.status} />
+                                    </td>
+
+                                    <td>{row.requestedAt || "-"}</td>
+                                    <td>{row.decidedAt || "-"}</td>
+                                </tr>
+                            ))}
+                            </tbody>
+                        </table>
+                    </div>
+                )}
+            </SectionCard>
+        </PageLayout>
+    );
+}

--- a/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
@@ -5,14 +5,13 @@ import com.settleops.domain.refund.api.dto.AdminRefundDecisionResponseDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.global.auth.annotation.LoginAdmin;
 import com.settleops.global.web.RequestIdResolver;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -48,26 +47,26 @@ public class AdminRefundController {
     public ResponseEntity<AdminRefundDecisionResponseDTO> approve(
             @PathVariable String refundId,
             @RequestBody @Valid AdminRefundDecisionRequestDTO req,
-            Authentication authentication,
+            @LoginAdmin String adminId,
             HttpServletRequest request
     ) {
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String adminId = userDetails.getUsername();
         String requestId = requestIdResolver.resolve(request);
-        return ResponseEntity.ok(refundAdminService.approve(refundId, adminId, req.getComment(), requestId));
+        return ResponseEntity.ok(
+                refundAdminService.approve(refundId, adminId, req.getComment(), requestId)
+        );
     }
 
     @PatchMapping("/{refundId}/reject")
     public ResponseEntity<AdminRefundDecisionResponseDTO> reject(
             @PathVariable String refundId,
             @RequestBody @Valid AdminRefundDecisionRequestDTO req,
-            Authentication authentication,
-            HttpServletRequest request
+            HttpServletRequest request,
+            @LoginAdmin String adminId
     ) {
-        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
-        String adminId = userDetails.getUsername();
         String requestId = requestIdResolver.resolve(request);
-        return ResponseEntity.ok(refundAdminService.reject(refundId, adminId, req.getComment(), requestId));
+        return ResponseEntity.ok(
+                refundAdminService.reject(refundId, adminId, req.getComment(), requestId)
+        );
     }
 
 }


### PR DESCRIPTION
## What
U6 환불 요청·현황 화면 추가
- GET /api/payments/{paymentId}/refund-context 조회 연결
- POST /api/refunds 환불 요청 연결
- GET /api/me/refunds 내 환불 현황 조회 연결
- U3 결제 상세에서 U6 환불 화면으로 paymentId 전달 라우팅 추가

A6 환불 큐 화면 추가
- GET /api/admin/refunds?status=&from=&to= 큐 조회 연결
- PATCH /api/admin/refunds/{refundId}/approve 승인 연결
- PATCH /api/admin/refunds/{refundId}/reject 거절 연결
- 승인/거절 결과의 status, decidedAt, requestId를 화면에 표시하고 Trace 이동 버튼 추가

Refund API 모듈 추가
- refundApi.js에 U6/A6 환불 관련 API 함수 분리

AdminRefundController requestId 접근 정리
- Controller 직접 getAttribute 방식이 아니라 RequestIdResolver.resolve(request) 사용
- approve/reject에서 @LoginAdmin 기반 adminId 전달 유지

공통 버튼 스타일 정리
- ActionButton 클래스명을 btn--{variant} 형식으로 수정해 기존 화면 스타일 규칙과 정합성 맞춤

## Why
기획서/RnR 기준 C 파트 소유 범위인 U6 환불 요청·현황, A6 환불 큐를 프론트에서 end-to-end로 연결하기 위함
운영/재현 응답의 requestId를 화면에서 바로 확인하고 A1 Trace로 이동할 수 있게 하여 request_id E2E 재현 계약을 맞추기 위함
requestId 접근을 Resolver 경유로 통일해 Filter/Resolver 책임 경계를 지키기 위함
기존 공통 버튼 스타일 규칙(btn--*)과 맞지 않던 부분을 정리해 화면 정합성을 맞추기 위함

## Scope
Refund 도메인(C 파트) 범위 내 변경
- admin-web
  - 환불 API 모듈 추가
  - Merchant U6 RefundPage 추가
  - Admin A6 RefundQueuePage 추가
  - Merchant/Admin 라우트 연결
  - U3 결제 상세 → U6 이동 CTA 연결
  - ActionButton 스타일 규칙 정리
- server
  - AdminRefundController의 approve/reject requestId 추출 방식 정리

## 문서 정합성 메모
- U6/A6 화면 및 API 경로는 기획서/RnR 정의 범위 내에서만 연결
- approve/reject는 comment 필수 전제 유지
- 운영 액션 응답의 requestId 바디 포함 방향 유지
- request_id 생성/주입 책임은 Filter 단일 책임으로 두고 Controller는 Resolver로만 접근

## Follow-up
이번 PR은 U6/A6 환불 화면의 데이터 연결과 기본 운영 흐름 연결까지를 범위로 했습니다.
세부 UI 문구/배치/상태 표현 정렬, 공통 컴포넌트 분리, 화면 디테일 고도화는 후속 PR에서 기획서 기준으로 추가 정리 예정입니다.