### PR TITLE
feat: expose lastRequestId in A4 settlement detail for Trace CTA

### DIFF
--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImpl.java
@@ -47,6 +47,9 @@ public class SettlementDetailQueryServiceImpl implements SettlementDetailQuerySe
         boolean refundAdjustmentPending =
                 refundAdjustmentPolicy.isRefundAdjustmentPending(settlementId);
 
+        String lastRequestId =
+                settlementDetailQueryRepository.findLatestSettlementRequestId(settlementId);
+
         AdminSettlementRefundSummaryResponse refund =
                 new AdminSettlementRefundSummaryResponse(
                         hasApprovedRefund,
@@ -62,6 +65,7 @@ public class SettlementDetailQueryServiceImpl implements SettlementDetailQuerySe
                 base.fee(),
                 base.vat(),
                 base.net(),
+                lastRequestId,
                 lines,
                 hold,
                 refund

--- a/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementDetailResponse.java
+++ b/server/src/main/java/com/settleops/domain/settlement/dto/AdminSettlementDetailResponse.java
@@ -14,6 +14,7 @@ public record AdminSettlementDetailResponse(
         long fee,
         long vat,
         long net,
+        String lastRequestId,
         List<AdminSettlementLineItemResponse> lines,
         AdminSettlementHoldSummaryResponse hold,
         AdminSettlementRefundSummaryResponse refund

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepository.java
@@ -15,4 +15,6 @@ public interface SettlementDetailQueryRepository {
     AdminSettlementHoldSummaryResponse findHoldSummary(String settlementId);
 
     boolean hasApprovedRefund(String settlementId);
+
+    String findLatestSettlementRequestId(String settlementId);
 }

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImpl.java
@@ -4,14 +4,16 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.domain.hold.domain.QHold;
 import com.settleops.domain.refund.domain.QRefund;
 import com.settleops.domain.refund.domain.RefundStatus;
 import com.settleops.domain.settlement.dto.AdminSettlementDetailBaseView;
 import com.settleops.domain.settlement.dto.AdminSettlementHoldSummaryResponse;
 import com.settleops.domain.settlement.dto.AdminSettlementLineItemResponse;
-import com.settleops.domain.hold.domain.QHold;
 import com.settleops.domain.settlement.entity.QSettlement;
 import com.settleops.domain.settlement.entity.QSettlementLine;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.audit.QAuditLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -111,5 +113,28 @@ public class SettlementDetailQueryRepositoryImpl implements SettlementDetailQuer
                         refund.status.eq(RefundStatus.APPROVED)
                 )
                 .fetchFirst() != null;
+    }
+
+    /**
+     * A4 Trace CTA용 최신 requestId 조회
+     *
+     * 기준:
+     * - audit_log.entity_type = SETTLEMENT
+     * - audit_log.entity_id = settlementId
+     * - 가장 최근 occurred_at / audit_id 1건의 request_id
+     */
+    @Override
+    public String findLatestSettlementRequestId(String settlementId) {
+        QAuditLog auditLog = QAuditLog.auditLog;
+
+        return queryFactory
+                .select(auditLog.requestId)
+                .from(auditLog)
+                .where(
+                        auditLog.entityType.eq(EntityType.SETTLEMENT),
+                        auditLog.entityId.eq(settlementId)
+                )
+                .orderBy(auditLog.occurredAt.desc(), auditLog.auditId.desc())
+                .fetchFirst();
     }
 }

--- a/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/AdminSettlementQueryControllerTest.java
@@ -2,7 +2,11 @@ package com.settleops.domain.settlement.api;
 
 import com.settleops.domain.settlement.application.SettlementDetailQueryService;
 import com.settleops.domain.settlement.application.SettlementQueryService;
