### PR TITLE
feat: add confirmed filter to consumer C3 order query

### DIFF
--- a/server/src/main/java/com/settleops/domain/order/api/ConsumerOrderQueryController.java
+++ b/server/src/main/java/com/settleops/domain/order/api/ConsumerOrderQueryController.java
@@ -30,14 +30,19 @@ public class ConsumerOrderQueryController {
      * Consumer 주문/결제 목록 조회
      *
      * - status는 orders.status SoT 기준(CREATED, PAID)만 허용한다.
+     * - confirmed는 PAYMENT_CONFIRMED 이벤트 존재 여부 기준으로 필터링한다.
+     *   - CONFIRMED   : PAYMENT_CONFIRMED 이벤트 존재
+     *   - UNCONFIRMED : PAYMENT_CONFIRMED 이벤트 미존재
+     *   - ALL/null    : 조건 미적용
      * - 잘못된 status 입력은 400(BAD_REQUEST)로 처리된다.
      */
     @GetMapping
     public ConsumerOrderListResponse getOrders(
             @LoginConsumer String loginConsumerId,
             @RequestParam(required = false) OrderStatus status,
+            @RequestParam(required = false) String confirmed,
             @RequestParam(required = false) String keyword
     ) {
-        return consumerOrderQueryService.getOrders(loginConsumerId, status, keyword);
+        return consumerOrderQueryService.getOrders(loginConsumerId, status, confirmed, keyword);
     }
 }

