### PR TITLE
[A1/A5] 공통 유틸 적용, Admin 권한 가드, A4 연계 및 기획서 누락사항 최종 정합 반영

### DIFF
--- a/admin-web/src/components/audit/AuditLogRowExpand.jsx
+++ b/admin-web/src/components/audit/AuditLogRowExpand.jsx
@@ -1,24 +1,5 @@
-// src/components/AuditLogRowExpand.jsx
-function formatDateTime(value) {
-  if (!value) return "-";
-
-  try {
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return value;
-
-    return new Intl.DateTimeFormat("ko-KR", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).format(date);
-  } catch {
-    return value;
-  }
-}
+import CopyableId from "../display/CopyableId.jsx";
+import { formatDateTimeWithSeconds } from "../../utils/format.js";
 
 function prettyJson(value) {
   if (!value) return "{}";
@@ -53,7 +34,7 @@ function EventRow({ event }) {
         }}
       >
         <div>
-          <strong>시각</strong> {formatDateTime(event?.occurredAt)}
+          <strong>시각</strong> {formatDateTimeWithSeconds(event?.occurredAt)}
         </div>
         <div>
           <strong>이벤트</strong> {event?.eventType || "-"}
@@ -62,7 +43,7 @@ function EventRow({ event }) {
           <strong>엔티티</strong> {event?.entityType || "-"}
         </div>
         <div>
-          <strong>엔티티 ID</strong> {event?.entityId || "-"}
+          <strong>엔티티 ID</strong> <CopyableId value={event?.entityId} />
         </div>
         <div>
           <strong>상태 변경</strong>{" "}
@@ -143,10 +124,11 @@ export default function AuditLogRowExpand({
           }}
         >
           <div>
-            <strong>requestId</strong> {item?.requestId || "-"}
+            <strong>requestId</strong> <CopyableId value={item?.requestId} />
           </div>
           <div>
-            <strong>occurredAt</strong> {formatDateTime(item?.occurredAt)}
+            <strong>occurredAt</strong>{" "}
+            {formatDateTimeWithSeconds(item?.occurredAt)}
           </div>
           <div>
             <strong>actorType</strong> {item?.actorType || "-"}
@@ -161,7 +143,7 @@ export default function AuditLogRowExpand({
             <strong>entityType</strong> {item?.entityType || "-"}
           </div>
           <div>
-            <strong>entityId</strong> {item?.entityId || "-"}
+            <strong>entityId</strong> <CopyableId value={item?.entityId} />
           </div>
           <div>
             <strong>merchantId</strong> {item?.merchantId || "-"}
@@ -206,7 +188,7 @@ export default function AuditLogRowExpand({
         <div style={{ marginBottom: "12px" }}>
           <strong>관련 이벤트</strong>
           <div style={{ marginTop: "6px", color: "#6b7280", fontSize: "14px" }}>
-            requestId: {eventRequestId || item?.requestId || "-"}
+            requestId: <CopyableId value={eventRequestId || item?.requestId} />
           </div>
         </div>
 

--- a/admin-web/src/components/audit/AuditLogTable.jsx
+++ b/admin-web/src/components/audit/AuditLogTable.jsx
@@ -1,21 +1,5 @@
-function formatDateTime(value) {
-  if (!value) return "-";
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  const hh = String(date.getHours()).padStart(2, "0");
-  const mi = String(date.getMinutes()).padStart(2, "0");
-  const ss = String(date.getSeconds()).padStart(2, "0");
-
-  return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`;
-}
+import Pagination from "../../components/table/Pagination.jsx";
+import { formatDateTimeWithSeconds } from "../../utils/format.js";
 
 function buildActorLabel(item) {
   const actorType = item?.actorType || "-";
@@ -52,16 +36,6 @@ export default function AuditLogTable({
   const startRow = totalElements === 0 ? 0 : page * size + 1;
   const endRow =
     totalElements === 0 ? 0 : Math.min((page + 1) * size, totalElements);
-
-  function handlePrevPage() {
-    if (page <= 0) return;
-    onPageChange?.(page - 1);
-  }
-
-  function handleNextPage() {
-    if (page >= totalPages - 1) return;
-    onPageChange?.(page + 1);
-  }
 
   return (
     <>
@@ -115,7 +89,7 @@ export default function AuditLogTable({
                       backgroundColor: isSelected ? "#F8FAFC" : "",
                     }}
                   >
-                    <td>{formatDateTime(item?.occurredAt)}</td>
+                    <td>{formatDateTimeWithSeconds(item?.occurredAt)}</td>
                     <td>{buildActorLabel(item)}</td>
                     <td>{item?.action || "-"}</td>
                     <td>{item?.entityType || "-"}</td>
@@ -128,29 +102,12 @@ export default function AuditLogTable({
         </table>
       </div>
 
-      <div className="pagination">
-        <button
-          type="button"
-          className="btn btn--secondary"
-          onClick={handlePrevPage}
-          disabled={loading || page <= 0}
-        >
-          이전
-        </button>
-
-        <button type="button" className="btn btn--primary" disabled>
-          {totalPages === 0 ? 0 : page + 1}
-        </button>
-
-        <button
-          type="button"
-          className="btn btn--secondary"
-          onClick={handleNextPage}
-          disabled={loading || totalPages === 0 || page >= totalPages - 1}
-        >
-          다음
-        </button>
-      </div>
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+        disabled={loading}
+      />
 
       <div className="table-toolbar" style={{ marginTop: "12px" }}>
         <div>

--- a/admin-web/src/components/hold/HoldDetailPanel.jsx
+++ b/admin-web/src/components/hold/HoldDetailPanel.jsx
@@ -1,35 +1,12 @@
-function formatDateTime(value) {
-  if (!value) return "-";
+import CopyableId from "../display/CopyableId.jsx";
+import { formatDateTimeWithSeconds } from "../../utils/format.js";
 
-  try {
-    const date = new Date(value);
-
-    if (Number.isNaN(date.getTime())) {
-      return value;
-    }
-
-    return new Intl.DateTimeFormat("ko-KR", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).format(date);
-  } catch {
-    return value;
-  }
-}
-
-function buildApproveDisabled(item, actionLoading) {
-  if (!item || actionLoading) return true;
-  return false;
-}
-
-function buildReleaseDisabled(item, actionLoading) {
-  if (!item || actionLoading) return true;
-  return false;
+function InfoItem({ label, children }) {
+  return (
+    <div>
+      <strong>{label}</strong> {children}
+    </div>
+  );
 }
 
 export default function HoldDetailPanel({
@@ -43,117 +20,106 @@ export default function HoldDetailPanel({
 }) {
   if (!item) {
     return (
-      <div className="info-list">
-        <div>
-          <strong>상세 패널</strong> 좌측 Hold row를 선택해 주세요.
-        </div>
-        <div>
-          <strong>표시 기준</strong> A5는 hold 1건 = row 1개입니다.
-        </div>
-        <div>
-          <strong>연결 조회</strong> payment 정보는 A4 정산 상세에서 확인합니다.
+      <div
+        style={{
+          border: "1px solid #e5e7eb",
+          borderRadius: "12px",
+          padding: "16px",
+          background: "#fff",
+        }}
+      >
+        <strong>Hold 상세</strong>
+        <div style={{ marginTop: "8px", color: "#6b7280" }}>
+          좌측에서 Hold row를 선택해 주세요.
         </div>
       </div>
     );
   }
 
   return (
-    <div className="page-section">
-      <div className="table-toolbar">
-        <div>Hold 상세</div>
-        <div className="action-panel">
-          <span className="badge badge--default">A5</span>
-          <span className="badge badge--primary">hold 기준</span>
-        </div>
+    <div
+      style={{
+        border: "1px solid #e5e7eb",
+        borderRadius: "12px",
+        padding: "16px",
+        background: "#fff",
+      }}
+    >
+      <div style={{ marginBottom: "12px" }}>
+        <strong>Hold 상세</strong>
       </div>
 
-      <div className="kv-list">
-        <div className="kv-item">
-          <div className="kv-item__label">holdId</div>
-          <div className="kv-item__value">
-            <span className="display-field copyable-id__text">
-              {item?.holdId || "-"}
-            </span>
-          </div>
-        </div>
+      <div
+        style={{
+          display: "grid",
+          gap: "8px",
+        }}
+      >
+        <InfoItem label="holdId">
+          <CopyableId value={item?.holdId} />
+        </InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">settlementId</div>
-          <div className="kv-item__value">
-            <span className="display-field copyable-id__text">
-              {item?.settlementId || "-"}
-            </span>
-          </div>
-        </div>
+        <InfoItem label="settlementId">
+          <CopyableId value={item?.settlementId} />
+        </InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">merchantId</div>
-          <div className="kv-item__value">
-            <span className="display-field">{item?.merchantId || "-"}</span>
-          </div>
-        </div>
+        <InfoItem label="merchantId">
+          <CopyableId value={item?.merchantId} />
+        </InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">status</div>
-          <div className="kv-item__value">
-            <span className="display-field">{item?.status || "-"}</span>
-          </div>
-        </div>
+        <InfoItem label="status">{item?.status || "-"}</InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">reasonCode</div>
-          <div className="kv-item__value">
-            <span className="display-field">{item?.reasonCode || "-"}</span>
-          </div>
-        </div>
+        <InfoItem label="reasonCode">{item?.reasonCode || "-"}</InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">createdAt</div>
-          <div className="kv-item__value">
-            <span className="display-field">
-              {formatDateTime(item?.createdAt)}
-            </span>
-          </div>
-        </div>
+        <InfoItem label="createdAt">
+          {formatDateTimeWithSeconds(item?.createdAt)}
+        </InfoItem>
 
-        <div className="kv-item">
-          <div className="kv-item__label">requestedComment</div>
-          <div className="kv-item__value">
-            <span className="display-field">{item?.requestedComment || "-"}</span>
-          </div>
-        </div>
+        <InfoItem label="requestedComment">
+          {item?.requestedComment || "-"}
+        </InfoItem>
       </div>
 
-      <div className="guard-notice" style={{ marginTop: "16px" }}>
-        <div className="guard-notice__title">운영 규칙</div>
-        <div className="guard-notice__description">
-          A5 목록은 hold 단위로만 보여주고, payment 연결 정보는 A4 정산 상세에서
+      <div
+        style={{
+          marginTop: "16px",
+          padding: "12px",
+          border: "1px solid #f1f5f9",
+          borderRadius: "8px",
+          background: "#fff7ed",
+          color: "#9a3412",
+          fontSize: "14px",
+          lineHeight: 1.5,
+        }}
+      >
+        <strong>운영 규칙</strong>
+        <div style={{ marginTop: "6px" }}>
+          A5 목록은 hold 단위로 보여주고, payment 연결 정보는 A4 정산 상세에서
           조회합니다.
         </div>
       </div>
 
-      {actionErrorMessage && (
-        <div className="info-list" style={{ marginTop: "16px" }}>
-          <div>
-            <strong>오류</strong> {actionErrorMessage}
-          </div>
-        </div>
-      )}
-
       {actionSuccessMessage && (
-        <div className="info-list" style={{ marginTop: "16px" }}>
-          <div>
-            <strong>완료</strong> {actionSuccessMessage}
-          </div>
+        <div style={{ marginTop: "16px", color: "#166534" }}>
+          {actionSuccessMessage}
         </div>
       )}
 
-      <div className="action-panel" style={{ marginTop: "16px" }}>
+      {actionErrorMessage && (
+        <div style={{ marginTop: "16px", color: "#b91c1c" }}>
+          {actionErrorMessage}
+        </div>
+      )}
+
+      <div
+        className="action-panel"
+        style={{ marginTop: "20px", display: "flex", gap: "8px", flexWrap: "wrap" }}
+      >
         <button
           type="button"
           className="btn btn--primary"
-          disabled={buildApproveDisabled(item, actionLoading)}
-          onClick={() => onApprove?.()}
+          onClick={onApprove}
+          disabled={actionLoading}
         >
           {actionLoading ? "처리 중..." : "Approve"}
         </button>
@@ -161,8 +127,8 @@ export default function HoldDetailPanel({
         <button
           type="button"
           className="btn btn--secondary"
-          disabled={buildReleaseDisabled(item, actionLoading)}
-          onClick={() => onRelease?.()}
+          onClick={onRelease}
+          disabled={actionLoading}
         >
           {actionLoading ? "처리 중..." : "Release"}
         </button>
@@ -170,8 +136,8 @@ export default function HoldDetailPanel({
         <button
           type="button"
           className="btn btn--secondary"
-          onClick={() => onMoveSettlementDetail?.(item?.settlementId)}
-          disabled={!item?.settlementId || actionLoading}
+          onClick={onMoveSettlementDetail}
+          disabled={!item?.settlementId}
         >
           A4 정산 상세로 이동
         </button>

--- a/admin-web/src/components/hold/HoldTable.jsx
+++ b/admin-web/src/components/hold/HoldTable.jsx
@@ -1,21 +1,6 @@
-function formatDateTime(value) {
-  if (!value) return "-";
-
-  const date = new Date(value);
-
-  if (Number.isNaN(date.getTime())) {
-    return value;
-  }
-
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, "0");
-  const dd = String(date.getDate()).padStart(2, "0");
-  const hh = String(date.getHours()).padStart(2, "0");
-  const mi = String(date.getMinutes()).padStart(2, "0");
-  const ss = String(date.getSeconds()).padStart(2, "0");
-
-  return `${yyyy}-${mm}-${dd} ${hh}:${mi}:${ss}`;
-}
+import Pagination from "../table/Pagination.jsx";
+import CopyableId from "../display/CopyableId.jsx";
+import { formatDateTimeWithSeconds } from "../../utils/format.js";
 
 function buildRowKey(item, index) {
   return `${item?.holdId ?? "hold"}-${index}`;
@@ -37,16 +22,6 @@ export default function HoldTable({
   const startRow = totalElements === 0 ? 0 : page * size + 1;
   const endRow =
     totalElements === 0 ? 0 : Math.min((page + 1) * size, totalElements);
-
-  function handlePrevPage() {
-    if (page <= 0) return;
-    onPageChange?.(page - 1);
-  }
-
-  function handleNextPage() {
-    if (page >= totalPages - 1) return;
-    onPageChange?.(page + 1);
-  }
 
   return (
     <>
@@ -99,18 +74,29 @@ export default function HoldTable({
                       backgroundColor: isSelected ? "#F8FAFC" : "",
                     }}
                   >
-                    <td>{formatDateTime(item?.createdAt)}</td>
-                    <td>
-                      <span className="copyable-id__text">
-                        {item?.holdId || "-"}
-                      </span>
+                    <td>{formatDateTimeWithSeconds(item?.createdAt)}</td>
+
+                    <td
+                      onClick={(event) => event.stopPropagation()}
+                      style={{ verticalAlign: "middle" }}
+                    >
+                      <CopyableId value={item?.holdId} short />
                     </td>
-                    <td>
-                      <span className="copyable-id__text">
-                        {item?.settlementId || "-"}
-                      </span>
+
+                    <td
+                      onClick={(event) => event.stopPropagation()}
+                      style={{ verticalAlign: "middle" }}
+                    >
+                      <CopyableId value={item?.settlementId} short />
                     </td>
-                    <td>{item?.merchantId || "-"}</td>
+
+                    <td
+                      onClick={(event) => event.stopPropagation()}
+                      style={{ verticalAlign: "middle" }}
+                    >
+                      <CopyableId value={item?.merchantId} short />
+                    </td>
+
                     <td>{item?.status || "-"}</td>
                     <td>{item?.reasonCode || "-"}</td>
                     <td>{item?.requestedComment || "-"}</td>
@@ -121,29 +107,12 @@ export default function HoldTable({
         </table>
       </div>
 
-      <div className="pagination">
-        <button
-          type="button"
-          className="btn btn--secondary"
-          onClick={handlePrevPage}
-          disabled={loading || page <= 0}
-        >
-          이전
-        </button>
-
-        <button type="button" className="btn btn--primary" disabled>
-          {totalPages === 0 ? 0 : page + 1}
-        </button>
-
-        <button
-          type="button"
-          className="btn btn--secondary"
-          onClick={handleNextPage}
-          disabled={loading || totalPages === 0 || page >= totalPages - 1}
-        >
-          다음
-        </button>
-      </div>
+      <Pagination
+        page={page}
+        totalPages={totalPages}
+        onPageChange={onPageChange}
+        disabled={loading}
+      />
 
       <div className="table-toolbar" style={{ marginTop: "12px" }}>
         <div>

--- a/admin-web/src/pages/admin/AdminAuditPage.jsx
+++ b/admin-web/src/pages/admin/AdminAuditPage.jsx
@@ -7,6 +7,8 @@ import AuditLogTable from "../../components/audit/AuditLogTable.jsx";
 import AuditLogRowExpand from "../../components/audit/AuditLogRowExpand.jsx";
 import { fetchAuditLogs } from "../../api/auditLogsApi.js";
 import { fetchAuditEvents } from "../../api/auditEventsApi.js";
+import { getMe } from "../../api/meApi.js";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
 
 const DEFAULT_PAGE = 0;
 const DEFAULT_SIZE = 20;
@@ -60,7 +62,6 @@ function buildRowKey(item, index) {
   return `${item?.auditId ?? "audit"}-${index}`;
 }
 
-// 최소 수정: date 입력값을 API 호출 직전에만 LocalDateTime 문자열로 변환
 function toFromDateTime(dateValue) {
   if (!dateValue) return undefined;
   return `${dateValue}T00:00:00`;
@@ -71,11 +72,39 @@ function toToDateTime(dateValue) {
   return `${dateValue}T23:59:59`;
 }
 
+function isAdminRole(me) {
+  if (!me) return false;
+
+  if (me.role === "ADMIN" || me.role === "ROLE_ADMIN") {
+    return true;
+  }
+
+  if (Array.isArray(me.authorities) && me.authorities.includes("ROLE_ADMIN")) {
+    return true;
+  }
+
+  return false;
+}
+
+function buildErrorInfo(error, fallbackMessage) {
+  return {
+    status: error?.status ?? null,
+    message:
+      error?.body?.message ||
+      error?.body?.reason ||
+      fallbackMessage,
+  };
+}
+
 export default function AdminAuditPage() {
   const location = useLocation();
   const navigate = useNavigate();
 
   const queryState = useMemo(() => parseQuery(location.search), [location.search]);
+
+  const [me, setMe] = useState(null);
+  const [meLoading, setMeLoading] = useState(true);
+  const [meErrorInfo, setMeErrorInfo] = useState(null);
 
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
@@ -90,6 +119,49 @@ export default function AdminAuditPage() {
   const items = Array.isArray(result.items) ? result.items : [];
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function loadMe() {
+      try {
+        setMeLoading(true);
+        setMeErrorInfo(null);
+
+        const meData = await getMe();
+
+        if (cancelled) return;
+
+        setMe(meData);
+
+        if (!isAdminRole(meData)) {
+          setMeErrorInfo({
+            status: 403,
+            message: "Admin 권한이 필요한 페이지입니다.",
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+
+        setMe(null);
+        setMeErrorInfo(buildErrorInfo(error, "권한 정보를 불러오지 못했습니다."));
+      } finally {
+        if (!cancelled) {
+          setMeLoading(false);
+        }
+      }
+    }
+
+    loadMe();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (meLoading || meErrorInfo || !isAdminRole(me)) {
+      return;
+    }
+
     if (!hasSearchKey) {
       setResult(EMPTY_RESULT);
       setErrorMessage("");
@@ -142,7 +214,7 @@ export default function AdminAuditPage() {
     return () => {
       cancelled = true;
     };
-  }, [hasSearchKey, queryState]);
+  }, [meLoading, meErrorInfo, me, hasSearchKey, queryState]);
 
   useEffect(() => {
     if (items.length === 0) {
@@ -174,6 +246,10 @@ export default function AdminAuditPage() {
   }, [items, selectedRowKey]);
 
   useEffect(() => {
+    if (meLoading || meErrorInfo || !isAdminRole(me)) {
+      return;
+    }
+
     const selectedRequestId = selectedItem?.requestId || result.requestId;
 
     if (!selectedItem || !selectedRequestId) {
@@ -212,7 +288,7 @@ export default function AdminAuditPage() {
     return () => {
       cancelled = true;
     };
-  }, [selectedItem, result.requestId]);
+  }, [meLoading, meErrorInfo, me, selectedItem, result.requestId]);
 
   function handleSearch(formValues) {
     const nextQuery = buildQuery({
@@ -241,6 +317,65 @@ export default function AdminAuditPage() {
 
   function handleSelectItem(rowKey) {
     setSelectedRowKey(rowKey);
+  }
+
+  if (meLoading) {
+    return (
+      <PageLayout
+        title="Trace / Audit"
+        description="A1 운영대시. requestId 또는 merchantId 기준으로 요청 단위 재현 타임라인을 조회합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">로딩 중</div>
+          <div className="guard-notice__description">
+            권한 정보를 확인하는 중입니다.
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo?.status === 401) {
+    return (
+      <PageLayout
+        title="Trace / Audit"
+        description="A1 운영대시. requestId 또는 merchantId 기준으로 요청 단위 재현 타임라인을 조회합니다."
+      >
+        <RequireLoginNotice />
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo?.status === 403) {
+    return (
+      <PageLayout
+        title="Trace / Audit"
+        description="A1 운영대시. requestId 또는 merchantId 기준으로 요청 단위 재현 타임라인을 조회합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            {meErrorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo) {
+    return (
+      <PageLayout
+        title="Trace / Audit"
+        description="A1 운영대시. requestId 또는 merchantId 기준으로 요청 단위 재현 타임라인을 조회합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">조회 실패</div>
+          <div className="guard-notice__description">
+            {meErrorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
   }
 
   return (
@@ -301,7 +436,6 @@ export default function AdminAuditPage() {
                 items={items}
                 requestId={result.requestId}
                 page={result.page ?? DEFAULT_PAGE}
-                size={result.size ?? DEFAULT_SIZE}
                 totalElements={result.totalElements ?? 0}
                 totalPages={result.totalPages ?? 0}
                 visibleCount={items.length}

--- a/admin-web/src/pages/admin/AdminHoldPage.jsx
+++ b/admin-web/src/pages/admin/AdminHoldPage.jsx
@@ -10,6 +10,9 @@ import {
   approveHold,
   releaseHold,
 } from "../../api/holdsApi.js";
+import { showToast } from "../../utils/toast.js";
+import { getMe } from "../../api/meApi.js";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
 
 const DEFAULT_PAGE = 0;
 const DEFAULT_SIZE = 20;
@@ -51,11 +54,39 @@ function buildRowKey(item, index) {
   return `${item?.holdId ?? "hold"}-${index}`;
 }
 
+function isAdminRole(me) {
+  if (!me) return false;
+
+  if (me.role === "ADMIN" || me.role === "ROLE_ADMIN") {
+    return true;
+  }
+
+  if (Array.isArray(me.authorities) && me.authorities.includes("ROLE_ADMIN")) {
+    return true;
+  }
+
+  return false;
+}
+
+function buildErrorInfo(error, fallbackMessage) {
+  return {
+    status: error?.status ?? null,
+    message:
+      error?.body?.message ||
+      error?.body?.reason ||
+      fallbackMessage,
+  };
+}
+
 export default function AdminHoldPage() {
   const location = useLocation();
   const navigate = useNavigate();
 
   const queryState = useMemo(() => parseQuery(location.search), [location.search]);
+
+  const [me, setMe] = useState(null);
+  const [meLoading, setMeLoading] = useState(true);
+  const [meErrorInfo, setMeErrorInfo] = useState(null);
 
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
@@ -69,6 +100,49 @@ export default function AdminHoldPage() {
   const items = Array.isArray(result.items) ? result.items : [];
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function loadMe() {
+      try {
+        setMeLoading(true);
+        setMeErrorInfo(null);
+
+        const meData = await getMe();
+
+        if (cancelled) return;
+
+        setMe(meData);
+
+        if (!isAdminRole(meData)) {
+          setMeErrorInfo({
+            status: 403,
+            message: "Admin 권한이 필요한 페이지입니다.",
+          });
+        }
+      } catch (error) {
+        if (cancelled) return;
+
+        setMe(null);
+        setMeErrorInfo(buildErrorInfo(error, "권한 정보를 불러오지 못했습니다."));
+      } finally {
+        if (!cancelled) {
+          setMeLoading(false);
+        }
+      }
+    }
+
+    loadMe();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (meLoading || meErrorInfo || !isAdminRole(me)) {
+      return;
+    }
+
     let cancelled = false;
 
     async function loadHolds() {
@@ -106,7 +180,7 @@ export default function AdminHoldPage() {
     return () => {
       cancelled = true;
     };
-  }, [queryState]);
+  }, [meLoading, meErrorInfo, me, queryState]);
 
   useEffect(() => {
     if (items.length === 0) {
@@ -183,14 +257,23 @@ export default function AdminHoldPage() {
       setActionErrorMessage("");
       setActionSuccessMessage("");
 
-      await approveHold(selectedItem.holdId, "");
+      const response = await approveHold(selectedItem.holdId, "");
 
       await reloadCurrentPage();
-      setActionSuccessMessage("Hold 승인 처리가 완료되었습니다.");
+
+      const message =
+        response?.status === "HOLD_ACTIVE"
+          ? "Hold 승인 처리가 완료되었습니다."
+          : "Hold 처리 결과를 확인해 주세요.";
+
+      setActionSuccessMessage(message);
+      showToast(message);
     } catch (error) {
-      setActionErrorMessage(
-        error?.body?.message || "Hold 승인 중 오류가 발생했습니다."
-      );
+      const message =
+        error?.body?.message || "Hold 승인 중 오류가 발생했습니다.";
+
+      setActionErrorMessage(message);
+      showToast(message);
     } finally {
       setActionLoading(false);
     }
@@ -204,14 +287,23 @@ export default function AdminHoldPage() {
       setActionErrorMessage("");
       setActionSuccessMessage("");
 
-      await releaseHold(selectedItem.holdId, "");
+      const response = await releaseHold(selectedItem.holdId, "");
 
       await reloadCurrentPage();
-      setActionSuccessMessage("Hold 해제 처리가 완료되었습니다.");
+
+      const message =
+        response?.status === "RELEASED"
+          ? "Hold 해제 처리가 완료되었습니다."
+          : "Hold 처리 결과를 확인해 주세요.";
+
+      setActionSuccessMessage(message);
+      showToast(message);
     } catch (error) {
-      setActionErrorMessage(
-        error?.body?.message || "Hold 해제 중 오류가 발생했습니다."
-      );
+      const message =
+        error?.body?.message || "Hold 해제 중 오류가 발생했습니다.";
+
+      setActionErrorMessage(message);
+      showToast(message);
     } finally {
       setActionLoading(false);
     }
@@ -220,6 +312,65 @@ export default function AdminHoldPage() {
   function handleMoveSettlementDetail() {
     if (!selectedItem?.settlementId) return;
     navigate(`/admin/settlements/${selectedItem.settlementId}`);
+  }
+
+  if (meLoading) {
+    return (
+      <PageLayout
+        title="Hold Queue"
+        description="A5 운영통제 큐. Hold 목록을 조회하고 승인/해제를 수행합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">로딩 중</div>
+          <div className="guard-notice__description">
+            권한 정보를 확인하는 중입니다.
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo?.status === 401) {
+    return (
+      <PageLayout
+        title="Hold Queue"
+        description="A5 운영통제 큐. Hold 목록을 조회하고 승인/해제를 수행합니다."
+      >
+        <RequireLoginNotice />
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo?.status === 403) {
+    return (
+      <PageLayout
+        title="Hold Queue"
+        description="A5 운영통제 큐. Hold 목록을 조회하고 승인/해제를 수행합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            {meErrorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo) {
+    return (
+      <PageLayout
+        title="Hold Queue"
+        description="A5 운영통제 큐. Hold 목록을 조회하고 승인/해제를 수행합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">조회 실패</div>
+          <div className="guard-notice__description">
+            {meErrorInfo.message}
+          </div>
+        </div>
+      </PageLayout>
+    );
   }
 
   return (

--- a/server/src/main/java/com/settleops/global/audit/AuditLogger.java
+++ b/server/src/main/java/com/settleops/global/audit/AuditLogger.java
@@ -40,8 +40,7 @@ public class AuditLogger {
         }
 
         if (cmd.getAction() == null) throw new BadRequestException("action is null");
-        if (cmd.getActorType() == null) throw new BadRequestException("actorType is null");
-        validateActorId(cmd.getActorId());
+        validateActor(cmd.getActorType(), cmd.getActorId());
 
         if (cmd.getEntityType() == null) throw new BadRequestException("entityType is null");
         if (cmd.getEntityId() == null || cmd.getEntityId().isBlank()) {
@@ -49,14 +48,29 @@ public class AuditLogger {
         }
     }
 
-    private void validateActorId(String actorId) {
-        if (actorId == null) throw new BadRequestException("actorId is null");
-        if (actorId.isBlank()) throw new BadRequestException("actorId is blank");
+    private void validateActor(ActorType actorType, String actorId) {
+        if (actorType == null) {
+            throw new BadRequestException("actorType is null");
+        }
+
+        if (actorId == null) {
+            throw new BadRequestException("actorId is null");
+        }
+
+        if (actorId.isBlank()) {
+            throw new BadRequestException("actorId is blank");
+        }
+
         if (actorId.length() > ACTOR_ID_MAX) {
             throw new BadRequestException("actorId too long (max 32)");
         }
+
         if (actorId.chars().anyMatch(ch -> ch <= 0x20 || ch >= 0x7F)) {
             throw new BadRequestException("actorId must be ASCII without whitespace");
+        }
+
+        if (actorType == ActorType.SYSTEM && !"SYSTEM".equals(actorId)) {
+            throw new BadRequestException("SYSTEM actorType requires actorId=SYSTEM");
         }
     }
 

--- a/server/src/main/java/com/settleops/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/settleops/global/config/SecurityConfig.java
@@ -72,6 +72,7 @@ public class SecurityConfig {
             auth.requestMatchers("/error", "/api/health").permitAll();
             auth.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll();
             auth.requestMatchers("/api/auth/**", "/api/me").permitAll();
+            auth.requestMatchers("/api/admin/**").hasRole("ADMIN");
             auth.anyRequest().authenticated();
         });
 


### PR DESCRIPTION
## What
- A1 / A5 화면에 공통 유틸 적용
  - Pagination 적용
  - CopyableId 공통 컴포넌트 적용
  - showToast 적용
  - formatDateTimeWithSeconds 적용
- Admin 화면 접근 시 권한 가드 추가
  - 프론트: getMe 기반 Admin role 확인
  - 백엔드: /api/admin/** -> hasRole("ADMIN") 적용
- A4 <-> A1, A4 <-> A5 연결 정합 보완
  - A4에서 Trace(A1) 이동 흐름 점검
  - A4에서 Hold Queue(A5) 이동 흐름 점검
  - A5에서 settlementId 기준 A4 상세 이동 정합 반영
- Audit / Trace 응답 계약 정리
  - AuditTraceRowDto에 requestId 포함
  - A1 상세 패널에서 row 단위 requestId 사용 가능하도록 정리
  - includeNoOp 파라미터 전파 정합 보완
- AuditLogger 검증 보강
  - actorType / actorId 검증 강화
  - SYSTEM actorType일 때 actorId=SYSTEM 규칙 반영
- 기획서 기준 누락/정합성 최종 점검 반영
  - no-op audit metaJson.noOp / noOpReason 규칙 재확인
  - AuditLogger 단일 진입점 유지 여부 점검
  - @LoginAdmin resolver / WebConfig 등록 여부 점검

## Why
- Admin 화면들이 공통 UI 규칙과 운영 재현 규칙을 동일 기준으로 따르도록 맞추기 위해
- 비관리자 세션에서 admin 화면/API가 노출되는 문제를 차단하기 위해
- A4를 운영 허브로 두고 A1 Trace / A5 Hold Queue로 이어지는 흐름을 기획서 기준으로 고정하기 위해
- Audit/Trace 응답 계약과 no-op 처리 규칙을 문서/코드/화면 모두 동일 기준으로 맞추기 위해

## Scope
- admin-web
  - AdminAuditPage
  - AdminHoldPage
  - HoldSearchForm
  - HoldTable
  - HoldDetailPanel
  - AuditLogTable
  - AuditLogRowExpand
- server
  - SecurityConfig
  - AuditLogger
  - AuditLog
  - AuditTraceRowDto
  - AuditTraceService / QueryService
  - LoginAdmin resolver 관련 설정

## Checklist
- [x] 공통 유틸 적용 완료
- [x] Admin 권한 가드 적용 완료
- [x] A4 -> A1 / A4 -> A5 연계 확인
- [x] A5 -> A4 settlementId 연계 확인
- [x] includeNoOp 전파 확인
- [x] no-op audit metaJson 정합 확인
- [x] @LoginAdmin resolver 등록 확인
- [x] /api/admin/** security 차단 확인
- [x] dev-login 후 admin API 200 확인

## Note
- 이번 PR은 신규 기능 추가보다 운영 화면 정합, 권한 통제, 공통 유틸 통일, 기획서 누락 보완에 초점을 둔 마감 성격의 반영입니다.