### PR TITLE
fix: align merchant settlement auth with @LoginMerchant

### DIFF
--- a/server/src/main/java/com/settleops/domain/settlement/api/MerchantSettlementQueryController.java
+++ b/server/src/main/java/com/settleops/domain/settlement/api/MerchantSettlementQueryController.java
@@ -3,8 +3,7 @@ package com.settleops.domain.settlement.api;
 import com.settleops.domain.settlement.application.MerchantSettlementQueryService;
 import com.settleops.domain.settlement.dto.MerchantSettlementDetailResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
-import com.settleops.global.auth.MerchantSessionResolver;
-import jakarta.servlet.http.HttpServletRequest;
+import com.settleops.global.auth.annotation.LoginMerchant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,16 +18,13 @@ import org.springframework.web.bind.annotation.*;
 public class MerchantSettlementQueryController {
 
     private final MerchantSettlementQueryService merchantSettlementQueryService;
-    private final MerchantSessionResolver merchantSessionResolver;
 
     @GetMapping
     public ResponseEntity<Page<MerchantSettlementListItemResponse>> getMerchantSettlements(
             @PathVariable String merchantId,
             @PageableDefault(size = 20) Pageable pageable,
-            HttpServletRequest request
+            @LoginMerchant String loginMerchantId
     ) {
-        String loginMerchantId = merchantSessionResolver.resolveMerchantId(request);
-
         Pageable fixedPageable = PageRequest.of(
                 pageable.getPageNumber(),
                 pageable.getPageSize()
@@ -47,10 +43,8 @@ public class MerchantSettlementQueryController {
     public ResponseEntity<MerchantSettlementDetailResponse> getMerchantSettlementDetail(
             @PathVariable String merchantId,
             @PathVariable String settlementId,
-            HttpServletRequest request
+            @LoginMerchant String loginMerchantId
     ) {
-        String loginMerchantId = merchantSessionResolver.resolveMerchantId(request);
-
         return ResponseEntity.ok(
                 merchantSettlementQueryService.getMerchantSettlementDetail(
                         loginMerchantId,

--- a/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerTest.java
@@ -6,8 +6,6 @@ import com.settleops.domain.settlement.dto.MerchantSettlementLineItemResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
 import com.settleops.domain.settlement.enums.SettlementLineType;
 import com.settleops.domain.settlement.enums.SettlementStatus;
-import com.settleops.global.auth.MerchantSessionResolver;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,14 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MerchantSettlementQueryControllerTest {
 
     @Test
-    @DisplayName("Merchant 정산 리스트 조회 시 resolver의 merchantId와 path merchantId를 서비스로 전달한다")
-    void getMerchantSettlements_passesResolvedMerchantIdAndPathMerchantId() {
+    @DisplayName("Merchant 정산 리스트 조회 시 loginMerchantId와 path merchantId를 서비스로 전달한다")
+    void getMerchantSettlements_passesLoginMerchantIdAndPathMerchantId() {
         MerchantSettlementQueryService merchantSettlementQueryService = Mockito.mock(MerchantSettlementQueryService.class);
-        MerchantSessionResolver merchantSessionResolver = Mockito.mock(MerchantSessionResolver.class);
         MerchantSettlementQueryController controller =
-                new MerchantSettlementQueryController(merchantSettlementQueryService, merchantSessionResolver);
+                new MerchantSettlementQueryController(merchantSettlementQueryService);
 
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
         PageRequest pageable = PageRequest.of(0, 20);
 
         MerchantSettlementListItemResponse item = new MerchantSettlementListItemResponse(
@@ -45,9 +41,6 @@ public class MerchantSettlementQueryControllerTest {
                 LocalDateTime.of(2026, 3, 11, 10, 0)
         );
 
-        Mockito.when(merchantSessionResolver.resolveMerchantId(request))
-                .thenReturn("merchant-1");
-
         Mockito.when(merchantSettlementQueryService.getMerchantSettlements(
                 "merchant-1",
                 "merchant-1",
@@ -57,13 +50,12 @@ public class MerchantSettlementQueryControllerTest {
         ResponseEntity<?> response = controller.getMerchantSettlements(
                 "merchant-1",
                 pageable,
-                request
+                "merchant-1"
         );
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).isNotNull();
 
-        Mockito.verify(merchantSessionResolver).resolveMerchantId(request);
         Mockito.verify(merchantSettlementQueryService).getMerchantSettlements(
                 "merchant-1",
                 "merchant-1",
@@ -72,14 +64,11 @@ public class MerchantSettlementQueryControllerTest {
     }
 
     @Test
-    @DisplayName("Merchant 정산 상세 조회 시 resolver의 merchantId와 settlementId를 서비스로 전달한다")
-    void getMerchantSettlementDetail_passesResolvedMerchantIdAndSettlementId() {
+    @DisplayName("Merchant 정산 상세 조회 시 loginMerchantId와 settlementId를 서비스로 전달한다")
+    void getMerchantSettlementDetail_passesLoginMerchantIdAndSettlementId() {
         MerchantSettlementQueryService merchantSettlementQueryService = Mockito.mock(MerchantSettlementQueryService.class);
-        MerchantSessionResolver merchantSessionResolver = Mockito.mock(MerchantSessionResolver.class);
         MerchantSettlementQueryController controller =
-                new MerchantSettlementQueryController(merchantSettlementQueryService, merchantSessionResolver);
-
-        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+                new MerchantSettlementQueryController(merchantSettlementQueryService);
 
         MerchantSettlementDetailResponse detail = new MerchantSettlementDetailResponse(
                 "settlement-1",
@@ -99,9 +88,6 @@ public class MerchantSettlementQueryControllerTest {
                 )
         );
 
-        Mockito.when(merchantSessionResolver.resolveMerchantId(request))
-                .thenReturn("merchant-1");
-
         Mockito.when(merchantSettlementQueryService.getMerchantSettlementDetail(
                 "merchant-1",
                 "merchant-1",
@@ -111,13 +97,12 @@ public class MerchantSettlementQueryControllerTest {
         ResponseEntity<?> response = controller.getMerchantSettlementDetail(
                 "merchant-1",
                 "settlement-1",
-                request
+                "merchant-1"
         );
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).isNotNull();
 
-        Mockito.verify(merchantSessionResolver).resolveMerchantId(request);
         Mockito.verify(merchantSettlementQueryService).getMerchantSettlementDetail(
                 "merchant-1",
                 "merchant-1",

--- a/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerWebMvcTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerWebMvcTest.java
@@ -7,15 +7,13 @@ import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
 import com.settleops.domain.settlement.enums.SettlementLineType;
 import com.settleops.domain.settlement.enums.SettlementStatus;
 import com.settleops.global.audit.AuditLogger;
-import com.settleops.global.auth.MerchantSessionResolver;
-import com.settleops.global.auth.resolver.LoginAdminArgumentResolver;
-import com.settleops.global.auth.resolver.LoginConsumerArgumentResolver;
+import com.settleops.global.auth.SessionAuthProvider;
+import com.settleops.global.auth.controller.MeController;
 import com.settleops.global.auth.resolver.LoginMerchantArgumentResolver;
 import com.settleops.global.error.ForbiddenException;
 import com.settleops.global.error.GlobalExceptionHandler;
 import com.settleops.global.error.NotFoundException;
 import com.settleops.global.error.UnauthorizedException;
-import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +22,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -31,17 +31,20 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(MerchantSettlementQueryController.class)
 @AutoConfigureMockMvc(addFilters = false)
-@Import(GlobalExceptionHandler.class)
+@Import({GlobalExceptionHandler.class, LoginMerchantArgumentResolver.class})
+@ActiveProfiles("test")
 class MerchantSettlementQueryControllerWebMvcTest {
+
+    private static final String MERCHANT_ID = "MERCHANT_1001";
 
     @Autowired
     private MockMvc mockMvc;
@@ -50,101 +53,106 @@ class MerchantSettlementQueryControllerWebMvcTest {
     private MerchantSettlementQueryService merchantSettlementQueryService;
 
     @MockitoBean
-    private MerchantSessionResolver merchantSessionResolver;
+    private SessionAuthProvider sessionAuthProvider;
 
     @MockitoBean
     private AuditLogger auditLogger;
 
-    @MockitoBean
-    private LoginMerchantArgumentResolver loginMerchantArgumentResolver;
-
-    @MockitoBean
-    private LoginConsumerArgumentResolver loginConsumerArgumentResolver;
-
-    @MockitoBean
-    private LoginAdminArgumentResolver loginAdminArgumentResolver;
-
     @Test
     @DisplayName("Merchant 정산 리스트 조회 시 세션이 없으면 401을 반환한다")
-    void getMerchantSettlements_unauthorizedWhenSessionMissing() throws Exception {
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenThrow(new UnauthorizedException("login required"));
+    void getMerchantSettlements_returns_unauthorized_when_session_missing() throws Exception {
+        when(sessionAuthProvider.getCurrentMerchantId())
+                .thenThrow(new UnauthorizedException("로그인이 필요합니다."));
 
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", "merchant-1"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", MERCHANT_ID))
                 .andExpect(status().isUnauthorized())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
-                .andExpect(jsonPath("$.reason").isEmpty())
-                .andExpect(jsonPath("$.message").value("login required"));
+                .andExpect(jsonPath("$.reason").doesNotExist())
+                .andExpect(jsonPath("$.message").value("로그인이 필요합니다."));
+
+        verifyNoInteractions(merchantSettlementQueryService);
     }
 
     @Test
     @DisplayName("Merchant 정산 리스트 조회 시 로그인 merchantId와 path merchantId가 다르면 403을 반환한다")
-    void getMerchantSettlements_forbiddenWhenMerchantMismatch() throws Exception {
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenReturn("merchant-1");
+    void getMerchantSettlements_returns_forbidden_when_merchant_mismatch() throws Exception {
+        when(sessionAuthProvider.getCurrentMerchantId())
+                .thenThrow(new ForbiddenException("접근 권한이 없습니다."));
 
-        when(merchantSettlementQueryService.getMerchantSettlements(
-                eq("merchant-1"),
-                eq("merchant-2"),
-                any()
-        )).thenThrow(new ForbiddenException("merchant mismatch"));
-
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", "merchant-2"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", "OTHER_MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID)
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isForbidden())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("FORBIDDEN"))
-                .andExpect(jsonPath("$.reason").isEmpty())
-                .andExpect(jsonPath("$.message").value("merchant mismatch"));
+                .andExpect(jsonPath("$.reason").doesNotExist())
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+
+        verifyNoInteractions(merchantSettlementQueryService);
     }
 
     @Test
     @DisplayName("Merchant 정산 상세 조회 시 존재하지 않는 settlementId면 404를 반환한다")
-    void getMerchantSettlementDetail_notFoundWhenSettlementDoesNotExist() throws Exception {
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenReturn("merchant-1");
-
+    void getMerchantSettlementDetail_returns_not_found_when_settlement_not_found() throws Exception {
+        when(sessionAuthProvider.getCurrentMerchantId()).thenReturn(MERCHANT_ID);
         when(merchantSettlementQueryService.getMerchantSettlementDetail(
-                "merchant-1",
-                "merchant-1",
-                "settlement-404"
+                eq(MERCHANT_ID),
+                eq(MERCHANT_ID),
+                eq("missing-settlement")
         )).thenThrow(new NotFoundException("settlement not found"));
 
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}", "merchant-1", "settlement-404"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}",
+                        MERCHANT_ID,
+                        "missing-settlement")
+                        .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID))
                 .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.reason").doesNotExist())
                 .andExpect(jsonPath("$.message").value("settlement not found"));
+
+        verify(merchantSettlementQueryService).getMerchantSettlementDetail(
+                MERCHANT_ID,
+                MERCHANT_ID,
+                "missing-settlement"
+        );
     }
 
     @Test
     @DisplayName("Merchant 정산 상세 조회 시 다른 merchant의 settlement이면 403을 반환한다")
-    void getMerchantSettlementDetail_forbiddenWhenSettlementOwnerDoesNotMatch() throws Exception {
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenReturn("merchant-1");
+    void getMerchantSettlementDetail_returns_forbidden_when_settlement_owner_does_not_match() throws Exception {
+        when(sessionAuthProvider.getCurrentMerchantId())
+                .thenThrow(new ForbiddenException("접근 권한이 없습니다."));
 
-        when(merchantSettlementQueryService.getMerchantSettlementDetail(
-                "merchant-1",
-                "merchant-1",
-                "settlement-1"
-        )).thenThrow(new ForbiddenException("merchant mismatch"));
-
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}", "merchant-1", "settlement-1"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}",
+                        "OTHER_MERCHANT",
+                        "settlement-1")
+                        .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID))
                 .andExpect(status().isForbidden())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.code").value("FORBIDDEN"))
                 .andExpect(jsonPath("$.reason").doesNotExist())
-                .andExpect(jsonPath("$.message").value("merchant mismatch"));
+                .andExpect(jsonPath("$.message").value("접근 권한이 없습니다."));
+
+        verifyNoInteractions(merchantSettlementQueryService);
     }
 
     @Test
     @DisplayName("Merchant 정산 상세 조회 성공 시 200과 상세 응답을 반환한다")
     void getMerchantSettlementDetail_success() throws Exception {
-        MerchantSettlementDetailResponse response = new MerchantSettlementDetailResponse(
+        MerchantSettlementDetailResponse detail = new MerchantSettlementDetailResponse(
                 "settlement-1",
                 LocalDate.of(2026, 3, 10),
                 SettlementStatus.READY,
                 10000L,
-                0L,
-                0L,
-                10000L,
+                1000L,
+                100L,
+                8900L,
                 List.of(
                         new MerchantSettlementLineItemResponse(
                                 "1",
@@ -155,48 +163,97 @@ class MerchantSettlementQueryControllerWebMvcTest {
                 )
         );
 
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenReturn("merchant-1");
-
+        when(sessionAuthProvider.getCurrentMerchantId()).thenReturn(MERCHANT_ID);
         when(merchantSettlementQueryService.getMerchantSettlementDetail(
-                "merchant-1",
-                "merchant-1",
-                "settlement-1"
-        )).thenReturn(response);
+                eq(MERCHANT_ID),
+                eq(MERCHANT_ID),
+                eq("settlement-1")
+        )).thenReturn(detail);
 
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}", "merchant-1", "settlement-1"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements/{settlementId}",
+                        MERCHANT_ID,
+                        "settlement-1")
+                        .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID))
                 .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.settlementId").value("settlement-1"))
+                .andExpect(jsonPath("$.baseDate").value("2026-03-10"))
                 .andExpect(jsonPath("$.status").value("READY"))
-                .andExpect(jsonPath("$.lines[0].paymentId").value("payment-1"));
+                .andExpect(jsonPath("$.gross").value(10000))
+                .andExpect(jsonPath("$.fee").value(1000))
+                .andExpect(jsonPath("$.vat").value(100))
+                .andExpect(jsonPath("$.net").value(8900))
+                .andExpect(jsonPath("$.lines.length()").value(1))
+                .andExpect(jsonPath("$.lines[0].settlementLineId").value("1"))
+                .andExpect(jsonPath("$.lines[0].type").value("PAYMENT"))
+                .andExpect(jsonPath("$.lines[0].paymentId").value("payment-1"))
+                .andExpect(jsonPath("$.lines[0].amount").value(10000));
+
+        verify(merchantSettlementQueryService).getMerchantSettlementDetail(
+                MERCHANT_ID,
+                MERCHANT_ID,
+                "settlement-1"
+        );
     }
 
     @Test
     @DisplayName("Merchant 정산 리스트 조회 성공 시 200과 페이지 응답을 반환한다")
     void getMerchantSettlements_success() throws Exception {
-        MerchantSettlementListItemResponse item = new MerchantSettlementListItemResponse(
+        MerchantSettlementListItemResponse item1 = new MerchantSettlementListItemResponse(
                 "settlement-1",
                 LocalDate.of(2026, 3, 10),
                 SettlementStatus.READY,
                 10000L,
-                0L,
-                0L,
-                10000L,
+                1000L,
+                100L,
+                8900L,
                 LocalDateTime.of(2026, 3, 11, 10, 0)
         );
 
-        when(merchantSessionResolver.resolveMerchantId(any(HttpServletRequest.class)))
-                .thenReturn("merchant-1");
+        MerchantSettlementListItemResponse item2 = new MerchantSettlementListItemResponse(
+                "settlement-2",
+                LocalDate.of(2026, 3, 11),
+                SettlementStatus.PAID,
+                20000L,
+                2000L,
+                200L,
+                17800L,
+                LocalDateTime.of(2026, 3, 12, 11, 0)
+        );
 
+        when(sessionAuthProvider.getCurrentMerchantId()).thenReturn(MERCHANT_ID);
         when(merchantSettlementQueryService.getMerchantSettlements(
-                eq("merchant-1"),
-                eq("merchant-1"),
-                any()
-        )).thenReturn(new PageImpl<>(List.of(item), PageRequest.of(0, 20), 1));
+                eq(MERCHANT_ID),
+                eq(MERCHANT_ID),
+                eq(PageRequest.of(0, 20))
+        )).thenReturn(new PageImpl<>(List.of(item1, item2), PageRequest.of(0, 20), 2));
 
-        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", "merchant-1"))
+        mockMvc.perform(get("/api/merchants/{merchantId}/settlements", MERCHANT_ID)
+                        .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
+                        .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID)
+                        .param("page", "0")
+                        .param("size", "20"))
                 .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.content.length()").value(2))
                 .andExpect(jsonPath("$.content[0].settlementId").value("settlement-1"))
-                .andExpect(jsonPath("$.content[0].status").value("READY"));
+                .andExpect(jsonPath("$.content[0].baseDate").value("2026-03-10"))
+                .andExpect(jsonPath("$.content[0].status").value("READY"))
+                .andExpect(jsonPath("$.content[0].gross").value(10000))
+                .andExpect(jsonPath("$.content[0].fee").value(1000))
+                .andExpect(jsonPath("$.content[0].vat").value(100))
+                .andExpect(jsonPath("$.content[0].net").value(8900))
+                .andExpect(jsonPath("$.content[1].settlementId").value("settlement-2"))
+                .andExpect(jsonPath("$.content[1].status").value("PAID"))
+                .andExpect(jsonPath("$.number").value(0))
+                .andExpect(jsonPath("$.size").value(20))
+                .andExpect(jsonPath("$.totalElements").value(2));
+
+        verify(merchantSettlementQueryService).getMerchantSettlements(
+                MERCHANT_ID,
+                MERCHANT_ID,
+                PageRequest.of(0, 20)
+        );
     }
 }


### PR DESCRIPTION
What
- A4 정산 상세 응답에 `lastRequestId`를 추가했습니다.
- `audit_log`에서 `entityType=SETTLEMENT`, `entityId=settlementId` 기준 최신 `requestId`를 조회하도록 read 경로를 보강했습니다.
- A4 상세 응답 DTO / 서비스 / 조회 리포지토리를 함께 수정했습니다.
- 관련 테스트를 함께 보강했습니다.

Why
- 기존 프론트는 `requestId || lastRequestId` 구조로 Trace CTA를 연결하고 있었지만,
  A4 상세 응답에 requestId 계열 값이 없어 Trace 이동이 비어 있을 수 있었습니다.
- 이번 변경은 settlement 상세 화면에서 settlement 기준 Trace 이동을 보강하기 위한 목적입니다.

Implementation
- `findLatestSettlementRequestId(settlementId)` 조회 메서드를 추가했습니다.
- 조회 기준은 아래와 같습니다.
  - `audit_log.entity_type = SETTLEMENT`
  - `audit_log.entity_id = settlementId`
  - 정렬: `occurred_at desc`, `audit_id desc`
- 조회 결과가 없으면 `lastRequestId`는 `null` 허용입니다.

Notes
- 이번 변경 범위는 settlement audit 기준 최신 requestId 조회에 한정됩니다.
- hold/refund 등 다른 entity의 최신 운영 액션 전체를 집계하거나 병합 조회하지 않습니다.
- requestId 생성 정책이나 audit 적재 정책 자체는 변경하지 않았습니다.