--- a/server/src/main/java/com/settleops/domain/order/application/ConsumerOrderQueryService.java
+++ b/server/src/main/java/com/settleops/domain/order/application/ConsumerOrderQueryService.java
@@ -41,15 +41,20 @@ public class ConsumerOrderQueryService {
      * Consumer 주문/결제 목록 조회
      *
      * - status 필터는 orders.status SoT 기준을 그대로 사용한다.
-     * - paid/confirmed 같은 파생 필드는 응답 조립부에서 별도 기준을 따른다.
+     * - confirmed 필터는 PAYMENT_CONFIRMED 이벤트 존재 여부 기준으로 동작한다.
+     *   - CONFIRMED   : PAYMENT_CONFIRMED 이벤트 존재
+     *   - UNCONFIRMED : PAYMENT_CONFIRMED 이벤트 미존재
+     *   - ALL/null    : 조건 미적용
+     * - paid/confirmed 같은 파생 필드는 응답 조립부에서 동일 기준을 따른다.
      */
     public ConsumerOrderListResponse getOrders(
             String loginConsumer,
             OrderStatus status,
+            String confirmed,
             String keyword
     ) {
         return new ConsumerOrderListResponse(
-                consumerOrderQueryRepository.findConsumerOrders(loginConsumer, status, keyword)
+                consumerOrderQueryRepository.findConsumerOrders(loginConsumer, status, confirmed, keyword)
         );
     }
 

--- a/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepository.java
@@ -8,6 +8,7 @@ import com.settleops.domain.order.api.dto.ConsumerOrderListItemResponse;
 import com.settleops.domain.order.domain.OrderStatus;
 import com.settleops.domain.payment.domain.PaymentEventType;
 import com.settleops.domain.payment.domain.QPaymentEvent;
+import com.settleops.global.error.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
@@ -95,6 +96,7 @@ public class ConsumerOrderQueryRepository {
     public List<ConsumerOrderListItemResponse> findConsumerOrders(
             String buyerId,
             OrderStatus status,
+            String confirmed,
             String keyword
     ) {
         QPaymentEvent confirmedEvent = new QPaymentEvent("confirmedEvent");
@@ -104,6 +106,16 @@ public class ConsumerOrderQueryRepository {
 
         if (status != null) {
             condition.and(orders.status.eq(status));
+        }
+
+        if (StringUtils.hasText(confirmed) && !"ALL".equalsIgnoreCase(confirmed)) {
+            if ("CONFIRMED".equalsIgnoreCase(confirmed)) {
+                condition.and(confirmedEvent.occurredAt.isNotNull());
+            } else if ("UNCONFIRMED".equalsIgnoreCase(confirmed)) {
+                condition.and(confirmedEvent.occurredAt.isNull());
+            } else {
+                throw new BadRequestException("invalid confirmed filter");
+            }
         }
 
         if (StringUtils.hasText(keyword)) {

--- a/server/src/test/java/com/settleops/domain/order/api/ConsumerOrderQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/order/api/ConsumerOrderQueryControllerTest.java
@@ -15,7 +15,9 @@ import com.settleops.global.error.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
+
 import static org.mockito.BDDMockito.then;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -175,7 +177,7 @@ class ConsumerOrderQueryControllerTest {
         BDDMockito.given(sessionAuthProvider.getCurrentConsumerId())
                 .willReturn(loginConsumerId);
 
-        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, null))
+        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, null, null))
                 .willReturn(response);
 
         mockMvc.perform(get("/api/consumer/orders")
@@ -195,7 +197,7 @@ class ConsumerOrderQueryControllerTest {
 
         then(consumerOrderQueryService)
                 .should()
-                .getOrders(loginConsumerId, null, null);
+                .getOrders(loginConsumerId, null, null, null);
     }
 
     @Test
@@ -220,7 +222,7 @@ class ConsumerOrderQueryControllerTest {
         BDDMockito.given(sessionAuthProvider.getCurrentConsumerId())
                 .willReturn(loginConsumerId);
 
-        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, OrderStatus.PAID, null))
+        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, OrderStatus.PAID, null, null))
                 .willReturn(response);
 
         mockMvc.perform(get("/api/consumer/orders")
@@ -232,7 +234,44 @@ class ConsumerOrderQueryControllerTest {
 
         then(consumerOrderQueryService)
                 .should()
-                .getOrders(loginConsumerId, OrderStatus.PAID, null);
+                .getOrders(loginConsumerId, OrderStatus.PAID, null, null);
+    }
+
+    @Test
+    @DisplayName("주문 목록 조회 시 confirmed 파라미터를 서비스로 전달한다")
+    void getOrders_withConfirmedFilter() throws Exception {
+        String loginConsumerId = "buyer-1";
+
+        ConsumerOrderListResponse response = new ConsumerOrderListResponse(
+                List.of(
+                        new ConsumerOrderListItemResponse(
+                                "22222222-2222-2222-2222-222222222222",
+                                "에어팟 프로",
+                                35000L,
+                                OrderStatus.PAID,
+                                true,
+                                true,
+                                LocalDateTime.of(2026, 3, 19, 13, 0, 0)
+                        )
+                )
+        );
+
+        BDDMockito.given(sessionAuthProvider.getCurrentConsumerId())
+                .willReturn(loginConsumerId);
+
+        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, "CONFIRMED", null))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/consumer/orders")
+                        .param("confirmed", "CONFIRMED")
+                        .sessionAttr("LOGIN_CONSUMER", "dummy"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.items[0].orderId").value("22222222-2222-2222-2222-222222222222"))
+                .andExpect(jsonPath("$.items[0].confirmed").value(true));
+
+        then(consumerOrderQueryService)
+                .should()
+                .getOrders(loginConsumerId, null, "CONFIRMED", null);
     }
 
     @Test
@@ -271,7 +310,7 @@ class ConsumerOrderQueryControllerTest {
         BDDMockito.given(sessionAuthProvider.getCurrentConsumerId())
                 .willReturn(loginConsumerId);
 
-        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, "에어팟"))
+        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, null, "에어팟"))
                 .willReturn(response);
 
         mockMvc.perform(get("/api/consumer/orders")
@@ -283,7 +322,7 @@ class ConsumerOrderQueryControllerTest {
 
         then(consumerOrderQueryService)
                 .should()
-                .getOrders(loginConsumerId, null, "에어팟");
+                .getOrders(loginConsumerId, null, null, "에어팟");
     }
 
     @Test
@@ -294,7 +333,7 @@ class ConsumerOrderQueryControllerTest {
         BDDMockito.given(sessionAuthProvider.getCurrentConsumerId())
                 .willReturn(loginConsumerId);
 
-        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, null))
+        BDDMockito.given(consumerOrderQueryService.getOrders(loginConsumerId, null, null, null))
                 .willReturn(new ConsumerOrderListResponse(List.of()));
 
         mockMvc.perform(get("/api/consumer/orders")
@@ -305,6 +344,6 @@ class ConsumerOrderQueryControllerTest {
 
         then(consumerOrderQueryService)
                 .should()
-                .getOrders(loginConsumerId, null, null);
+                .getOrders(loginConsumerId, null, null, null);
     }
 }

