### PR TITLE
refactor(frontend): remove direct axios usage from pages

### DIFF
--- a/admin-web/src/api/adminBatchApi.js
+++ b/admin-web/src/api/adminBatchApi.js
@@ -1,0 +1,33 @@
+import { requestJson } from "./http.js";
+
+function buildQueryString(params) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : "";
+}
+
+export function getSettlementBatchHistory(params) {
+  return requestJson(
+    `/api/admin/settlement-batches/history${buildQueryString(params)}`,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export function runSettlementBatch(baseDate) {
+  return requestJson(
+    `/api/admin/settlement-batches/run${buildQueryString({ baseDate })}`,
+    {
+      method: "POST",
+    }
+  );
+}

--- a/admin-web/src/api/adminSettlementApi.js
+++ b/admin-web/src/api/adminSettlementApi.js
@@ -1,0 +1,22 @@
+import { requestJson } from "./http.js";
+
+export function getAdminSettlementDetail(settlementId, options = {}) {
+  return requestJson(`/api/admin/settlements/${settlementId}`, {
+    method: "GET",
+    signal: options.signal,
+  });
+}
+
+export function getAdminSettlementTraceEntry(settlementId, options = {}) {
+  return requestJson(`/api/admin/settlements/${settlementId}/trace-entry`, {
+    method: "GET",
+    signal: options.signal,
+  });
+}
+
+export function requestAdminSettlementPaid(settlementId) {
+  return requestJson(`/api/admin/settlements/${settlementId}/request-paid`, {
+    method: "PATCH",
+    body: JSON.stringify({}),
+  });
+}

--- a/admin-web/src/api/adminSettlementListApi.js
+++ b/admin-web/src/api/adminSettlementListApi.js
@@ -1,0 +1,21 @@
+import { requestJson } from "./http.js";
+
+function buildQueryString(params) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : "";
+}
+
+export function getAdminSettlements(params = {}) {
+  return requestJson(`/api/admin/settlements${buildQueryString(params)}`, {
+    method: "GET",
+  });
+}

--- a/admin-web/src/api/consumerOrderApi.js
+++ b/admin-web/src/api/consumerOrderApi.js
@@ -12,9 +12,11 @@ export function createConsumerOrder({ merchantId, buyerId, itemName, amount }) {
   });
 }
 
-// order detail page load TODO: (C3페이지 에서 C2페이지 호출)
+// C2 상세
 export function getConsumerOrderDetail(orderId) {
-  return requestJson(`/api/consumer/orders/${orderId}`);
+  return requestJson(`/api/consumer/orders/${orderId}`, {
+    method: "GET",
+  });
 }
 
 // C3 목록
@@ -42,5 +44,7 @@ export function getConsumerOrders({
     ? `/api/consumer/orders?${queryString}`
     : `/api/consumer/orders`;
 
-  return requestJson(url);
+  return requestJson(url, {
+    method: "GET",
+  });
 }

--- a/admin-web/src/api/merchantSettlementApi.js
+++ b/admin-web/src/api/merchantSettlementApi.js
@@ -1,0 +1,40 @@
+import { requestJson } from "./http.js";
+
+function buildQueryString(params) {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === "") {
+      return;
+    }
+    searchParams.set(key, String(value));
+  });
+
+  const query = searchParams.toString();
+  return query ? `?${query}` : "";
+}
+
+export function getMerchantSettlements(merchantId, params = {}) {
+  return requestJson(
+    `/api/merchants/${encodeURIComponent(merchantId)}/settlements${buildQueryString(params)}`,
+    {
+      method: "GET",
+    }
+  );
+}
+
+export function getMerchantSettlementDetail(
+  merchantId,
+  settlementId,
+  options = {}
+) {
+  return requestJson(
+    `/api/merchants/${encodeURIComponent(
+      merchantId
+    )}/settlements/${encodeURIComponent(settlementId)}`,
+    {
+      method: "GET",
+      signal: options.signal,
+    }
+  );
+}

