### PR TITLE
[A1] Trace/Audit event 조회 추가 및 no-op 서버 필터링 반영

### DIFF
--- a/server/src/main/java/com/settleops/domain/admin/query/trace/controller/AuditEventController.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/controller/AuditEventController.java
@@ -1,0 +1,22 @@
+package com.settleops.domain.admin.query.trace.controller;
+
+import com.settleops.domain.admin.query.trace.dto.AuditEventResponseDto;
+import com.settleops.domain.admin.query.trace.service.AuditEventQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+@RequiredArgsConstructor
+public class AuditEventController {
+
+    private final AuditEventQueryService auditEventQueryService;
+
+    @GetMapping("/audit-events")
+    public AuditEventResponseDto search(@RequestParam String requestId) {
+        return auditEventQueryService.findByRequestId(requestId);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/controller/AuditTraceController.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/controller/AuditTraceController.java
@@ -28,10 +28,11 @@ public class AuditTraceController {
             @RequestParam(required = false) EntityType entityType,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)  LocalDateTime to,
+            @RequestParam(required = false) boolean includeNoOp,
             @PageableDefault(size = 20) Pageable pageable
     ){
 
-        AuditTraceSearchRequestDto rq = new AuditTraceSearchRequestDto(requestId,merchantId,entityType,from,to);
+        AuditTraceSearchRequestDto rq = new AuditTraceSearchRequestDto(requestId,merchantId,entityType,from,to,includeNoOp);
 
         return auditTraceService.searchAuditTraces(rq,pageable);
 

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditEventResponseDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditEventResponseDto.java
@@ -1,0 +1,14 @@
+package com.settleops.domain.admin.query.trace.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AuditEventResponseDto {
+
+    private final String requestId;
+    private final List<AuditEventRowDto> items;
+}

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditEventRowDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditEventRowDto.java
@@ -1,0 +1,41 @@
+package com.settleops.domain.admin.query.trace.dto;
+
+import com.settleops.global.audit.EntityType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuditEventRowDto {
+
+    private LocalDateTime occurredAt;
+    private String eventType;
+    private EntityType entityType;
+    private String entityId;
+    private String statusBefore;
+    private String statusAfter;
+    private String metaJson;
+
+    public static AuditEventRowDto of(
+            LocalDateTime occurredAt,
+            String eventType,
+            EntityType entityType,
+            String entityId,
+            String statusBefore,
+            String statusAfter,
+            String metaJson
+    ) {
+        return new AuditEventRowDto(
+                occurredAt,
+                eventType,
+                entityType,
+                entityId,
+                statusBefore,
+                statusAfter,
+                (metaJson == null || metaJson.isBlank()) ? "{}" : metaJson
+        );
+    }
+}

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditTraceRowDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditTraceRowDto.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AuditTraceRowDto {
 
-//    3.  DTO 매핑(A1 6컬럼 중심)
+    //    3.  DTO 매핑(A1 6컬럼 중심)
 //    엔티티(AuditLog)를 그대로 반환 금지
 //    응답 필드 고정: (occurredAt,actorType/actorId, action,entityType, entityId, statusBeforeAfter, metaJson 등)
     private LocalDateTime occurredAt;
@@ -31,6 +31,7 @@ public class AuditTraceRowDto {
     // 확장 필드(기본은 숨김 처리 가능)
     private Long auditId;
     private String merchantId;
+    private String requestId;
 
     public static AuditTraceRowDto from(AuditLog log) {
         if (log == null) throw new BadRequestException("요청 값이 올바르지 않습니다.");
@@ -48,7 +49,8 @@ public class AuditTraceRowDto {
                 // metaJson은 DDL/PrePersist 상 NOT NULL이지만, 방어적으로 한 번 더 처리
                 (log.getMetaJson() == null || log.getMetaJson().isBlank()) ? "{}" : log.getMetaJson(),
                 log.getAuditId(),
-                log.getMerchantId()
+                log.getMerchantId(),
+                log.getRequestId()
         );
     }
 

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditTraceSearchRequestDto.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/dto/AuditTraceSearchRequestDto.java
@@ -14,5 +14,6 @@ public class AuditTraceSearchRequestDto {
     private EntityType entityType;
     private LocalDateTime from;
     private LocalDateTime to;
+    private boolean includeNoOp;
 
 }

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/service/AuditEventQueryService.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/service/AuditEventQueryService.java
@@ -1,0 +1,136 @@
+package com.settleops.domain.admin.query.trace.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.domain.admin.query.trace.dto.AuditEventResponseDto;
+import com.settleops.domain.admin.query.trace.dto.AuditEventRowDto;
+import com.settleops.domain.hold.domain.QHoldEvent;
+import com.settleops.domain.payment.domain.QPaymentEvent;
+import com.settleops.domain.refund.domain.QRefundEvent;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.error.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuditEventQueryService {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final ObjectMapper objectMapper;
+
+    public AuditEventResponseDto findByRequestId(String requestId) {
+        if (requestId == null || requestId.isBlank()) {
+            throw new BadRequestException("requestId는 필수입니다.");
+        }
+
+        List<AuditEventRowDto> items = new ArrayList<>();
+
+        addPaymentEvents(requestId, items);
+        addHoldEvents(requestId, items);
+        addRefundEvents(requestId, items);
+
+        items.sort(
+                Comparator.comparing(
+                                AuditEventRowDto::getOccurredAt,
+                                Comparator.nullsLast(Comparator.naturalOrder())
+                        )
+                        .thenComparing(
+                                AuditEventRowDto::getEntityType,
+                                Comparator.nullsLast(Comparator.naturalOrder())
+                        )
+                        .thenComparing(
+                                AuditEventRowDto::getEntityId,
+                                Comparator.nullsLast(String::compareTo)
+                        )
+        );
+
+        return new AuditEventResponseDto(requestId, items);
+    }
+
+    private void addPaymentEvents(String requestId, List<AuditEventRowDto> items) {
+        QPaymentEvent paymentEvent = QPaymentEvent.paymentEvent;
+
+        var rows = jpaQueryFactory
+                .selectFrom(paymentEvent)
+                .where(paymentEvent.requestId.eq(requestId))
+                .fetch();
+
+        for (var event : rows) {
+            items.add(AuditEventRowDto.of(
+                    event.getOccurredAt(),
+                    event.getEventType().name(),
+                    EntityType.PAYMENT,
+                    event.getPaymentId(),
+                    event.getStatusBefore() == null ? null : event.getStatusBefore().name(),
+                    event.getStatusAfter() == null ? null : event.getStatusAfter().name(),
+                    "{}"
+            ));
+        }
+    }
+
+    private void addHoldEvents(String requestId, List<AuditEventRowDto> items) {
+        QHoldEvent holdEvent = QHoldEvent.holdEvent;
+
+        var rows = jpaQueryFactory
+                .selectFrom(holdEvent)
+                .where(holdEvent.requestId.eq(requestId))
+                .fetch();
+
+        for (var event : rows) {
+            String metaJson = normalizeJson(event.getMetaJson());
+
+            items.add(AuditEventRowDto.of(
+                    event.getOccurredAt(),
+                    event.getEventType().name(),
+                    EntityType.HOLD,
+                    event.getHoldId(),
+                    extractStatus(metaJson, "before"),
+                    extractStatus(metaJson, "after"),
+                    metaJson
+            ));
+        }
+    }
+
+    private void addRefundEvents(String requestId, List<AuditEventRowDto> items) {
+        QRefundEvent refundEvent = QRefundEvent.refundEvent;
+
+        var rows = jpaQueryFactory
+                .selectFrom(refundEvent)
+                .where(refundEvent.requestId.eq(requestId))
+                .fetch();
+
+        for (var event : rows) {
+            items.add(AuditEventRowDto.of(
+                    event.getOccurredAt(),
+                    event.getEventType().name(),
+                    EntityType.REFUND,
+                    event.getRefundId(),
+                    event.getStatusBefore() == null ? null : event.getStatusBefore().name(),
+                    event.getStatusAfter() == null ? null : event.getStatusAfter().name(),
+                    "{}"
+            ));
+        }
+    }
+
+    private String normalizeJson(String metaJson) {
+        return (metaJson == null || metaJson.isBlank()) ? "{}" : metaJson;
+    }
+
+    private String extractStatus(String metaJson, String nodeName) {
+        try {
+            JsonNode root = objectMapper.readTree(metaJson);
+            JsonNode statusNode = root.path(nodeName).path("status");
+            return statusNode.isMissingNode() || statusNode.isNull() ? null : statusNode.asText();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/com/settleops/domain/admin/query/trace/service/AuditTraceService.java
+++ b/server/src/main/java/com/settleops/domain/admin/query/trace/service/AuditTraceService.java
@@ -29,6 +29,7 @@ public class AuditTraceService {
         LocalDateTime from = rq.getFrom();
         LocalDateTime to = rq.getTo();
         LocalDateTime now = LocalDateTime.now();
+        boolean includeNoOp = rq.isIncludeNoOp();
 
         boolean hasRequestId = requestId != null && !requestId.isBlank();
         boolean hasMerchantId = merchantId != null && !merchantId.isBlank();
@@ -42,11 +43,11 @@ public class AuditTraceService {
 
         if (hasRequestId) {
             if (hasEntityType) {
-                pageResult = auditTraceQueryService.findByRequestIdAndEntityType(requestId, entityType, pageable);
+                pageResult = auditTraceQueryService.findByRequestIdAndEntityType(requestId, entityType, includeNoOp, pageable);
             } else {
-                pageResult = auditTraceQueryService.findByRequestId(requestId, pageable);
+                pageResult = auditTraceQueryService.findByRequestId(requestId, includeNoOp, pageable);
             }
-        } else if (hasMerchantId) {
+        } else  {
             if (to == null && from == null) {
                 to = now;
                 from = to.minusDays(7);
@@ -56,9 +57,9 @@ public class AuditTraceService {
             if (!to.isAfter(from)) throw new BadRequestException("to는 from 이후여야 합니다.");
 
             if (hasEntityType) {
-                pageResult = auditTraceQueryService.findByMerchantInRangeAndEntityType(merchantId, entityType, from, to, pageable);
+                pageResult = auditTraceQueryService.findByMerchantInRangeAndEntityType(merchantId, entityType, from, to, includeNoOp, pageable);
             } else {
-                pageResult = auditTraceQueryService.findByMerchantInRange(merchantId, from, to, pageable);
+                pageResult = auditTraceQueryService.findByMerchantInRange(merchantId, from, to, includeNoOp, pageable);
             }
         }
         if (pageResult == null) throw new IllegalStateException("pageResult is null");

--- a/server/src/main/java/com/settleops/global/audit/AuditLogQuery.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogQuery.java
@@ -9,16 +9,16 @@ import java.time.LocalDateTime;
 // AuditLog 조회(Trace/A1)를 위해 requestId·merchantId 기준 페이징 검색을 제공하는 조회 전용(Query) 인터페이스
 
 public interface AuditLogQuery {
-    Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, Pageable pageable);
+    Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, boolean includeNoOp, Pageable pageable);
 
     Page<AuditLog> findByRequestIdAndEntityTypeOrderByOccurredAtDesc(
-            String requestId, EntityType entityType, Pageable pageable);
+            String requestId, EntityType entityType, boolean includeNoOp, Pageable pageable);
 
     Page<AuditLog> findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(
-            String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable);
+            String merchantId, LocalDateTime from, LocalDateTime to, boolean includeNoOp, Pageable pageable);
 
     Page<AuditLog> findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(
-            String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable);
+            String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, boolean includeNoOp, Pageable pageable);
 
     // A2 (Batch SKIP) 전용: action + entityType(BATCH) + 기간
     Page<AuditLog> findByActionAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(

--- a/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
@@ -99,10 +99,12 @@ public class AuditLogRepositoryImpl implements  AuditLogQuery{
             return null;
         }
 
-        return Expressions.booleanTemplate(
-                "coalesce(json_extract({0}, '$.noOp') = true, false) = false",
+        var noOpValue = Expressions.stringTemplate(
+                "json_unquote(json_extract({0}, '$.noOp'))",
                 auditLog.metaJson
         );
+
+        return noOpValue.isNull().or(noOpValue.ne("true"));
     }
 
     // A2(SKIP) 전용: actionCond 포함

--- a/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.settleops.global.audit;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.settleops.global.enums.Action;
 import lombok.RequiredArgsConstructor;
@@ -24,24 +25,24 @@ public class AuditLogRepositoryImpl implements  AuditLogQuery{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, Pageable pageable) {
+    public Page<AuditLog> findByRequestIdOrderByOccurredAtDesc(String requestId, boolean includeNoOp,Pageable pageable) {
 
-        return page(auditLog.requestId.eq(requestId), null,null,pageable);
+        return page(auditLog.requestId.eq(requestId), null,null, noOpCondition(includeNoOp), pageable);
     }
 
     @Override
-    public Page<AuditLog> findByRequestIdAndEntityTypeOrderByOccurredAtDesc(String requestId, EntityType entityType, Pageable pageable) {
-        return page(auditLog.requestId.eq(requestId),auditLog.entityType.eq(entityType),null,pageable);
+    public Page<AuditLog> findByRequestIdAndEntityTypeOrderByOccurredAtDesc(String requestId, EntityType entityType, boolean includeNoOp,Pageable pageable) {
+        return page(auditLog.requestId.eq(requestId),auditLog.entityType.eq(entityType),null,  noOpCondition(includeNoOp), pageable);
     }
 
     @Override
-    public Page<AuditLog> findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable) {
-        return page(auditLog.merchantId.eq(merchantId),null,auditLog.occurredAt.between(from, to),pageable);
+    public Page<AuditLog> findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, LocalDateTime from, LocalDateTime to, boolean includeNoOp,Pageable pageable) {
+        return page(auditLog.merchantId.eq(merchantId),null,auditLog.occurredAt.between(from, to), noOpCondition(includeNoOp), pageable);
     }
 
     @Override
-    public Page<AuditLog> findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable) {
-        return page(auditLog.merchantId.eq(merchantId),auditLog.entityType.eq(entityType),auditLog.occurredAt.between(from, to),pageable);
+    public Page<AuditLog> findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, boolean includeNoOp,Pageable pageable) {
+        return page(auditLog.merchantId.eq(merchantId),auditLog.entityType.eq(entityType),auditLog.occurredAt.between(from, to), noOpCondition(includeNoOp),pageable);
     }
 
     // occurredAt DESC 고정 + pageable offset/limit 적용 + countQuery로 Page 구성
@@ -49,10 +50,11 @@ public class AuditLogRepositoryImpl implements  AuditLogQuery{
     private Page<AuditLog> page(BooleanExpression keyCond,
                                 BooleanExpression entityTypeCond,
                                 BooleanExpression rangeCond,
+                                BooleanExpression noOpCond,
                                 Pageable pageable) {
 
         // Expressions.allOf는 null-safe
-        BooleanExpression whereCond = allOf(keyCond, entityTypeCond, rangeCond);
+        BooleanExpression whereCond = allOf(keyCond, entityTypeCond, rangeCond, noOpCond);
 
         List<AuditLog> content = jpaQueryFactory
                 .selectFrom(auditLog)
@@ -91,6 +93,18 @@ public class AuditLogRepositoryImpl implements  AuditLogQuery{
                 pageable
         );
     }
+
+    private BooleanExpression noOpCondition(boolean includeNoOp) {
+        if (includeNoOp) {
+            return null;
+        }
+
+        return Expressions.booleanTemplate(
+                "coalesce(json_extract({0}, '$.noOp') = true, false) = false",
+                auditLog.metaJson
+        );
+    }
+
     // A2(SKIP) 전용: actionCond 포함
     private Page<AuditLog> pageWithAction(
             BooleanExpression keyCond,

--- a/server/src/main/java/com/settleops/global/audit/AuditTraceQueryService.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditTraceQueryService.java
@@ -14,18 +14,18 @@ import java.time.LocalDateTime;
 public class AuditTraceQueryService {
     private final AuditLogRepository auditLogRepository;
 
-    public Page<AuditLog> findByRequestId(String requestId, Pageable pageable){
-      return auditLogRepository.findByRequestIdOrderByOccurredAtDesc(requestId,pageable) ;
+    public Page<AuditLog> findByRequestId(String requestId, boolean includeNoOp, Pageable pageable){
+      return auditLogRepository.findByRequestIdOrderByOccurredAtDesc(requestId,includeNoOp,pageable) ;
     }
 
-    public Page<AuditLog> findByRequestIdAndEntityType(String requestId, EntityType entityType, Pageable pageable){
-        return auditLogRepository.findByRequestIdAndEntityTypeOrderByOccurredAtDesc(requestId,entityType,pageable);
+    public Page<AuditLog> findByRequestIdAndEntityType(String requestId, EntityType entityType, boolean includeNoOp,  Pageable pageable){
+        return auditLogRepository.findByRequestIdAndEntityTypeOrderByOccurredAtDesc(requestId,entityType,includeNoOp,pageable);
     }
-    public Page<AuditLog> findByMerchantInRange(String merchantId, LocalDateTime from, LocalDateTime to, Pageable pageable){
-        return auditLogRepository.findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,from,to,pageable);
+    public Page<AuditLog> findByMerchantInRange(String merchantId, LocalDateTime from, LocalDateTime to, boolean includeNoOp,  Pageable pageable){
+        return auditLogRepository.findByMerchantIdAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,from,to,includeNoOp,pageable);
     }
-    public Page<AuditLog> findByMerchantInRangeAndEntityType(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, Pageable pageable){
-        return auditLogRepository.findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,entityType,from,to,pageable);
+    public Page<AuditLog> findByMerchantInRangeAndEntityType(String merchantId, EntityType entityType, LocalDateTime from, LocalDateTime to, boolean includeNoOp, Pageable pageable){
+        return auditLogRepository.findByMerchantIdAndEntityTypeAndOccurredAtBetweenOrderByOccurredAtDesc(merchantId,entityType,from,to,includeNoOp,pageable);
     }
 
 }

--- a/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/settleops/global/error/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -94,6 +95,19 @@ public class GlobalExceptionHandler {
                 );
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.ofBadRequest(errorMessage));
+    }
+
+    /**
+     * [POLICY] 필수 RequestParam 누락 처리
+     * - Spring binding 단계에서 발생하는 누락 오류는 400 Bad Request로 변환한다.
+     * - 메시지는 단일 정책으로 "<parameterName>는 필수입니다." 형태를 사용한다.
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException e
+    ) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ErrorResponse.ofBadRequest(e.getParameterName() + "는 필수입니다."));
     }
 
     /**

--- a/server/src/test/java/com/settleops/domain/admin/query/trace/AuditEventControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/admin/query/trace/AuditEventControllerTest.java
@@ -1,0 +1,123 @@
+package com.settleops.domain.admin.query.trace;
+
+import com.settleops.domain.admin.query.trace.controller.AuditEventController;
+import com.settleops.domain.admin.query.trace.dto.AuditEventResponseDto;
+import com.settleops.domain.admin.query.trace.dto.AuditEventRowDto;
+import com.settleops.domain.admin.query.trace.service.AuditEventQueryService;
+import com.settleops.global.audit.AuditLogger;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.auth.SessionAuthProvider;
+import com.settleops.global.error.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuditEventController.class)
+class AuditEventControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    AuditEventQueryService auditEventQueryService;
+
+    @MockitoBean
+    SessionAuthProvider sessionAuthProvider;
+
+    @MockitoBean
+    AuditLogger auditLogger;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void requestId_should_return_200_with_items() throws Exception {
+        // Given
+        AuditEventRowDto row1 = AuditEventRowDto.of(
+                LocalDateTime.parse("2026-03-22T10:00:00"),
+                "PAYMENT_CONFIRMED",
+                EntityType.PAYMENT,
+                "payment-1",
+                "CAPTURED",
+                "CAPTURED",
+                "{}"
+        );
+
+        AuditEventRowDto row2 = AuditEventRowDto.of(
+                LocalDateTime.parse("2026-03-22T10:01:00"),
+                "HOLD_APPROVED",
+                EntityType.HOLD,
+                "hold-1",
+                "HOLD_REQUESTED",
+                "HOLD_ACTIVE",
+                "{\"comment\":\"승인\"}"
+        );
+
+        AuditEventResponseDto response = new AuditEventResponseDto(
+                "req-1",
+                List.of(row1, row2)
+        );
+
+        given(auditEventQueryService.findByRequestId("req-1"))
+                .willReturn(response);
+
+        // When / Then
+        mockMvc.perform(get("/api/admin/audit-events")
+                        .param("requestId", "req-1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value("req-1"))
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items.length()").value(2))
+                .andExpect(jsonPath("$.items[0].eventType").value("PAYMENT_CONFIRMED"))
+                .andExpect(jsonPath("$.items[0].entityType").value("PAYMENT"))
+                .andExpect(jsonPath("$.items[0].entityId").value("payment-1"))
+                .andExpect(jsonPath("$.items[0].statusBefore").value("CAPTURED"))
+                .andExpect(jsonPath("$.items[0].statusAfter").value("CAPTURED"))
+                .andExpect(jsonPath("$.items[0].metaJson").value("{}"))
+                .andExpect(jsonPath("$.items[1].eventType").value("HOLD_APPROVED"))
+                .andExpect(jsonPath("$.items[1].entityType").value("HOLD"))
+                .andExpect(jsonPath("$.items[1].entityId").value("hold-1"));
+
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+        verify(auditEventQueryService, times(1)).findByRequestId(captor.capture());
+        assertEquals("req-1", captor.getValue());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void blank_requestId_should_return_400() throws Exception {
+        // Given
+        given(auditEventQueryService.findByRequestId(anyString()))
+                .willThrow(new BadRequestException("requestId는 필수입니다."));
+
+        // When / Then
+        mockMvc.perform(get("/api/admin/audit-events")
+                        .param("requestId", " "))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.reason").value(nullValue()))
+                .andExpect(jsonPath("$.message").value("requestId는 필수입니다."));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void missing_requestId_should_return_400_by_spring_binding() throws Exception {
+        mockMvc.perform(get("/api/admin/audit-events"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/server/src/test/java/com/settleops/domain/admin/query/trace/AuditTraceControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/admin/query/trace/AuditTraceControllerTest.java
@@ -68,7 +68,7 @@ class AuditTraceControllerTest {
                 .andExpect(jsonPath("$.message").value("requestId 또는 merchantId는 필수입니다."));
     }
 
-    //둘 다 오면 requestId 우선 (merchantId 무시)a
+    //둘 다 오면 requestId 우선 (merchantId 무시)
     @Test
     @WithMockUser(roles = "ADMIN")
     void requestId_and_merchantId_both_given_should_prioritize_requestId() throws Exception {
@@ -152,6 +152,7 @@ class AuditTraceControllerTest {
 
                 // Then: 200 , items 반환
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.requestId").value("R1"))
                 .andExpect(jsonPath("$.items[0].requestId").value("R1"))
                 .andExpect(jsonPath("$.items").isArray())
                 .andExpect(jsonPath("$.items.length()").value(1))

--- a/server/src/test/java/com/settleops/domain/admin/query/trace/AuditTraceControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/admin/query/trace/AuditTraceControllerTest.java
@@ -68,7 +68,7 @@ class AuditTraceControllerTest {
                 .andExpect(jsonPath("$.message").value("requestId 또는 merchantId는 필수입니다."));
     }
 
-    //둘 다 오면 requestId 우선 (merchantId 무시)
+    //둘 다 오면 requestId 우선 (merchantId 무시)a
     @Test
     @WithMockUser(roles = "ADMIN")
     void requestId_and_merchantId_both_given_should_prioritize_requestId() throws Exception {
@@ -119,6 +119,7 @@ class AuditTraceControllerTest {
 
 //        (requestId="R1", items=List.of(…dummy 1개…), page/size/total…)
         AuditLog log = AuditLog.builder()
+                .requestId("R1")
                 .occurredAt(LocalDateTime.parse("2026-02-25T00:00:00"))
                 .actorType(ActorType.ADMIN)
                 .actorId("admin1")
@@ -151,7 +152,7 @@ class AuditTraceControllerTest {
 
                 // Then: 200 , items 반환
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.requestId").value("R1"))
+                .andExpect(jsonPath("$.items[0].requestId").value("R1"))
                 .andExpect(jsonPath("$.items").isArray())
                 .andExpect(jsonPath("$.items.length()").value(1))
                 .andExpect(jsonPath("$.items[0].actorId").value("admin1"))
@@ -253,6 +254,7 @@ class AuditTraceControllerTest {
                 .andExpect(jsonPath("$.items[0].action").exists())
                 .andExpect(jsonPath("$.items[0].entityType").exists())
                 .andExpect(jsonPath("$.items[0].entityId").exists())
+                .andExpect(jsonPath("$.items[0].requestId").value("R1"))
                 // metaJson은 null 금지 + 빈 값은 "{}"
                 .andExpect(jsonPath("$.items[0].metaJson").value("{}"))
                 // 확장필드 존재

--- a/server/src/test/java/com/settleops/domain/admin/query/trace/service/AuditEventQueryServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/admin/query/trace/service/AuditEventQueryServiceTest.java
@@ -1,0 +1,34 @@
+package com.settleops.domain.admin.query.trace.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.global.error.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class AuditEventQueryServiceTest {
+
+    private AuditEventQueryService auditEventQueryService;
+
+    @BeforeEach
+    void setUp() {
+        JPAQueryFactory jpaQueryFactory = mock(JPAQueryFactory.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        auditEventQueryService = new AuditEventQueryService(jpaQueryFactory, objectMapper);
+    }
+
+    @Test
+    void blank_requestId_should_throw_bad_request() {
+        BadRequestException ex = assertThrows(
+                BadRequestException.class,
+                () -> auditEventQueryService.findByRequestId(" ")
+        );
+
+        assertEquals("requestId는 필수입니다.", ex.getMessage());
+    }
+}

--- a/server/src/test/java/com/settleops/domain/admin/query/trace/service/AuditTraceServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/admin/query/trace/service/AuditTraceServiceTest.java
@@ -39,14 +39,15 @@ class AuditTraceServiceTest {
                 "M1",   // merchantId
                 null,   // entityType
                 null,   // from
-                null    // to
+                null ,   // to
+                false  // includeNoOp
         );
 
         var pageable = PageRequest.of(0, 20);
 
         // queryService가 호출되면 빈 페이지 반환(서비스가 끝까지 진행되게)
         Page<AuditLog> emptyPage = new PageImpl<>(List.of(), pageable, 0);
-        when(auditTraceQueryService.findByMerchantInRange(eq("M1"), any(), any(), eq(pageable)))
+        when(auditTraceQueryService.findByMerchantInRange(eq("M1"), any(), any(), eq(false), eq(pageable)))
                 .thenReturn(emptyPage);
 
         // When
@@ -57,7 +58,7 @@ class AuditTraceServiceTest {
         ArgumentCaptor<LocalDateTime> toCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 
         verify(auditTraceQueryService, times(1))
-                .findByMerchantInRange(eq("M1"), fromCaptor.capture(), toCaptor.capture(), eq(pageable));
+                .findByMerchantInRange(eq("M1"), fromCaptor.capture(), toCaptor.capture(), eq(false), eq(pageable));
 
         LocalDateTime from = fromCaptor.getValue();
         LocalDateTime to = toCaptor.getValue();
@@ -80,7 +81,8 @@ class AuditTraceServiceTest {
                 "M1",                       // merchantId
                 null,                       // entityType
                 LocalDateTime.parse("2026-02-01T00:00:00"), // from
-                null // to
+                null, // to
+                false
         );
 
         var pageable = PageRequest.of(0, 20);
@@ -100,7 +102,8 @@ class AuditTraceServiceTest {
                 "M1",                       // merchantId
                 null,                       // entityType
                 null,                       // from
-                LocalDateTime.parse("2026-02-08T00:00:00")  // to
+                LocalDateTime.parse("2026-02-08T00:00:00"),  // to
+                false
         );
 
         var pageable = PageRequest.of(0, 20);
@@ -118,7 +121,8 @@ class AuditTraceServiceTest {
                 "M1",                       // merchantId
                 null,                       // entityType
                 LocalDateTime.parse("2026-02-08T00:00:00"),  // from
-                LocalDateTime.parse("2026-02-08T00:00:00")  // to
+                LocalDateTime.parse("2026-02-08T00:00:00"),  // to
+                false
         );
 
         var pageable = PageRequest.of(0, 20);
@@ -127,6 +131,39 @@ class AuditTraceServiceTest {
                 () -> auditTraceService.searchAuditTraces(rq, pageable));
 
         assertEquals("to는 from 이후여야 합니다.", ex.getMessage());
+    }
+
+    @Test
+    void merchantId_only_with_includeNoOp_true_should_pass_true_to_query_service() {
+        // Given
+        AuditTraceSearchRequestDto rq = new AuditTraceSearchRequestDto(
+                null,   // requestId
+                "M1",   // merchantId
+                null,   // entityType
+                null,   // from
+                null,   // to
+                true    // includeNoOp
+        );
+
+        var pageable = PageRequest.of(0, 20);
+
+        Page<AuditLog> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+        when(auditTraceQueryService.findByMerchantInRange(eq("M1"), any(), any(), eq(true), eq(pageable)))
+                .thenReturn(emptyPage);
+
+        // When
+        auditTraceService.searchAuditTraces(rq, pageable);
+
+        // Then
+        ArgumentCaptor<LocalDateTime> fromCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+        ArgumentCaptor<LocalDateTime> toCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+        verify(auditTraceQueryService, times(1))
+                .findByMerchantInRange(eq("M1"), fromCaptor.capture(), toCaptor.capture(), eq(true), eq(pageable));
+
+        assertNotNull(fromCaptor.getValue());
+        assertNotNull(toCaptor.getValue());
+        assertTrue(toCaptor.getValue().isAfter(fromCaptor.getValue()));
     }
 
 }

--- a/server/src/test/java/com/settleops/global/audit/AuditLogRepositoryImplMySqlIT.java
+++ b/server/src/test/java/com/settleops/global/audit/AuditLogRepositoryImplMySqlIT.java
@@ -1,0 +1,134 @@
+package com.settleops.global.audit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.settleops.global.enums.Action;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test-db")
+@Transactional
+class AuditLogRepositoryImplMySqlIT {
+
+    @Autowired
+    private AuditLogRepository auditLogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("includeNoOp=false 이면 no-op=true 로그는 제외된다")
+    void findByRequestId_excludes_noop_when_includeNoOp_false() throws Exception {
+        // given
+        String requestId = UUID.randomUUID().toString();
+
+        auditLogRepository.save(AuditLog.builder()
+                .requestId(requestId)
+                .occurredAt(LocalDateTime.now().minusMinutes(1))
+                .actorType(ActorType.ADMIN)
+                .actorId("admin1")
+                .action(Action.HOLD_APPROVED)
+                .entityType(EntityType.HOLD)
+                .entityId(UUID.randomUUID().toString())
+                .statusBefore("HOLD_REQUESTED")
+                .statusAfter("HOLD_ACTIVE")
+                .merchantId("mrc_1001")
+                .metaJson(metaJson(false, null))
+                .build());
+
+        auditLogRepository.save(AuditLog.builder()
+                .requestId(requestId)
+                .occurredAt(LocalDateTime.now())
+                .actorType(ActorType.ADMIN)
+                .actorId("admin1")
+                .action(Action.HOLD_APPROVED)
+                .entityType(EntityType.HOLD)
+                .entityId(UUID.randomUUID().toString())
+                .statusBefore("HOLD_ACTIVE")
+                .statusAfter("HOLD_ACTIVE")
+                .merchantId("mrc_1001")
+                .metaJson(metaJson(true, "ALREADY_APPROVED"))
+                .build());
+
+        // when
+        var page = auditLogRepository.findByRequestIdOrderByOccurredAtDesc(
+                requestId,
+                false,
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        assertThat(page.getTotalElements()).isEqualTo(1);
+        assertThat(page.getContent()).hasSize(1);
+        assertThat(page.getContent().get(0).getMetaJson()).contains("\"noOp\":false");
+    }
+
+    @Test
+    @DisplayName("includeNoOp=true 이면 no-op=true 로그도 포함된다")
+    void findByRequestId_includes_noop_when_includeNoOp_true() throws Exception {
+        // given
+        String requestId = UUID.randomUUID().toString();
+
+        auditLogRepository.save(AuditLog.builder()
+                .requestId(requestId)
+                .occurredAt(LocalDateTime.now().minusMinutes(1))
+                .actorType(ActorType.ADMIN)
+                .actorId("admin1")
+                .action(Action.HOLD_APPROVED)
+                .entityType(EntityType.HOLD)
+                .entityId(UUID.randomUUID().toString())
+                .statusBefore("HOLD_REQUESTED")
+                .statusAfter("HOLD_ACTIVE")
+                .merchantId("mrc_1001")
+                .metaJson(metaJson(false, null))
+                .build());
+
+        auditLogRepository.save(AuditLog.builder()
+                .requestId(requestId)
+                .occurredAt(LocalDateTime.now())
+                .actorType(ActorType.ADMIN)
+                .actorId("admin1")
+                .action(Action.HOLD_APPROVED)
+                .entityType(EntityType.HOLD)
+                .entityId(UUID.randomUUID().toString())
+                .statusBefore("HOLD_ACTIVE")
+                .statusAfter("HOLD_ACTIVE")
+                .merchantId("mrc_1001")
+                .metaJson(metaJson(true, "ALREADY_APPROVED"))
+                .build());
+
+        // when
+        var page = auditLogRepository.findByRequestIdOrderByOccurredAtDesc(
+                requestId,
+                true,
+                PageRequest.of(0, 20)
+        );
+
+        // then
+        assertThat(page.getTotalElements()).isEqualTo(2);
+        assertThat(page.getContent()).hasSize(2);
+    }
+
+    private String metaJson(boolean noOp, String noOpReason) throws Exception {
+        Map<String, Object> meta = new LinkedHashMap<>();
+        meta.put("noOp", noOp);
+
+        if (noOpReason != null) {
+            meta.put("noOpReason", noOpReason);
+        }
+
+        return objectMapper.writeValueAsString(meta);
+    }
+}


### PR DESCRIPTION
## What
- A1 Trace/Audit 조회에 `includeNoOp` 파라미터를 추가했습니다.
- `/api/admin/audit-logs` 조회 경로에 no-op 서버 필터링을 관통 반영했습니다.
- `AuditTraceRowDto`에 `requestId`를 추가해 row 기준 event 조회 연결이 가능하도록 보강했습니다.
- `/api/admin/audit-events?requestId=...` API를 추가했습니다.
- 동일 requestId 기준으로 payment_event / hold_event / refund_event를 조회해 시간순으로 반환하도록 구현했습니다.
- 필수 request parameter 누락 시 400(BAD_REQUEST)로 처리되도록 `GlobalExceptionHandler`를 보강했습니다.
- 관련 controller/service 테스트를 추가 및 보강했습니다.

## Why
- 기존 A1은 audit_log 목록만 조회하고 있어, 기획서의 “audit 우선 + 펼침 시 event 묶음” 요구를 충족하지 못했습니다.
- no-op를 프론트에서 로컬 필터링하면 서버 totalElements/totalPages와 화면 표시 건수가 어긋나는 문제가 있어, 서버 필터링으로 정합성을 맞출 필요가 있었습니다.
- merchantId 기반 다건 조회에서도 선택 row의 requestId를 기준으로 상세 event를 안정적으로 조회할 수 있어야 했습니다.
- request parameter 누락이 500으로 처리되던 케이스를 400 규격으로 맞춰 API 에러 정합성을 보완했습니다.

## Scope
- backend only
- A1 Trace/Audit 조회 API
- A1 event 펼침용 조회 API
- no-op 서버 필터링
- 예외 처리 및 관련 테스트

## Out of Scope
- admin-web 프론트 구현/연동
- batch event 별도 테이블 도입
- A1 UI 상세 패널 event 렌더링

## Notes
- 현재 event 펼침 조회는 `payment_event`, `hold_event`, `refund_event`만 반영했습니다.
- `settlement_batch`는 별도 insert-only batch_event 테이블이 아니라 batch 실행 이력 SoT로 사용 중이므로, 이번 A1 event 조회 범위에서는 제외했습니다.
- 프론트 변경분은 별도 UI PR로 분리 예정입니다.

## Test
- `AuditTraceControllerTest`
- `AuditTraceServiceTest`
- `AuditEventControllerTest`
- `AuditEventQueryServiceTest`

## Risks / Checkpoints
- `includeNoOp=false`가 requestId/merchantId 조회 양쪽 모두에 동일하게 적용되는지 재확인 필요
- A1 프론트 연동 시 기존 로컬 no-op 필터는 제거되어야 서버 pagination과 정합성이 맞습니다
- A1 row expand는 반드시 `row.requestId` 기준으로 `/api/admin/audit-events`를 호출해야 합니다