--- a/server/src/test/java/com/settleops/domain/order/application/ConsumerOrderQueryServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/order/application/ConsumerOrderQueryServiceTest.java
@@ -149,12 +149,12 @@ class ConsumerOrderQueryServiceTest {
                 )
         );
 
-        given(consumerOrderQueryRepository.findConsumerOrders(loginConsumer, null, null))
+        given(consumerOrderQueryRepository.findConsumerOrders(loginConsumer, null, null, null))
                 .willReturn(items);
 
         // when
         ConsumerOrderListResponse result =
-                consumerOrderQueryService.getOrders(loginConsumer, null, null);
+                consumerOrderQueryService.getOrders(loginConsumer, null, null, null);
 
         // then
         assertThat(result.items()).hasSize(1);
@@ -166,7 +166,41 @@ class ConsumerOrderQueryServiceTest {
 
         then(consumerOrderQueryRepository)
                 .should()
-                .findConsumerOrders(loginConsumer, null, null);
+                .findConsumerOrders(loginConsumer, null, null, null);
+    }
+
+    @Test
+    @DisplayName("confirmed 필터를 repository로 그대로 전달한다")
+    void getOrders_withConfirmedFilter() {
+        // given
+        String loginConsumer = "buyer_2001";
+
+        List<ConsumerOrderListItemResponse> items = List.of(
+                new ConsumerOrderListItemResponse(
+                        "550e8400-e29b-41d4-a716-446655440010",
+                        "아이폰 14 프로",
+                        125000L,
+                        OrderStatus.PAID,
+                        true,
+                        true,
+                        LocalDateTime.of(2026, 3, 18, 10, 30, 0)
+                )
+        );
+
+        given(consumerOrderQueryRepository.findConsumerOrders(loginConsumer, null, "CONFIRMED", null))
+                .willReturn(items);
+
+        // when
+        ConsumerOrderListResponse result =
+                consumerOrderQueryService.getOrders(loginConsumer, null, "CONFIRMED", null);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).confirmed()).isTrue();
+
+        then(consumerOrderQueryRepository)
+                .should()
+                .findConsumerOrders(loginConsumer, null, "CONFIRMED", null);
     }
 
     @Test
@@ -175,18 +209,18 @@ class ConsumerOrderQueryServiceTest {
         // given
         String loginConsumer = "buyer_2001";
 
-        given(consumerOrderQueryRepository.findConsumerOrders(loginConsumer, null, null))
+        given(consumerOrderQueryRepository.findConsumerOrders(loginConsumer, null, null, null))
                 .willReturn(List.of());
 
         // when
         ConsumerOrderListResponse result =
-                consumerOrderQueryService.getOrders(loginConsumer, null, null);
+                consumerOrderQueryService.getOrders(loginConsumer, null, null, null);
 
         // then
         assertThat(result.items()).isEmpty();
 
         then(consumerOrderQueryRepository)
                 .should()
-                .findConsumerOrders(loginConsumer, null, null);
+                .findConsumerOrders(loginConsumer, null, null, null);
     }
 }

--- a/server/src/test/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/order/infra/ConsumerOrderQueryRepositoryTest.java
@@ -8,6 +8,7 @@ import com.settleops.domain.payment.domain.Payment;
 import com.settleops.domain.payment.domain.PaymentEvent;
 import com.settleops.domain.payment.infra.PaymentEventRepository;
 import com.settleops.domain.payment.infra.PaymentRepository;
+import com.settleops.global.error.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test-db")
@@ -162,7 +164,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(myBuyerId, null, null);
+                consumerOrderQueryRepository.findConsumerOrders(myBuyerId, null, null, null);
 
         // then
         assertThat(results).hasSize(2);
@@ -233,7 +235,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null);
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null, null);
 
         // then
         ConsumerOrderListItemResponse first = results.stream()
