### PR TITLE
feat(c1): 주문 생성 preview 모달 및 buyerId 표시 전용화

### DIFF
--- a/admin-web/src/api/consumerOrderApi.js
+++ b/admin-web/src/api/consumerOrderApi.js
@@ -1,10 +1,11 @@
 import { requestJson } from "./http.js";
 
-export function createConsumerOrder({ merchantId, itemName, amount }) {
+export function createConsumerOrder({ merchantId, buyerId, itemName, amount }) {
   return requestJson("/api/consumer/orders", {
     method: "POST",
     body: JSON.stringify({
       merchantId,
+      buyerId,
       itemName,
       amount,
     }),

--- a/admin-web/src/api/consumerOrderApi.js
+++ b/admin-web/src/api/consumerOrderApi.js
@@ -1,10 +1,14 @@
 import { requestJson } from "./http.js";
 
-export function createConsumerOrder(payload) {
-    return requestJson("/api/consumer/orders", {
-        method: "POST",
-        body: JSON.stringify(payload),
-    });
+export function createConsumerOrder({ merchantId, itemName, amount }) {
+  return requestJson("/api/consumer/orders", {
+    method: "POST",
+    body: JSON.stringify({
+      merchantId,
+      itemName,
+      amount,
+    }),
+  });
 }
 
 // order detail page load TODO: (C3페이지 에서 C2페이지 호출)

--- a/admin-web/src/pages/consumer/OrderCreatePage.jsx
+++ b/admin-web/src/pages/consumer/OrderCreatePage.jsx
@@ -83,6 +83,7 @@ export default function OrderCreatePage() {
 
     async function handleConfirmCreate() {
         const merchantId = form.merchantId.trim();
+        const buyerId = form.buyerId.trim();
         const itemName = form.itemName.trim();
         const amount = Number(form.amount.trim());
 
@@ -93,6 +94,7 @@ export default function OrderCreatePage() {
         try {
             const response = await createConsumerOrder({
                 merchantId,
+                buyerId,
                 itemName,
                 amount,
             });

--- a/admin-web/src/pages/consumer/OrderCreatePage.jsx
+++ b/admin-web/src/pages/consumer/OrderCreatePage.jsx
@@ -1,9 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
 import ActionButton from "../../components/layout/ActionButton.jsx";
-import StatusBadge from "../../components/display/StatusBadge.jsx";
 import { createConsumerOrder } from "../../api/consumerOrderApi.js";
+import OrderCreatePreviewModal from "./OrderCreatePreviewModal.jsx";
+import { getMe } from "../../api/meApi.js";
 
 const INITIAL_FORM = {
     merchantId: "",
@@ -16,7 +18,11 @@ export default function OrderCreatePage() {
     const [form, setForm] = useState(INITIAL_FORM);
     const [loading, setLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
-    const [result, setResult] = useState(null);
+    const [previewOpen, setPreviewOpen] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [meLoading, setMeLoading] = useState(true);
+
+    const navigate = useNavigate();
 
     function handleChange(event) {
         const { name, value } = event.target;
@@ -27,92 +33,171 @@ export default function OrderCreatePage() {
         }));
 
         setErrorMessage("");
-        setResult(null);
     }
 
-    async function handleSubmit(e) {
-        e.preventDefault();
-        setErrorMessage("");
-        setResult(null);
-
+    function validateForm() {
         const merchantId = form.merchantId.trim();
-        const buyerId = form.buyerId.trim();
         const itemName = form.itemName.trim();
         const rawAmount = form.amount.trim();
 
-        if (!merchantId || !buyerId || !itemName || !rawAmount) {
-            setErrorMessage("모든 값을 입력해야 합니다.");
-            return;
+        if (!form.buyerId.trim()) {
+            return "로그인 사용자 정보를 먼저 확인해야 합니다.";
+        }
+
+        if (!merchantId || !itemName || !rawAmount) {
+            return "merchantId, 상품/주문명, amount를 입력해야 합니다.";
         }
 
         if (!/^\d+$/.test(rawAmount)) {
-            setErrorMessage("amount는 KRW 정수(원)만 입력 가능합니다.");
-            return;
+            return "amount는 정수만 입력 가능합니다.";
         }
 
         const amount = Number(rawAmount);
-
         if (!Number.isSafeInteger(amount) || amount <= 0) {
-            setErrorMessage("amount는 1원 이상의 정수여야 합니다.");
+            return "amount는 1 이상의 정수여야 합니다.";
+        }
+
+        return "";
+    }
+
+    function handleSubmit(event) {
+        event.preventDefault();
+
+        const validationMessage = validateForm();
+        if (validationMessage) {
+            setErrorMessage(validationMessage);
             return;
         }
 
+        setErrorMessage("");
+        setPreviewOpen(true);
+    }
+
+    function handleClosePreview() {
+        if (submitting) {
+            return;
+        }
+
+        setPreviewOpen(false);
+    }
+
+    async function handleConfirmCreate() {
+        const merchantId = form.merchantId.trim();
+        const itemName = form.itemName.trim();
+        const amount = Number(form.amount.trim());
+
+        setSubmitting(true);
         setLoading(true);
+        setErrorMessage("");
 
         try {
             const response = await createConsumerOrder({
                 merchantId,
-                buyerId,
                 itemName,
                 amount,
             });
 
-            setResult(response);
-            setForm(INITIAL_FORM);
+            setPreviewOpen(false);
+            setForm((prev) => ({
+                ...INITIAL_FORM,
+                buyerId: prev.buyerId,
+            }));
+            navigate(`/consumer/orders/${response.orderId}`);
         } catch (error) {
-            setErrorMessage(error?.body?.message || "주문 생성에 실패했습니다.");
+            setPreviewOpen(false);
+            setErrorMessage(
+                error?.body?.message ||
+                error?.body?.reason ||
+                "주문 생성에 실패했습니다."
+            );
         } finally {
+            setSubmitting(false);
             setLoading(false);
         }
     }
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function fetchMe() {
+            try {
+                const response = await getMe();
+
+                if (cancelled) {
+                    return;
+                }
+
+                setForm((prev) => ({
+                    ...prev,
+                    buyerId: response.buyerId ?? "",
+                }));
+
+                if (!response.buyerId) {
+                    setErrorMessage("로그인 사용자 식별자(buyerId)를 확인할 수 없습니다.");
+                }
+            } catch (error) {
+                if (cancelled) {
+                    return;
+                }
+
+                setErrorMessage("로그인 사용자 정보를 불러오지 못했습니다.");
+            } finally {
+                if (!cancelled) {
+                    setMeLoading(false);
+                }
+            }
+        }
+
+        fetchMe();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
     return (
         <PageLayout
             title="거래 생성"
             description="seed 거래 최소 스펙만 입력합니다."
         >
-            <SectionCard>
+            <SectionCard title="주문 생성">
                 <form className="form-stack" onSubmit={handleSubmit}>
                     <div className="form-field">
-                        <label>merchantId</label>
+                        <label className="form-field__label">merchantId</label>
                         <input
+                            className="input"
                             name="merchantId"
                             value={form.merchantId}
                             onChange={handleChange}
+                            placeholder="MERCHANT_1001"
                         />
                     </div>
 
                     <div className="form-field">
-                        <label>buyerId</label>
+                        <label className="form-field__label">buyerId</label>
                         <input
+                            className="input"
                             name="buyerId"
                             value={form.buyerId}
-                            onChange={handleChange}
+                            readOnly
                         />
                     </div>
 
                     <div className="form-field">
-                        <label>itemName</label>
+                        <label className="form-field__label">상품/주문명</label>
                         <input
+                            className="input"
                             name="itemName"
                             value={form.itemName}
                             onChange={handleChange}
+                            placeholder="쿠쿠 밥솥 20년 모델"
                         />
                     </div>
 
                     <div className="form-field">
-                        <label>amount</label>
+                        <label className="form-field__label">amount</label>
                         <input
+                            className="input"
                             name="amount"
                             type="number"
                             step="1"
@@ -120,29 +205,29 @@ export default function OrderCreatePage() {
                             inputMode="numeric"
                             value={form.amount}
                             onChange={handleChange}
+                            placeholder="15000"
                         />
                     </div>
 
-                    {errorMessage ? <div className="state-error">{errorMessage}</div> : null}
+                    {errorMessage ? (
+                        <div className="state-error">{errorMessage}</div>
+                    ) : null}
 
                     <div className="button-row">
-                        <ActionButton type="submit" disabled={loading}>
+                        <ActionButton type="submit" disabled={loading || submitting || meLoading || !form.buyerId}>
                             {loading ? "생성 중..." : "주문 생성"}
                         </ActionButton>
                     </div>
                 </form>
             </SectionCard>
 
-            {result ? (
-                <SectionCard>
-                    <div className="info-list">
-                        <div><strong>orderId</strong> {result.orderId}</div>
-                        <div><strong>shortId</strong> {result.orderId?.slice(0, 8)}</div>
-                        <div><strong>status</strong> <StatusBadge status={result.status} /></div>
-                        <div><strong>amount</strong> {result.amount}</div>
-                    </div>
-                </SectionCard>
-            ) : null}
+            <OrderCreatePreviewModal
+                open={previewOpen}
+                form={form}
+                submitting={submitting}
+                onClose={handleClosePreview}
+                onConfirm={handleConfirmCreate}
+            />
         </PageLayout>
     );
 }

--- a/admin-web/src/pages/consumer/OrderCreatePreviewModal.jsx
+++ b/admin-web/src/pages/consumer/OrderCreatePreviewModal.jsx
@@ -1,0 +1,133 @@
+import ActionButton from "../../components/layout/ActionButton.jsx";
+import InfoRow from "../../components/display/InfoRow.jsx";
+import AmountText from "../../components/display/AmountText.jsx";
+
+export default function OrderCreatePreviewModal({
+                                                    open,
+                                                    form,
+                                                    submitting,
+                                                    onClose,
+                                                    onConfirm,
+                                                }) {
+    if (!open) {
+        return null;
+    }
+
+    function handleBackdropClick(e) {
+        if (e.target === e.currentTarget) {
+            onClose?.();
+        }
+    }
+
+    return (
+        <div className="app-modal-backdrop" onClick={handleBackdropClick}>
+            <div className="app-modal">
+
+                <div className="app-modal__header">
+                    <h2 className="app-modal__title">
+                        주문신청 내역 확인
+                    </h2>
+
+                    <button
+                        type="button"
+                        className="app-modal__close"
+                        onClick={onClose}
+                        disabled={submitting}
+                    >
+                        닫기
+                    </button>
+                </div>
+
+                <div className="app-modal__body">
+
+                    <div className="form-stack">
+
+                        <div className="guard-notice">
+                            <div className="guard-notice__title">
+                                미리보기
+                            </div>
+
+                            <div className="guard-notice__description">
+                                아래 내용으로 주문신청(seed 생성)하시겠습니까?
+                            </div>
+                        </div>
+
+
+                        <div className="kv-list">
+
+                            <InfoRow label="merchantId">
+                                <span className="display-field">
+                                    {form.merchantId || "-"}
+                                </span>
+                            </InfoRow>
+
+                            <InfoRow label="상품/주문명">
+                                <span className="display-field">
+                                    {form.itemName || "-"}
+                                </span>
+                            </InfoRow>
+
+                            <InfoRow label="amount">
+                                <AmountText
+                                    value={
+                                        form.amount
+                                            ? Number(form.amount)
+                                            : ""
+                                    }
+                                />
+                            </InfoRow>
+
+                            <InfoRow label="buyerId">
+                                <span className="display-field">
+                                    {form.buyerId || "-"}
+                                </span>
+                            </InfoRow>
+
+                        </div>
+
+
+                        <div className="guard-notice">
+                            <div className="guard-notice__description">
+                                주의: 본 화면은 비멱등 seed이며,
+                                중복 생성이 허용됩니다.
+                                실제 결제 승인/상태 변경은
+                                다음 화면에서 수행됩니다.
+                            </div>
+                        </div>
+
+                    </div>
+
+                </div>
+
+
+                <div className="app-modal__footer">
+
+                    <div className="button-row">
+
+                        <ActionButton
+                            type="button"
+                            variant="secondary"
+                            onClick={onClose}
+                            disabled={submitting}
+                        >
+                            수정
+                        </ActionButton>
+
+                        <ActionButton
+                            type="button"
+                            onClick={onConfirm}
+                            disabled={submitting}
+                        >
+                            {submitting
+                                ? "생성 중..."
+                                : "맞습니다. 주문신청"}
+                        </ActionButton>
+
+                    </div>
+
+                </div>
+
+            </div>
+        </div>
+    );
+}

--- a/admin-web/src/style/state.css
+++ b/admin-web/src/style/state.css
@@ -66,3 +66,63 @@
   opacity: 1;
   transform: translateX(-50%) translateY(0);
 }
+
+.app-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 24px;
+
+  background: rgba(17, 24, 39, 0.45);
+}
+
+.app-modal {
+  width: min(640px, 100%);
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+
+  border: 1px solid var(--color-border);
+  border-radius: 20px;
+  background: var(--color-surface);
+
+  box-shadow: var(--shadow-sm);
+}
+
+.app-modal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding: 20px 24px 16px;
+
+  border-bottom: 1px solid var(--color-border);
+}
+
+.app-modal__title {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+}
+
+.app-modal__close {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+
+  padding: 4px 10px;
+
+  background: var(--color-surface);
+  cursor: pointer;
+}
+
+.app-modal__body {
+  padding: 20px 24px;
+}
+
+.app-modal__footer {
+  padding: 16px 24px 24px;
+  border-top: 1px solid var(--color-border);
+}


### PR DESCRIPTION
## What
C1 주문 생성 전 미리보기 모달 추가
modal/backdrop 스타일 추가

주문 생성 요청 body 구조 정리
초기 수정에서 merchantId, itemName, amount 최소 스펙으로 정리했으나,
현재 서버 CreateOrderRequestDTO 및 최신 기획서 기준 C1 최소 필드에 buyerId가 포함되어 있어
buyerId를 /api/me 기반 자동완성 + readOnly 표시 유지하면서
create 요청 body에 다시 포함하도록 수정

getMe 응답 fallback 체인 제거 후 buyerId 단일 키 사용
생성 완료 후 C2 상세(/consumer/orders/{orderId})로 이동 유지

## Why
C1 seed 생성 화면을 기획서 LOCKED 범위에 맞게 정리하기 위해
주문 생성 전 미리보기 단계를 추가해 비멱등 seed 생성임을 명확히 하기 위해
C1은 seed 생성만 담당하고 실제 결제 승인/상태 변경은 C2에서 수행한다는 규칙을 UI에 반영하기 위해
/api/me 기반 자동완성 구조로 사용자 식별 표시를 통일하기 위해

초기 수정에서 buyerId를 body에서 제거했으나,
현재 서버 DTO(CreateOrderRequestDTO)와 최신 기획서 C1 최소 필드 정의에 맞추기 위해
buyerId를 create 요청에 다시 포함하도록 정합성 수정

## Scope
Consumer C1 주문 생성 화면 범위

OrderCreatePage.jsx
OrderCreatePreviewModal.jsx
consumerOrderApi.js
공통 modal 스타일(css)

백엔드 API / DTO / 예외 포맷 변경 없음
기존 PR 위 추가 수정