-import com.settleops.domain.settlement.dto.*;
+import com.settleops.domain.settlement.dto.AdminSettlementDetailResponse;
+import com.settleops.domain.settlement.dto.AdminSettlementHoldSummaryResponse;
+import com.settleops.domain.settlement.dto.AdminSettlementLineItemResponse;
+import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
+import com.settleops.domain.settlement.dto.AdminSettlementRefundSummaryResponse;
 import com.settleops.domain.settlement.enums.SettlementLineType;
 import com.settleops.domain.settlement.enums.SettlementStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +23,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AdminSettlementQueryControllerTest {
+
     @Test
     @DisplayName("관리자 정산 리스트 조회 시 merchantId 파라미터를 서비스로 전달한다")
     void getSettlements_withMerchantIdFilter() {
@@ -109,7 +114,7 @@ public class AdminSettlementQueryControllerTest {
 
     @Test
     @DisplayName("관리자 정산 상세 조회 시 settlementId를 서비스로 전달한다")
-    void getSettlementDetail_withSettlementId(){
+    void getSettlementDetail_withSettlementId() {
         SettlementQueryService settlementQueryService = Mockito.mock(SettlementQueryService.class);
         SettlementDetailQueryService settlementDetailQueryService = Mockito.mock(SettlementDetailQueryService.class);
         AdminSettlementQueryController controller =
@@ -124,6 +129,7 @@ public class AdminSettlementQueryControllerTest {
                 0L,
                 0L,
                 10000L,
+                "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
                 List.of(
                         new AdminSettlementLineItemResponse(
                                 "1",
@@ -143,6 +149,8 @@ public class AdminSettlementQueryControllerTest {
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).isNotNull();
+        assertThat(((AdminSettlementDetailResponse) response.getBody()).lastRequestId())
+                .isEqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
 
         Mockito.verify(settlementDetailQueryService)
                 .getAdminSettlementDetail("settlement-1");

--- a/server/src/test/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/SettlementDetailQueryServiceImplTest.java
@@ -27,11 +27,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Transactional
 public class SettlementDetailQueryServiceImplTest {
 
-    @Autowired SettlementDetailQueryService settlementDetailQueryService;
+    @Autowired
+    SettlementDetailQueryService settlementDetailQueryService;
 
-    @Autowired SettlementRepository settlementRepository;
+    @Autowired
+    SettlementRepository settlementRepository;
 
-    @Autowired SettlementLineRepository settlementLineRepository;
+    @Autowired
+    SettlementLineRepository settlementLineRepository;
 
     @Test
     @DisplayName("관리자 정산 상세 조회 시 존재하지 않는 settlementId면 404를 반환한다")
@@ -90,6 +93,7 @@ public class SettlementDetailQueryServiceImplTest {
         assertThat(response.fee()).isEqualTo(0L);
         assertThat(response.vat()).isEqualTo(0L);
         assertThat(response.net()).isEqualTo(10000L);
+        assertThat(response.lastRequestId()).isNull();
 
         assertThat(response.lines()).hasSize(2);
         assertThat(response.lines())

--- a/server/src/test/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/infra/SettlementDetailQueryRepositoryImplTest.java
@@ -1,17 +1,21 @@
 package com.settleops.domain.settlement.infra;
 
+import com.settleops.domain.hold.domain.Hold;
+import com.settleops.domain.hold.domain.HoldReasonCode;
+import com.settleops.domain.hold.domain.HoldStatus;
+import com.settleops.domain.hold.infra.HoldRepository;
 import com.settleops.domain.refund.domain.Refund;
 import com.settleops.domain.refund.domain.RefundStatus;
 import com.settleops.domain.refund.infra.RefundRepository;
 import com.settleops.domain.settlement.dto.AdminSettlementHoldSummaryResponse;
 import com.settleops.domain.settlement.dto.AdminSettlementLineItemResponse;
-import com.settleops.domain.hold.domain.Hold;
-import com.settleops.domain.hold.domain.HoldReasonCode;
-import com.settleops.domain.hold.domain.HoldStatus;
-import com.settleops.domain.hold.infra.HoldRepository;
 import com.settleops.domain.settlement.entity.Settlement;
 import com.settleops.domain.settlement.entity.SettlementLine;
 import com.settleops.domain.settlement.enums.SettlementLineType;
+import com.settleops.global.audit.ActorType;
+import com.settleops.global.audit.AuditLog;
+import com.settleops.global.audit.EntityType;
+import com.settleops.global.enums.Action;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -213,6 +217,60 @@ public class SettlementDetailQueryRepositoryImplTest {
 
         // then
         assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("A4 Trace CTA용 최신 requestId는 settlement audit 기준 최신값을 반환한다")
+    void findLatestSettlementRequestId_returnsLatestRequestId() {
+        // given
+        String settlementId = UUID.randomUUID().toString();
+
+        Settlement settlement = createSettlement(
+                settlementId,
+                "merchant-1",
+                LocalDate.of(2026, 3, 10),
+                10000L
+        );
+        settlementRepository.save(settlement);
+
+        AuditLog olderLog = AuditLog.builder()
+                .requestId("11111111-1111-1111-1111-111111111111")
+                .occurredAt(LocalDateTime.of(2026, 3, 11, 10, 0, 0))
+                .actorType(ActorType.ADMIN)
+                .actorId("admin1")
+                .action(Action.SETTLEMENT_PAY_REQUESTED)
+                .entityType(EntityType.SETTLEMENT)
+                .entityId(settlementId)
+                .statusBefore("READY")
+                .statusAfter("PAY_REQUESTED")
+                .merchantId("merchant-1")
+                .metaJson("{\"noOp\":false}")
+                .build();
+
+        AuditLog newerLog = AuditLog.builder()
+                .requestId("22222222-2222-2222-2222-222222222222")
+                .occurredAt(LocalDateTime.of(2026, 3, 11, 11, 0, 0))
+                .actorType(ActorType.ADMIN)
+                .actorId("admin2")
+                .action(Action.SETTLEMENT_PAY_APPROVED)
+                .entityType(EntityType.SETTLEMENT)
+                .entityId(settlementId)
+                .statusBefore("PAY_REQUESTED")
+                .statusAfter("PAID")
+                .merchantId("merchant-1")
+                .metaJson("{\"noOp\":false}")
+                .build();
+
+        entityManager.persist(olderLog);
+        entityManager.persist(newerLog);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        String result = settlementDetailQueryRepository.findLatestSettlementRequestId(settlementId);
+
+        // then
+        assertThat(result).isEqualTo("22222222-2222-2222-2222-222222222222");
     }
 
     private Settlement createSettlement(


### PR DESCRIPTION
What
- A4 정산 상세 응답에 `lastRequestId`를 추가했습니다.
- `audit_log`에서 `entityType=SETTLEMENT`, `entityId=settlementId` 기준 최신 `requestId`를 조회하도록 read 경로를 보강했습니다.
- A4 상세 응답 DTO / 서비스 / 조회 리포지토리를 함께 수정했습니다.
- 관련 테스트(`AdminSettlementQueryControllerTest`, `SettlementDetailQueryServiceImplTest`, `SettlementDetailQueryRepositoryImplTest`)를 함께 보강했습니다.

Why
- 기획서 기준 A4는 settlementId 앵커 운영 허브이며, 관련 화면 CTA(Hold 큐 / Refund 큐 / Trace / Batch)를 제공해야 합니다.
- 기존 프론트는 `requestId || lastRequestId` 구조로 Trace CTA를 연결하고 있었지만, A4 상세 응답에 실제 requestId 계열 값이 없어 Trace 버튼이 비활성/무효 상태가 될 수 있었습니다.
- 이번 변경에서 `current requestId`가 아니라 `lastRequestId`를 추가한 이유는, A4 상세 조회 요청 자체의 requestId보다 settlement 관련 최신 운영 액션(request-paid / approve-paid / hold 등)의 requestId가 운영 재현 관점에서 더 유의미하다고 봤기 때문입니다.

Scope
- `AdminSettlementDetailResponse`
- `SettlementDetailQueryServiceImpl`
- `SettlementDetailQueryRepository`
- `SettlementDetailQueryRepositoryImpl`
- 관련 테스트 3건 수정/추가

Implementation
- `findLatestSettlementRequestId(settlementId)` 조회 메서드를 추가했습니다.
- 조회 기준은 아래와 같습니다.
  - `audit_log.entity_type = SETTLEMENT`
  - `audit_log.entity_id = settlementId`
  - 최신순 정렬: `occurred_at desc`, `audit_id desc`
- 조회 결과가 없으면 `lastRequestId`는 `null` 허용입니다.
- 프론트는 기존대로 `requestId || lastRequestId`를 사용하면 됩니다.

Test
- `./gradlew compileTestJava`
- `./gradlew test --tests "*SettlementDetail*"`
- `./gradlew test`

Notes
- 이번 변경은 A4 상세 응답 보강 범위만 다루며, requestId 생성/주입 정책(`RequestIdFilter`)이나 운영 액션의 audit 적재 정책 자체는 변경하지 않았습니다.
- 조회 기준은 `audit_log(entityType=SETTLEMENT, entityId=settlementId)`의 최신 1건입니다.
- `lastRequestId`는 settlement 관련 audit가 존재할 때만 값이 내려가며, audit가 아직 없는 seed/데이터에서는 `null`일 수 있습니다.
- 즉 이번 PR은 requestId 생성 정책 변경이나 audit 적재 정책 변경이 아니라, A4 운영 허브에서 Trace로 넘어가기 위한 read model 보강 범위입니다.