@@ -253,6 +255,179 @@ class ConsumerOrderQueryRepositoryTest {
         assertThat(second.orderStatus()).isEqualTo(OrderStatus.CREATED);
         assertThat(second.paid()).isFalse();
         assertThat(second.confirmed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("C3 목록 조회 시 confirmed=CONFIRMED 이면 confirmed=true row만 반환한다")
+    void findConsumerOrders_filterByConfirmedConfirmed() {
+        // given
+        String buyerId = "buyer_list_confirmed_filter";
+
+        Orders notConfirmedOrder = Orders.create("m_1001", buyerId, "아이폰 14 프로", 125000L);
+        Orders confirmedOrder = Orders.create("m_1001", buyerId, "에어팟 프로", 35000L);
+
+        ordersRepository.save(notConfirmedOrder);
+        ordersRepository.save(confirmedOrder);
+
+        Payment payment1 = Payment.create(
+                notConfirmedOrder.getOrderId(),
+                notConfirmedOrder.getMerchantId(),
+                notConfirmedOrder.getBuyerId(),
+                notConfirmedOrder.getAmount()
+        );
+        payment1.capture();
+        paymentRepository.save(payment1);
+
+        Payment payment2 = Payment.create(
+                confirmedOrder.getOrderId(),
+                confirmedOrder.getMerchantId(),
+                confirmedOrder.getBuyerId(),
+                confirmedOrder.getAmount()
+        );
+        payment2.capture();
+        paymentRepository.save(payment2);
+
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment1.getPaymentId(),
+                "11111111-1111-1111-1111-111111111111"
+        ));
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment2.getPaymentId(),
+                "22222222-2222-2222-2222-222222222222"
+        ));
+        paymentEventRepository.save(PaymentEvent.confirmed(
+                payment2.getPaymentId(),
+                "33333333-3333-3333-3333-333333333333"
+        ));
+
+        // when
+        List<ConsumerOrderListItemResponse> results =
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, "CONFIRMED", null);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).orderId()).isEqualTo(confirmedOrder.getOrderId());
+        assertThat(results.get(0).confirmed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("C3 목록 조회 시 confirmed=UNCONFIRMED 이면 confirmed=false row만 반환한다")
+    void findConsumerOrders_filterByConfirmedUnconfirmed() {
+        // given
+        String buyerId = "buyer_list_unconfirmed_filter";
+
+        Orders notConfirmedOrder = Orders.create("m_1001", buyerId, "아이폰 14 프로", 125000L);
+        Orders confirmedOrder = Orders.create("m_1001", buyerId, "에어팟 프로", 35000L);
+
+        ordersRepository.save(notConfirmedOrder);
+        ordersRepository.save(confirmedOrder);
+
+        Payment payment1 = Payment.create(
+                notConfirmedOrder.getOrderId(),
+                notConfirmedOrder.getMerchantId(),
+                notConfirmedOrder.getBuyerId(),
+                notConfirmedOrder.getAmount()
+        );
+        payment1.capture();
+        paymentRepository.save(payment1);
+
+        Payment payment2 = Payment.create(
+                confirmedOrder.getOrderId(),
+                confirmedOrder.getMerchantId(),
+                confirmedOrder.getBuyerId(),
+                confirmedOrder.getAmount()
+        );
+        payment2.capture();
+        paymentRepository.save(payment2);
+
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment1.getPaymentId(),
+                "11111111-1111-1111-1111-111111111111"
+        ));
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment2.getPaymentId(),
+                "22222222-2222-2222-2222-222222222222"
+        ));
+        paymentEventRepository.save(PaymentEvent.confirmed(
+                payment2.getPaymentId(),
+                "33333333-3333-3333-3333-333333333333"
+        ));
+
+        // when
+        List<ConsumerOrderListItemResponse> results =
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, "UNCONFIRMED", null);
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).orderId()).isEqualTo(notConfirmedOrder.getOrderId());
+        assertThat(results.get(0).confirmed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("C3 목록 조회 시 confirmed=ALL 이면 전체를 반환한다")
+    void findConsumerOrders_filterByConfirmedAll() {
+        // given
+        String buyerId = "buyer_list_all_filter";
+
+        Orders notConfirmedOrder = Orders.create("m_1001", buyerId, "아이폰 14 프로", 125000L);
+        Orders confirmedOrder = Orders.create("m_1001", buyerId, "에어팟 프로", 35000L);
+
+        ordersRepository.save(notConfirmedOrder);
+        ordersRepository.save(confirmedOrder);
+
+        Payment payment1 = Payment.create(
+                notConfirmedOrder.getOrderId(),
+                notConfirmedOrder.getMerchantId(),
+                notConfirmedOrder.getBuyerId(),
+                notConfirmedOrder.getAmount()
+        );
+        payment1.capture();
+        paymentRepository.save(payment1);
+
+        Payment payment2 = Payment.create(
+                confirmedOrder.getOrderId(),
+                confirmedOrder.getMerchantId(),
+                confirmedOrder.getBuyerId(),
+                confirmedOrder.getAmount()
+        );
+        payment2.capture();
+        paymentRepository.save(payment2);
+
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment1.getPaymentId(),
+                "11111111-1111-1111-1111-111111111111"
+        ));
+        paymentEventRepository.save(PaymentEvent.captured(
+                payment2.getPaymentId(),
+                "22222222-2222-2222-2222-222222222222"
+        ));
+        paymentEventRepository.save(PaymentEvent.confirmed(
+                payment2.getPaymentId(),
+                "33333333-3333-3333-3333-333333333333"
+        ));
+
+        // when
+        List<ConsumerOrderListItemResponse> results =
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, "ALL", null);
+
+        // then
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("C3 목록 조회 시 잘못된 confirmed 값이면 400 예외를 던진다")
+    void findConsumerOrders_filterByConfirmedInvalid() {
+        // given
+        String buyerId = "buyer_list_invalid_confirmed";
+
+        Orders order = Orders.create("m_1001", buyerId, "아이폰 14 프로", 125000L);
+        ordersRepository.save(order);
+
+        // when // then
+        assertThatThrownBy(() ->
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, "INVALID", null)
+        ).isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("invalid confirmed filter");
     }
 
     @Test
