### PR TITLE
refactor(admin-web): polish CopyableId and InfoRow components

### DIFF
--- a/admin-web/src/components/display/CopyableId.jsx
+++ b/admin-web/src/components/display/CopyableId.jsx
@@ -2,44 +2,52 @@ import { copyText } from "../../utils/copyText.js";
 import { showToast } from "../../utils/toast.js";
 
 export default function CopyableId({
-                                       value,
-                                       short = false,
-                                   }) {
+    value,
+    short = false,
+    className = "",
+    disabled = false,
+    title,
+    buttonLabel = "복사",
+    emptyText = "-",
+}) {
     if (!value) {
-        return <span>-</span>;
+        return <span>{emptyText}</span>;
     }
 
     async function handleCopy(event) {
         event.preventDefault();
         event.stopPropagation();
 
+        if (disabled) return;
+
         try {
-            await copyText(value);
+            await copyText(String(value));
             showToast("복사 완료");
         } catch (error) {
             console.error("copy failed", error);
         }
     }
 
+    const resolvedTitle = title ?? String(value);
+    const textClassName = short
+        ? "copyable-id__text copyable-id__text--short"
+        : "copyable-id__text";
+
     return (
-        <span className="copyable-id" title={value}>
-            <span
-                className={
-                    short
-                        ? "copyable-id__text copyable-id__text--short"
-                        : "copyable-id__text"
-                }
-            >
-                {value}
-            </span>
+        <span
+            className={`copyable-id ${className}`.trim()}
+            title={resolvedTitle}
+        >
+            <span className={textClassName}>{String(value)}</span>
 
             <button
                 type="button"
                 className="copyable-id__button"
                 onClick={handleCopy}
                 aria-label="ID 복사"
+                disabled={disabled}
             >
-                복사
+                {buttonLabel}
             </button>
         </span>
     );

--- a/admin-web/src/components/display/InfoRow.jsx
+++ b/admin-web/src/components/display/InfoRow.jsx
@@ -1,8 +1,59 @@
-export default function InfoRow({ label, children }) {
+import StatusBadge from "../display/StatusBadge.jsx";
+import CopyableId from "../display/CopyableId.jsx";
+
+export default function InfoRow({
+    label,
+    value,
+    children,
+    copyable = false,
+    status = false,
+    emptyText = "-",
+    columns = "160px 1fr",
+    className = "",
+}) {
+    let content = children ?? value;
+
+    if (content === null || content === undefined || content === "") {
+        content = emptyText;
+    }
+
+    if (copyable && content !== emptyText) {
+        content = <CopyableId value={content} short />;
+    } else if (status && content !== emptyText) {
+        content = <StatusBadge status={content} />;
+    }
+
     return (
-        <div className="kv-item">
-            <div className="kv-item__label">{label}</div>
-            <div className="kv-item__value">{children}</div>
+        <div
+            className={`kv-item ${className}`.trim()}
+            style={{
+                display: "grid",
+                gridTemplateColumns: columns,
+                gap: "12px",
+                alignItems: "start",
+                padding: "6px 0",
+            }}
+        >
+            <div
+                className="kv-item__label"
+                style={{
+                    color: "var(--color-text-muted, #6b7280)",
+                    fontWeight: 600,
+                    lineHeight: 1.5,
+                }}
+            >
+                {label}
+            </div>
+
+            <div
+                className="kv-item__value"
+                style={{
+                    lineHeight: 1.5,
+                    minWidth: 0,
+                }}
+            >
+                {content}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## 변경 내용
- CopyableId 공통 컴포넌트 구조/표시 방식 정리
- InfoRow 공통 컴포넌트 구조 정리
- display 계열 공통 컴포넌트 사용성을 높이기 위한 최소 범위 리팩터링

## 목적
- 페이지별 로컬 표시 로직을 줄이고 공통 display 컴포넌트 재사용성을 높이기 위함
- admin/merchant 화면에서 ID 표시와 정보 row 표현의 일관성을 맞추기 위함

## 범위
- admin-web/src/components/display/CopyableId.jsx
- admin-web/src/components/display/InfoRow.jsx

## 비고
- 전역 디자인 리뉴얼이 아니라 기존 화면 정합을 유지하는 범위의 공통 컴포넌트 보정입니다.
- 페이지별 상세 레이아웃 변경은 별도 브랜치/PR에서 다루는 것을 전제로 했습니다.