--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -14,6 +13,10 @@ import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 
 import { formatDateTimeWithSeconds } from "../../utils/format.js";
+import {
+  getSettlementBatchHistory,
+  runSettlementBatch,
+} from "../../api/adminBatchApi.js";
 
 function formatDate(date) {
   return date.toISOString().slice(0, 10);
@@ -41,10 +44,10 @@ function normalizeHistoryPayload(data) {
 }
 
 function buildErrorMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -211,20 +214,14 @@ export default function BatchPage() {
       setErrorMessage("");
 
       try {
-        const response = await axios.get(
-          "/api/admin/settlement-batches/history",
-          {
-            withCredentials: true,
-            params: {
-              from: queryFrom,
-              to: queryTo,
-              page: 0,
-              size: 20,
-            },
-          }
-        );
+        const data = await getSettlementBatchHistory({
+          from: queryFrom,
+          to: queryTo,
+          page: 0,
+          size: 20,
+        });
 
-        const normalized = normalizeHistoryPayload(response.data);
+        const normalized = normalizeHistoryPayload(data);
         setHistoryRows(normalized.rows);
         setHistoryTotal(normalized.totalElements);
       } catch (error) {
@@ -266,16 +263,9 @@ export default function BatchPage() {
       setErrorMessage("");
       setRunResult(null);
 
-      const response = await axios.post(
-        "/api/admin/settlement-batches/run",
-        null,
-        {
-          withCredentials: true,
-          params: { baseDate },
-        }
-      );
+      const data = await runSettlementBatch(baseDate);
 
-      setRunResult(response.data || null);
+      setRunResult(data || null);
       await fetchHistory();
     } catch (error) {
       console.error("A2 배치 실행 실패", error);

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -8,6 +7,11 @@ import StatusBadge from "../../components/display/StatusBadge.jsx";
 import GuardNotice from "../../components/common/GuardNotice.jsx";
 import CopyableId from "../../components/display/CopyableId.jsx";
 import InfoRow from "../../components/display/InfoRow.jsx";
+import {
+  getAdminSettlementDetail,
+  getAdminSettlementTraceEntry,
+  requestAdminSettlementPaid,
+} from "../../api/adminSettlementApi.js";
 
 function formatAmount(value) {
   if (value === null || value === undefined || value === "") return "-";
@@ -17,10 +21,10 @@ function formatAmount(value) {
 }
 
 function mapDetailErrorToMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -51,10 +55,10 @@ function mapRequestPaidReasonToMessage(reason) {
 }
 
 function mapTraceEntryErrorToMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -128,17 +132,10 @@ export default function SettlementDetailAdminPage() {
         setLoading(true);
         setLoadError("");
 
-        const response = await axios.get(
-          `/api/admin/settlements/${settlementId}`,
-          {
-            withCredentials: true,
-            signal,
-          }
-        );
-
-        setDetail(response.data || null);
+        const data = await getAdminSettlementDetail(settlementId, { signal });
+        setDetail(data || null);
       } catch (error) {
-        if (error?.name === "CanceledError" || error?.code === "ERR_CANCELED") {
+        if (error?.name === "AbortError" || error?.code === "ERR_CANCELED") {
           return;
         }
         setDetail(null);
@@ -157,18 +154,12 @@ export default function SettlementDetailAdminPage() {
         setTraceEntryError("");
         setTraceRequestId("");
 
-        const response = await axios.get(
-          `/api/admin/settlements/${settlementId}/trace-entry`,
-          {
-            withCredentials: true,
-            signal,
-          }
-        );
+        const data = await getAdminSettlementTraceEntry(settlementId, { signal });
 
         const requestId =
-          response?.data?.traceRequestId ||
-          response?.data?.requestId ||
-          response?.data?.resolvedRequestId ||
+          data?.traceRequestId ||
+          data?.requestId ||
+          data?.resolvedRequestId ||
           "";
 
         if (!requestId) {
@@ -181,7 +172,7 @@ export default function SettlementDetailAdminPage() {
 
         setTraceRequestId(requestId);
       } catch (error) {
-        if (error?.name === "CanceledError" || error?.code === "ERR_CANCELED") {
+        if (error?.name === "AbortError" || error?.code === "ERR_CANCELED") {
           return;
         }
         setTraceRequestId("");
@@ -280,17 +271,13 @@ export default function SettlementDetailAdminPage() {
       setActionMessage("");
       setActionError("");
 
-      await axios.patch(
-        `/api/admin/settlements/${detail.settlementId}/request-paid`,
-        {},
-        { withCredentials: true }
-      );
+      await requestAdminSettlementPaid(detail.settlementId);
 
       setActionMessage("지급 요청이 완료되었습니다.");
       await reloadPageData();
     } catch (error) {
-      const statusCode = error?.response?.status;
-      const reason = error?.response?.data?.reason;
+      const statusCode = error?.status;
+      const reason = error?.body?.reason;
 
       if (statusCode === 401) {
         setActionError(

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, Link, useSearchParams } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -12,6 +11,7 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import { formatNumber } from "../../utils/format.js";
+import { getAdminSettlements } from "../../api/adminSettlementListApi.js";
 
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
@@ -37,10 +37,10 @@ function normalizeSettlementList(payload) {
 }
 
 function buildErrorMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -86,12 +86,8 @@ export default function SettlementManagePage() {
         if (nextStatus) params.status = nextStatus;
         if (nextMerchantId.trim()) params.merchantId = nextMerchantId.trim();
 
-        const response = await axios.get("/api/admin/settlements", {
-          withCredentials: true,
-          params,
-        });
-
-        setRows(normalizeSettlementList(response.data));
+        const data = await getAdminSettlements(params);
+        setRows(normalizeSettlementList(data));
       } catch (error) {
         console.error("정산 리스트 조회 실패", error);
         setRows([]);

--- a/admin-web/src/pages/consumer/MyOrdersPage.jsx
+++ b/admin-web/src/pages/consumer/MyOrdersPage.jsx
@@ -1,8 +1,5 @@
-// admin-web/src/pages/consumer/MyOrdersPage.jsx
-
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -14,6 +11,7 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import { formatDateTime } from "../../utils/format.js";
+import { getConsumerOrders } from "../../api/consumerOrderApi.js";
 
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
@@ -37,10 +35,10 @@ function normalizeOrderList(payload) {
 }
 
 function buildErrorMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -122,12 +120,8 @@ export default function MyOrdersPage() {
       const params = {};
       if (nextStatus) params.status = nextStatus;
 
-      const response = await axios.get("/api/consumer/orders", {
-        withCredentials: true,
-        params,
-      });
-
-      setRows(normalizeOrderList(response.data));
+      const data = await getConsumerOrders(params);
+      setRows(normalizeOrderList(data));
     } catch (error) {
       console.error("C3 주문/결제 내역 조회 실패", error);
       setRows([]);

--- a/admin-web/src/pages/merchant/SettlementDetailPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementDetailPage.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -8,6 +7,8 @@ import StatusBadge from "../../components/display/StatusBadge.jsx";
 import CopyableId from "../../components/display/CopyableId.jsx";
 import InfoRow from "../../components/display/InfoRow.jsx";
 import GuardNotice from "../../components/common/GuardNotice.jsx";
+import { getMe } from "../../api/meApi.js";
+import { getMerchantSettlementDetail } from "../../api/merchantSettlementApi.js";
 
 function formatAmount(value) {
   if (value === null || value === undefined || value === "") return "-";
@@ -17,10 +18,10 @@ function formatAmount(value) {
 }
 
 function mapDetailErrorToMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -73,11 +74,8 @@ export default function SettlementDetailPage() {
   const [loadError, setLoadError] = useState("");
 
   const fetchMerchantId = useCallback(async () => {
-    const response = await axios.get("/api/me", {
-      withCredentials: true,
-    });
-
-    const resolvedMerchantId = extractMerchantId(response.data);
+    const response = await getMe();
+    const resolvedMerchantId = extractMerchantId(response);
 
     if (!resolvedMerchantId) {
       throw new Error("세션에서 merchantId를 확인할 수 없습니다.");
@@ -95,19 +93,15 @@ export default function SettlementDetailPage() {
         const resolvedMerchantId = merchantId || (await fetchMerchantId());
         setMerchantId(resolvedMerchantId);
 
-        const response = await axios.get(
-          `/api/merchants/${encodeURIComponent(
-            resolvedMerchantId
-          )}/settlements/${settlementId}`,
-          {
-            withCredentials: true,
-            signal,
-          }
+        const data = await getMerchantSettlementDetail(
+          resolvedMerchantId,
+          settlementId,
+          { signal }
         );
 
-        setDetail(response.data || null);
+        setDetail(data || null);
       } catch (error) {
-        if (error?.name === "CanceledError" || error?.code === "ERR_CANCELED") {
+        if (error?.name === "AbortError" || error?.code === "ERR_CANCELED") {
           return;
         }
         setDetail(null);

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -1,8 +1,5 @@
-// /admin-web/src/pages/merchant/SettlementListPage.jsx
-
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import axios from "axios";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
@@ -14,6 +11,8 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import { formatNumber } from "../../utils/format.js";
+import { getMe } from "../../api/meApi.js";
+import { getMerchantSettlements } from "../../api/merchantSettlementApi.js";
 
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
@@ -63,10 +62,10 @@ function extractMerchantId(payload) {
 }
 
 function buildErrorMessage(error) {
-  const status = error?.response?.status;
+  const status = error?.status;
   const message =
-    error?.response?.data?.message ||
-    error?.response?.data?.reason ||
+    error?.body?.message ||
+    error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
@@ -107,11 +106,8 @@ export default function SettlementListPage() {
   const pageTitle = useMemo(() => "정산 리스트", []);
 
   const fetchMerchantId = useCallback(async () => {
-    const response = await axios.get("/api/me", {
-      withCredentials: true,
-    });
-
-    const resolvedMerchantId = extractMerchantId(response.data);
+    const response = await getMe();
+    const resolvedMerchantId = extractMerchantId(response);
 
     if (!resolvedMerchantId) {
       throw new Error("세션에서 merchantId를 확인할 수 없습니다.");
@@ -134,15 +130,8 @@ export default function SettlementListPage() {
         if (nextFromDate) params.from = nextFromDate;
         if (nextToDate) params.to = nextToDate;
 
-        const response = await axios.get(
-          `/api/merchants/${encodeURIComponent(resolvedMerchantId)}/settlements`,
-          {
-            withCredentials: true,
-            params,
-          }
-        );
-
-        setRows(normalizeSettlementList(response.data));
+        const data = await getMerchantSettlements(resolvedMerchantId, params);
+        setRows(normalizeSettlementList(data));
       } catch (error) {
         console.error("U4 정산 리스트 조회 실패", error);
         setRows([]);


### PR DESCRIPTION
## 변경 내용
- 페이지 컴포넌트에서 direct axios import 제거
- admin / merchant / consumer 페이지 요청을 api 레이어로 분리
- 공통 requestJson 기반으로 호출 경로 통일
- 에러 처리 구조를 axios response 기준에서 requestJson(error.status / error.body) 기준으로 정리

## 대상 화면
- A2 BatchPage
- A3 SettlementManagePage
- A4 SettlementDetailAdminPage
- C3 MyOrdersPage
- U4 SettlementListPage
- U5 SettlementDetailPage

## 추가된 API 파일
- adminBatchApi.js
- adminSettlementApi.js
- adminSettlementListApi.js
- merchantSettlementApi.js

## 확인 사항
- 페이지 라우팅 및 조회/상세 이동 정상 동작 확인
- direct axios import 제거 기준으로 정리