@@ -289,7 +464,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null);
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null, null);
 
         // then
         ConsumerOrderListItemResponse createdRow = results.stream()
@@ -325,7 +500,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(buyerId, OrderStatus.PAID, null);
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, OrderStatus.PAID, null, null);
 
         // then
         assertThat(results).hasSize(1);
@@ -348,7 +523,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, "에어팟");
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null, "에어팟");
 
         // then
         assertThat(results).hasSize(1);
@@ -371,7 +546,7 @@ class ConsumerOrderQueryRepositoryTest {
 
         // when
         List<ConsumerOrderListItemResponse> results =
-                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null);
+                consumerOrderQueryRepository.findConsumerOrders(buyerId, null, null, null);
 
         // then
         assertThat(results).hasSize(2);


### PR DESCRIPTION
What
- Consumer C3 주문/결제 목록 조회에 `confirmed` 필터를 추가했습니다.
- `ConsumerOrderQueryController`에서 `confirmed` query param을 수신하도록 변경했습니다.
- `ConsumerOrderQueryService` / `ConsumerOrderQueryRepository` 시그니처를 확장했습니다.
- repository 조회 조건에 confirmed predicate를 반영했습니다.
- 관련 controller / service / repository 테스트를 함께 수정 및 보강했습니다.

Why
- C3 기획상 검색 조건은 `status + confirmed + keyword` 조합을 사용합니다.
- 현재 응답 row의 `confirmed` 값 계산은 정상이나, 서버가 `confirmed` query param을 받지 않아 조회 필터가 적용되지 않는 상태였습니다.
- 조회 필터와 화면 표시가 모두 PAYMENT_CONFIRMED 이벤트 존재 여부 기준을 사용하도록 정합성을 맞추기 위해 수정했습니다.

Implementation
- `confirmed` 판정 기준
  - `CONFIRMED`   : PAYMENT_CONFIRMED 이벤트 존재
  - `UNCONFIRMED` : PAYMENT_CONFIRMED 이벤트 미존재
  - `ALL` / `null`: 조건 미적용
- 잘못된 `confirmed` 값은 `BadRequestException`으로 처리합니다.

Scope
- `ConsumerOrderQueryController`
- `ConsumerOrderQueryService`
- `ConsumerOrderQueryRepository`
- `ConsumerOrderQueryControllerTest`
- `ConsumerOrderQueryServiceTest`
- `ConsumerOrderQueryRepositoryTest`

Test
- `./gradlew test --tests "*ConsumerOrderQuery*"`
- `./gradlew test`

Notes
- 이번 변경은 C3 confirmed 필터 서버 지원 범위에 한정됩니다.
- 프론트의 confirmed select/UI 주석 해제 및 화면 확인은 develop 반영 후 별도 진행 예정입니다.