### PR TITLE
fix(frontend): add session-based role guards to admin/merchant/consumer pages

### DIFF
--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -11,6 +11,7 @@ import GuardNotice from "../../components/common/GuardNotice.jsx";
 import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
 
 import { formatDateTimeWithSeconds } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
@@ -54,25 +55,33 @@ function extractRole(payload) {
   );
 }
 
-function buildAuthErrorMessage(error) {
-  const status = error?.status;
+function buildAuthErrorInfo(error) {
+  const status = error?.status ?? null;
   const message =
     error?.body?.message ||
     error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+    return {
+      status: 401,
+      message: "로그인이 필요합니다. 개발용 로그인 페이지에서 세션을 생성해주세요.",
+    };
   }
 
   if (status === 403) {
-    return "Admin 권한이 없어 배치 콘솔에 접근할 수 없습니다.";
+    return {
+      status: 403,
+      message: "Admin 권한이 필요한 페이지입니다.",
+    };
   }
 
-  return (
-    message ||
-    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
-  );
+  return {
+    status,
+    message:
+      message ||
+      "현재 세션의 역할을 확인할 수 없습니다. 개발용 로그인 페이지에서 다시 로그인해 주세요.",
+  };
 }
 
 function buildErrorMessage(error) {
@@ -83,7 +92,7 @@ function buildErrorMessage(error) {
     error?.message;
 
   if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+    return "인증이 만료되었거나 로그인되지 않았습니다. 개발용 로그인 페이지에서 세션을 다시 생성해 주세요.";
   }
 
   if (status === 403) {
@@ -239,7 +248,7 @@ export default function BatchPage() {
 
   const [authChecking, setAuthChecking] = useState(true);
   const [isAllowed, setIsAllowed] = useState(false);
-  const [authErrorMessage, setAuthErrorMessage] = useState("");
+  const [authErrorInfo, setAuthErrorInfo] = useState(null);
 
   const fetchHistory = useCallback(
     async (nextFromDate, nextToDate) => {
@@ -278,7 +287,7 @@ export default function BatchPage() {
     async function checkAdminRole() {
       try {
         setAuthChecking(true);
-        setAuthErrorMessage("");
+        setAuthErrorInfo(null);
         setIsAllowed(false);
 
         const me = await getMe();
@@ -292,13 +301,14 @@ export default function BatchPage() {
         }
 
         setIsAllowed(false);
-        setAuthErrorMessage(
-          "Admin 전용 배치 콘솔입니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
-        );
+        setAuthErrorInfo({
+          status: 403,
+          message: "Admin 권한이 필요한 페이지입니다.",
+        });
       } catch (error) {
         if (!mounted) return;
         setIsAllowed(false);
-        setAuthErrorMessage(buildAuthErrorMessage(error));
+        setAuthErrorInfo(buildAuthErrorInfo(error));
       } finally {
         if (mounted) {
           setAuthChecking(false);
@@ -318,13 +328,13 @@ export default function BatchPage() {
     fetchHistory();
   }, [isAllowed, fetchHistory]);
 
-  const handleSearch = async (event) => {
+  async function handleSearch(event) {
     event.preventDefault();
     if (!isAllowed) return;
     await fetchHistory();
-  };
+  }
 
-  const handleReset = async () => {
+  async function handleReset() {
     const nextFrom = getDefaultFrom();
     const nextTo = getDefaultTo();
 
@@ -333,9 +343,9 @@ export default function BatchPage() {
 
     if (!isAllowed) return;
     await fetchHistory(nextFrom, nextTo);
-  };
+  }
 
-  const handleRunBatch = async () => {
+  async function handleRunBatch() {
     if (!isAllowed || !baseDate) return;
 
     try {
@@ -353,7 +363,7 @@ export default function BatchPage() {
     } finally {
       setRunLoading(false);
     }
-  };
+  }
 
   const summary = useMemo(() => {
     const total = historyTotal;
@@ -386,7 +396,18 @@ export default function BatchPage() {
     );
   }
 
-  if (!isAllowed) {
+  if (authErrorInfo?.status === 401) {
+    return (
+      <PageLayout
+        title="배치 실행 · 이력"
+        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
+      >
+        <RequireLoginNotice />
+      </PageLayout>
+    );
+  }
+
+  if (authErrorInfo?.status === 403) {
     return (
       <PageLayout
         title="배치 실행 · 이력"
@@ -394,15 +415,32 @@ export default function BatchPage() {
       >
         <GuardNotice
           title="접근 불가"
-          message={authErrorMessage}
+          message={authErrorInfo.message}
           tone="danger"
         />
-        <ErrorState
-          title="Admin 전용 화면"
-          description={authErrorMessage}
-        />
+        <ErrorState message={authErrorInfo.message} />
       </PageLayout>
     );
+  }
+
+  if (authErrorInfo) {
+    return (
+      <PageLayout
+        title="배치 실행 · 이력"
+        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
+      >
+        <GuardNotice
+          title="조회 실패"
+          message={authErrorInfo.message}
+          tone="danger"
+        />
+        <ErrorState message={authErrorInfo.message} />
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return null;
   }
 
   return (
@@ -470,10 +508,11 @@ export default function BatchPage() {
               <InfoRow label="result">
                 <StatusBadge status={extractRunResult(runResult)} />
               </InfoRow>
-              <InfoRow label="baseDate">
-                {extractRunBaseDate(runResult, baseDate)}
-              </InfoRow>
-              <InfoRow label="runId">{extractRunId(runResult)}</InfoRow>
+              <InfoRow
+                label="baseDate"
+                value={extractRunBaseDate(runResult, baseDate)}
+              />
+              <InfoRow label="runId" value={extractRunId(runResult)} />
               <InfoRow label="requestId">
                 {extractRunRequestId(runResult) ? (
                   <CopyableValue value={extractRunRequestId(runResult)} />
@@ -489,7 +528,7 @@ export default function BatchPage() {
       {errorMessage ? (
         <>
           <GuardNotice title="처리 실패" message={errorMessage} tone="danger" />
-          <ErrorState title="배치 콘솔 처리 실패" description={errorMessage} />
+          <ErrorState message={errorMessage} />
         </>
       ) : null}
 
@@ -598,7 +637,7 @@ export default function BatchPage() {
         </div>
       </SectionCard>
 
-      <SectionCard title="배치 이력" description={`총 ${historyTotal}건`}>
+      <SectionCard title={`배치 이력 (${historyTotal}건)`}>
         {loading ? (
           <LoadingBlock
             title="로딩 중"

--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -13,6 +13,7 @@ import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 
 import { formatDateTimeWithSeconds } from "../../utils/format.js";
+import { getMe } from "../../api/meApi.js";
 import {
   getSettlementBatchHistory,
   runSettlementBatch,
@@ -41,6 +42,37 @@ function normalizeHistoryPayload(data) {
     totalElements: Number(page?.totalElements ?? 0),
     numberOfElements: Number(page?.numberOfElements ?? content.length),
   };
+}
+
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+  }
+
+  if (status === 403) {
+    return "Admin 권한이 없어 배치 콘솔에 접근할 수 없습니다.";
+  }
+
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+  );
 }
 
 function buildErrorMessage(error) {
@@ -205,6 +237,10 @@ export default function BatchPage() {
   const [errorMessage, setErrorMessage] = useState("");
   const [runResult, setRunResult] = useState(null);
 
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
+
   const fetchHistory = useCallback(
     async (nextFromDate, nextToDate) => {
       const queryFrom = nextFromDate ?? fromDate;
@@ -237,11 +273,54 @@ export default function BatchPage() {
   );
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkAdminRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+
+        if (!mounted) return;
+
+        if (role === "ADMIN") {
+          setIsAllowed(true);
+          return;
+        }
+
+        setIsAllowed(false);
+        setAuthErrorMessage(
+          "Admin 전용 배치 콘솔입니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+        );
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkAdminRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
     fetchHistory();
-  }, [fetchHistory]);
+  }, [isAllowed, fetchHistory]);
 
   const handleSearch = async (event) => {
     event.preventDefault();
+    if (!isAllowed) return;
     await fetchHistory();
   };
 
@@ -252,11 +331,12 @@ export default function BatchPage() {
     setFromDate(nextFrom);
     setToDate(nextTo);
 
+    if (!isAllowed) return;
     await fetchHistory(nextFrom, nextTo);
   };
 
   const handleRunBatch = async () => {
-    if (!baseDate) return;
+    if (!isAllowed || !baseDate) return;
 
     try {
       setRunLoading(true);
@@ -289,6 +369,41 @@ export default function BatchPage() {
 
     return { total, okCount, failCount, skipCount };
   }, [historyRows, historyTotal]);
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title="배치 실행 · 이력"
+        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title="배치 실행 · 이력"
+        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Admin 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -3,12 +3,15 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
 import SectionCard from "../../components/layout/SectionCard.jsx";
+import ActionButton from "../../components/layout/ActionButton.jsx";
 import StatusBadge from "../../components/display/StatusBadge.jsx";
-import GuardNotice from "../../components/common/GuardNotice.jsx";
 import CopyableId from "../../components/display/CopyableId.jsx";
 import InfoRow from "../../components/display/InfoRow.jsx";
+import GuardNotice from "../../components/common/GuardNotice.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+
 import { getMe } from "../../api/meApi.js";
 import {
   getAdminSettlementDetail,
@@ -43,9 +46,11 @@ function buildAuthErrorMessage(error) {
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
   }
+
   if (status === 403) {
     return "Admin 권한이 없어 정산 상세 화면에 접근할 수 없습니다.";
   }
+
   return (
     message ||
     "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
@@ -62,12 +67,15 @@ function mapDetailErrorToMessage(error) {
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
   }
+
   if (status === 403) {
     return "Admin 권한이 없어 정산 상세를 조회할 수 없습니다.";
   }
+
   if (status === 404) {
     return "정산 정보를 찾을 수 없습니다.";
   }
+
   return message || "정산 상세 조회 중 오류가 발생했습니다.";
 }
 
@@ -96,12 +104,15 @@ function mapTraceEntryErrorToMessage(error) {
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
   }
+
   if (status === 403) {
     return "Admin 권한이 없어 Trace로 이동할 수 없습니다.";
   }
+
   if (status === 404) {
     return "이 정산 건에 대한 Trace 진입 가능한 request_id가 아직 없습니다.";
   }
+
   return message || "Trace 진입 정보를 조회하는 중 오류가 발생했습니다.";
 }
 
@@ -342,7 +353,7 @@ export default function SettlementDetailAdminPage() {
     return messages;
   }, [holdActive, refund, status]);
 
-  const handleRequestPaid = async () => {
+  async function handleRequestPaid() {
     if (!isAllowed || !detail?.settlementId) return;
 
     try {
@@ -372,12 +383,12 @@ export default function SettlementDetailAdminPage() {
     } finally {
       setRequestPaidLoading(false);
     }
-  };
+  }
 
-  const handleTraceEntry = () => {
+  function handleTraceEntry() {
     if (!isAllowed || !traceRequestId) return;
     navigate(`/admin/audit?requestId=${encodeURIComponent(traceRequestId)}`);
-  };
+  }
 
   if (authChecking) {
     return (
@@ -396,6 +407,23 @@ export default function SettlementDetailAdminPage() {
   }
 
   if (!isAllowed) {
+    if (
+      authErrorMessage.includes("로그인") ||
+      authErrorMessage.includes("인증")
+    ) {
+      return (
+        <PageLayout
+          title="정산 상세"
+          description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
+        >
+          <RequireLoginNotice
+            title="Admin 전용 화면"
+            message={authErrorMessage}
+          />
+        </PageLayout>
+      );
+    }
+
     return (
       <PageLayout
         title="정산 상세"
@@ -406,10 +434,7 @@ export default function SettlementDetailAdminPage() {
           message={authErrorMessage}
           tone="danger"
         />
-        <ErrorState
-          title="Admin 전용 화면"
-          description={authErrorMessage}
-        />
+        <ErrorState message={authErrorMessage} />
       </PageLayout>
     );
   }
@@ -421,12 +446,10 @@ export default function SettlementDetailAdminPage() {
         description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
       >
         <SectionCard title="로딩 중">
-          <div className="state-block">
-            <div className="state-block__title">로딩 중</div>
-            <div className="state-block__description">
-              정산 상세 데이터를 불러오고 있습니다.
-            </div>
-          </div>
+          <LoadingBlock
+            title="로딩 중"
+            description="정산 상세 데이터를 불러오고 있습니다."
+          />
         </SectionCard>
       </PageLayout>
     );
@@ -439,6 +462,7 @@ export default function SettlementDetailAdminPage() {
         description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
       >
         <GuardNotice title="조회 실패" message={loadError} tone="danger" />
+        <ErrorState message={loadError} />
       </PageLayout>
     );
   }
@@ -501,23 +525,23 @@ export default function SettlementDetailAdminPage() {
 
       <SectionCard title="상단 액션">
         <div className="action-panel">
-          <button
+          <ActionButton
             type="button"
-            className="btn btn--primary"
+            variant="primary"
             onClick={handleRequestPaid}
             disabled={requestPaidDisabled || requestPaidLoading}
           >
             {requestPaidLoading ? "요청 중…" : "지급 요청"}
-          </button>
+          </ActionButton>
 
-          <button
+          <ActionButton
             type="button"
-            className="btn btn--secondary"
+            variant="secondary"
             onClick={handleTraceEntry}
             disabled={traceButtonDisabled}
           >
             {traceEntryLoading ? "확인 중…" : "Trace로 보기"}
-          </button>
+          </ActionButton>
 
           <Link
             to={buildHoldCreateLink(currentSettlementId)}
@@ -621,9 +645,7 @@ export default function SettlementDetailAdminPage() {
             label="adjustment pending"
             value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
           />
-          <InfoRow label="refund status">
-            <StatusBadge status={refundStatus} />
-          </InfoRow>
+          <InfoRow label="refund status" status value={refundStatus} />
         </SectionCard>
       </div>
 
@@ -643,17 +665,9 @@ export default function SettlementDetailAdminPage() {
       </SectionCard>
 
       <SectionCard title="연결 정보">
-        <InfoRow label="settlementId">
-          <CopyableValue value={currentSettlementId} />
-        </InfoRow>
-
-        <InfoRow label="requestId">
-          {traceRequestId ? <CopyableValue value={traceRequestId} /> : "-"}
-        </InfoRow>
-
-        <InfoRow label="merchantId">
-          {merchantId !== "-" ? <CopyableValue value={merchantId} /> : "-"}
-        </InfoRow>
+        <InfoRow label="settlementId" copyable value={currentSettlementId} />
+        <InfoRow label="requestId" copyable value={traceRequestId || "-"} />
+        <InfoRow label="merchantId" copyable value={merchantId} />
 
         <InfoRow label="paymentIds">
           {paymentIds.length === 0 ? (
@@ -726,9 +740,7 @@ export default function SettlementDetailAdminPage() {
             label="adjustment pending"
             value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
           />
-          <InfoRow label="status">
-            <StatusBadge status={refundStatus} />
-          </InfoRow>
+          <InfoRow label="status" status value={refundStatus} />
           <InfoRow
             label="refund line amount"
             value={refundLineAmount > 0 ? formatAmount(refundLineAmount) : "-"}

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -7,6 +7,9 @@ import StatusBadge from "../../components/display/StatusBadge.jsx";
 import GuardNotice from "../../components/common/GuardNotice.jsx";
 import CopyableId from "../../components/display/CopyableId.jsx";
 import InfoRow from "../../components/display/InfoRow.jsx";
+import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import ErrorState from "../../components/feedback/ErrorState.jsx";
+import { getMe } from "../../api/meApi.js";
 import {
   getAdminSettlementDetail,
   getAdminSettlementTraceEntry,
@@ -18,6 +21,35 @@ function formatAmount(value) {
   const num = Number(value);
   if (Number.isNaN(num)) return String(value);
   return `${num.toLocaleString("ko-KR")}원`;
+}
+
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+  }
+  if (status === 403) {
+    return "Admin 권한이 없어 정산 상세 화면에 접근할 수 없습니다.";
+  }
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+  );
 }
 
 function mapDetailErrorToMessage(error) {
@@ -126,6 +158,10 @@ export default function SettlementDetailAdminPage() {
   const [traceEntryError, setTraceEntryError] = useState("");
   const [traceRequestId, setTraceRequestId] = useState("");
 
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
+
   const fetchDetail = useCallback(
     async (signal) => {
       try {
@@ -192,10 +228,53 @@ export default function SettlementDetailAdminPage() {
   );
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkAdminRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+
+        if (!mounted) return;
+
+        if (role === "ADMIN") {
+          setIsAllowed(true);
+          return;
+        }
+
+        setIsAllowed(false);
+        setAuthErrorMessage(
+          "Admin 전용 정산 상세 화면입니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+        );
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkAdminRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+
     const controller = new AbortController();
     reloadPageData(controller.signal);
     return () => controller.abort();
-  }, [reloadPageData]);
+  }, [isAllowed, reloadPageData]);
 
   const currentSettlementId = detail?.settlementId || settlementId || "-";
   const merchantId = detail?.merchantId || "-";
@@ -264,7 +343,7 @@ export default function SettlementDetailAdminPage() {
   }, [holdActive, refund, status]);
 
   const handleRequestPaid = async () => {
-    if (!detail?.settlementId) return;
+    if (!isAllowed || !detail?.settlementId) return;
 
     try {
       setRequestPaidLoading(true);
@@ -296,9 +375,44 @@ export default function SettlementDetailAdminPage() {
   };
 
   const handleTraceEntry = () => {
-    if (!traceRequestId) return;
+    if (!isAllowed || !traceRequestId) return;
     navigate(`/admin/audit?requestId=${encodeURIComponent(traceRequestId)}`);
   };
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title="정산 상세"
+        description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title="정산 상세"
+        description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Admin 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   if (loading) {
     return (

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -11,6 +11,7 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import { formatNumber } from "../../utils/format.js";
+import { getMe } from "../../api/meApi.js";
 import { getAdminSettlements } from "../../api/adminSettlementListApi.js";
 
 const STATUS_OPTIONS = [
@@ -34,6 +35,37 @@ function normalizeSettlementList(payload) {
   if (Array.isArray(payload?.items)) return payload.items;
   if (Array.isArray(payload?.content)) return payload.content;
   return [];
+}
+
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+  }
+
+  if (status === 403) {
+    return "Admin 권한이 없어 정산 관리 화면에 접근할 수 없습니다.";
+  }
+
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+  );
 }
 
 function buildErrorMessage(error) {
@@ -74,6 +106,10 @@ export default function SettlementManagePage() {
     searchParams.get("merchantId") ?? ""
   );
 
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
+
   const pageTitle = useMemo(() => "A3 정산 관리", []);
 
   const fetchSettlements = useCallback(
@@ -100,16 +136,60 @@ export default function SettlementManagePage() {
   );
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkAdminRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+
+        if (!mounted) return;
+
+        if (role === "ADMIN") {
+          setIsAllowed(true);
+          return;
+        }
+
+        setIsAllowed(false);
+        setAuthErrorMessage(
+          "Admin 전용 정산 관리 화면입니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
+        );
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkAdminRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+
     const nextStatus = searchParams.get("status") ?? "";
     const nextMerchantId = searchParams.get("merchantId") ?? "";
 
     setStatus(nextStatus);
     setMerchantId(nextMerchantId);
     fetchSettlements(nextStatus, nextMerchantId);
-  }, [searchParams, fetchSettlements]);
+  }, [searchParams, fetchSettlements, isAllowed]);
 
   const handleSearch = (event) => {
     event.preventDefault();
+    if (!isAllowed) return;
 
     const nextParams = {};
     if (status) nextParams.status = status;
@@ -121,13 +201,49 @@ export default function SettlementManagePage() {
   const handleReset = () => {
     setStatus("");
     setMerchantId("");
+    if (!isAllowed) return;
     setSearchParams({});
   };
 
   const handleRowClick = (settlementId) => {
-    if (!settlementId) return;
+    if (!isAllowed || !settlementId) return;
     navigate(`/admin/settlements/${settlementId}`);
   };
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Admin 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -10,6 +10,8 @@ import GuardNotice from "../../components/common/GuardNotice.jsx";
 import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+
 import { formatNumber } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
 import { getAdminSettlements } from "../../api/adminSettlementListApi.js";
@@ -34,6 +36,7 @@ function normalizeSettlementList(payload) {
   if (Array.isArray(payload?.data)) return payload.data;
   if (Array.isArray(payload?.items)) return payload.items;
   if (Array.isArray(payload?.content)) return payload.content;
+  if (Array.isArray(payload?.page?.content)) return payload.page.content;
   return [];
 }
 
@@ -55,7 +58,7 @@ function buildAuthErrorMessage(error) {
     error?.message;
 
   if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요.";
+    return "로그인이 필요합니다. 개발용 로그인 페이지에서 세션을 생성해주세요.";
   }
 
   if (status === 403) {
@@ -187,28 +190,26 @@ export default function SettlementManagePage() {
     fetchSettlements(nextStatus, nextMerchantId);
   }, [searchParams, fetchSettlements, isAllowed]);
 
-  const handleSearch = (event) => {
+  function handleSearch(event) {
     event.preventDefault();
-    if (!isAllowed) return;
 
     const nextParams = {};
     if (status) nextParams.status = status;
     if (merchantId.trim()) nextParams.merchantId = merchantId.trim();
 
     setSearchParams(nextParams);
-  };
+  }
 
-  const handleReset = () => {
+  function handleReset() {
     setStatus("");
     setMerchantId("");
-    if (!isAllowed) return;
     setSearchParams({});
-  };
+  }
 
-  const handleRowClick = (settlementId) => {
-    if (!isAllowed || !settlementId) return;
+  function handleRowClick(settlementId) {
+    if (!settlementId) return;
     navigate(`/admin/settlements/${settlementId}`);
-  };
+  }
 
   if (authChecking) {
     return (
@@ -227,6 +228,23 @@ export default function SettlementManagePage() {
   }
 
   if (!isAllowed) {
+    if (
+      authErrorMessage.includes("로그인") ||
+      authErrorMessage.includes("인증")
+    ) {
+      return (
+        <PageLayout
+          title={pageTitle}
+          description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
+        >
+          <RequireLoginNotice
+            title="인증 필요"
+            message={authErrorMessage}
+          />
+        </PageLayout>
+      );
+    }
+
     return (
       <PageLayout
         title={pageTitle}
@@ -237,10 +255,7 @@ export default function SettlementManagePage() {
           message={authErrorMessage}
           tone="danger"
         />
-        <ErrorState
-          title="Admin 전용 화면"
-          description={authErrorMessage}
-        />
+        <ErrorState message={authErrorMessage} />
       </PageLayout>
     );
   }
@@ -339,14 +354,21 @@ export default function SettlementManagePage() {
       {errorMessage ? (
         <>
           <GuardNotice title="조회 실패" message={errorMessage} tone="danger" />
-          <ErrorState
-            title="정산 리스트 조회 실패"
-            description={errorMessage}
-          />
+          <ErrorState message={errorMessage} />
         </>
       ) : null}
 
-      <SectionCard title="정산 리스트" description={`총 ${rows.length}건`}>
+      <SectionCard title="정산 리스트">
+        <div
+          style={{
+            marginBottom: "12px",
+            color: "var(--color-text-muted, #6b7280)",
+            fontSize: "14px",
+          }}
+        >
+          총 {rows.length}건
+        </div>
+
         {loading ? (
           <LoadingBlock
             title="로딩 중"

--- a/admin-web/src/pages/consumer/MyOrdersPage.jsx
+++ b/admin-web/src/pages/consumer/MyOrdersPage.jsx
@@ -11,6 +11,7 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import { formatDateTime } from "../../utils/format.js";
+import { getMe } from "../../api/meApi.js";
 import { getConsumerOrders } from "../../api/consumerOrderApi.js";
 
 const STATUS_OPTIONS = [
@@ -18,6 +19,37 @@ const STATUS_OPTIONS = [
   { value: "CREATED", label: "CREATED" },
   { value: "PAID", label: "PAID" },
 ];
+
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Consumer 세션을 다시 생성해 주세요.";
+  }
+
+  if (status === 403) {
+    return "Consumer 권한이 없어 주문/결제 내역 화면에 접근할 수 없습니다.";
+  }
+
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Consumer 세션으로 다시 로그인해 주세요."
+  );
+}
 
 function formatAmount(value) {
   if (value === null || value === undefined || value === "") return "-";
@@ -110,6 +142,10 @@ export default function MyOrdersPage() {
 
   const [status, setStatus] = useState(searchParams.get("status") ?? "");
 
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
+
   const pageTitle = useMemo(() => "내 주문/결제 내역", []);
 
   const fetchOrders = useCallback(async (nextStatus = "") => {
@@ -132,13 +168,57 @@ export default function MyOrdersPage() {
   }, []);
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkConsumerRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+
+        if (!mounted) return;
+
+        if (role === "CONSUMER") {
+          setIsAllowed(true);
+          return;
+        }
+
+        setIsAllowed(false);
+        setAuthErrorMessage(
+          "Consumer 전용 주문/결제 내역 화면입니다. /auth/dev-login 에서 Consumer 세션으로 다시 로그인해 주세요."
+        );
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkConsumerRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed) return;
+
     const nextStatus = searchParams.get("status") ?? "";
     setStatus(nextStatus);
     fetchOrders(nextStatus);
-  }, [searchParams, fetchOrders]);
+  }, [searchParams, fetchOrders, isAllowed]);
 
   const handleSearch = (event) => {
     event.preventDefault();
+    if (!isAllowed) return;
 
     const nextParams = {};
     if (status) nextParams.status = status;
@@ -148,13 +228,49 @@ export default function MyOrdersPage() {
 
   const handleReset = () => {
     setStatus("");
+    if (!isAllowed) return;
     setSearchParams({});
   };
 
   const handleRowClick = (orderId) => {
-    if (!orderId) return;
+    if (!isAllowed || !orderId) return;
     navigate(`/consumer/orders/${orderId}`);
   };
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="Consumer 기준으로 주문/결제 내역을 조회하고, pay 이후 PAID와 CONFIRMED 상태를 함께 확인합니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="Consumer 기준으로 주문/결제 내역을 조회하고, pay 이후 PAID와 CONFIRMED 상태를 함께 확인합니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Consumer 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout

--- a/admin-web/src/pages/consumer/MyOrdersPage.jsx
+++ b/admin-web/src/pages/consumer/MyOrdersPage.jsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+// admin-web/src/pages/consumer/MyOrdersPage.jsx
+
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
@@ -10,9 +12,15 @@ import GuardNotice from "../../components/common/GuardNotice.jsx";
 import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+
 import { formatDateTime } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
 import { getConsumerOrders } from "../../api/consumerOrderApi.js";
+
+const PAGE_TITLE = "내 주문/결제 내역";
+const PAGE_DESCRIPTION =
+  "C3 내 주문/결제 내역. row 클릭 시 주문 상세 화면으로 이동합니다.";
 
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
@@ -20,84 +28,57 @@ const STATUS_OPTIONS = [
   { value: "PAID", label: "PAID" },
 ];
 
-function extractRole(payload) {
-  return (
-    payload?.role ||
-    payload?.data?.role ||
-    payload?.user?.role ||
-    payload?.principal?.role ||
-    null
-  );
+function parseStatus(searchParams) {
+  return searchParams.get("status") ?? "";
 }
 
-function buildAuthErrorMessage(error) {
-  const status = error?.status;
-  const message =
-    error?.body?.message ||
-    error?.body?.reason ||
-    error?.message;
+function isConsumerRole(me) {
+  if (!me) return false;
 
-  if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Consumer 세션을 다시 생성해 주세요.";
+  if (me.role === "CONSUMER" || me.role === "ROLE_CONSUMER") {
+    return true;
   }
 
-  if (status === 403) {
-    return "Consumer 권한이 없어 주문/결제 내역 화면에 접근할 수 없습니다.";
+  if (
+    Array.isArray(me.authorities) &&
+    me.authorities.includes("ROLE_CONSUMER")
+  ) {
+    return true;
   }
 
-  return (
-    message ||
-    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Consumer 세션으로 다시 로그인해 주세요."
-  );
+  return false;
 }
 
-function formatAmount(value) {
-  if (value === null || value === undefined || value === "") return "-";
-  const num = Number(value);
-  if (Number.isNaN(num)) return String(value);
-  return `${num.toLocaleString("ko-KR")}원`;
+function buildErrorInfo(error, fallbackMessage) {
+  return {
+    status: error?.status ?? null,
+    message:
+      error?.body?.message ||
+      error?.body?.reason ||
+      error?.message ||
+      fallbackMessage,
+  };
 }
 
 function normalizeOrderList(payload) {
   if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.data)) return payload.data;
   if (Array.isArray(payload?.items)) return payload.items;
+  if (Array.isArray(payload?.data)) return payload.data;
   if (Array.isArray(payload?.content)) return payload.content;
   return [];
 }
 
-function buildErrorMessage(error) {
-  const status = error?.status;
-  const message =
-    error?.body?.message ||
-    error?.body?.reason ||
-    error?.message;
-
-  if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Consumer 세션을 다시 생성해 주세요.";
+function formatAmount(value) {
+  if (value === null || value === undefined || value === "") {
+    return "-";
   }
 
-  if (status === 403) {
-    return "Consumer 권한이 없어 주문/결제 내역을 조회할 수 없습니다.";
+  const numberValue = Number(value);
+  if (Number.isNaN(numberValue)) {
+    return String(value);
   }
 
-  if (status === 404) {
-    return "주문/결제 내역 API 경로를 찾을 수 없습니다. 백엔드 라우팅을 확인해 주세요.";
-  }
-
-  return (
-    message ||
-    "주문/결제 내역을 불러오지 못했습니다. 백엔드 연결 상태와 API 응답 구조를 확인해 주세요."
-  );
-}
-
-function isConfirmed(row) {
-  return (
-    row?.confirmed === true ||
-    row?.isConfirmed === true ||
-    Boolean(row?.confirmedAt) ||
-    Boolean(row?.paymentConfirmedAt)
-  );
+  return `${numberValue.toLocaleString("ko-KR")}원`;
 }
 
 function getOrderId(row, index) {
@@ -112,6 +93,10 @@ function getItemName(row) {
   return row?.itemName ?? row?.productName ?? row?.title ?? "-";
 }
 
+function getAmount(row) {
+  return row?.amount ?? row?.totalAmount ?? row?.paymentAmount ?? null;
+}
+
 function getCreatedAt(row) {
   return row?.createdAt ?? row?.orderedAt ?? row?.orderCreatedAt ?? null;
 }
@@ -122,6 +107,15 @@ function getOrderStatus(row) {
 
 function getPaymentStatus(row) {
   return row?.paymentStatus ?? row?.payment?.status ?? "-";
+}
+
+function isConfirmed(row) {
+  return (
+    row?.confirmed === true ||
+    row?.isConfirmed === true ||
+    Boolean(row?.confirmedAt) ||
+    Boolean(row?.paymentConfirmedAt)
+  );
 }
 
 function CopyableCell({ value }) {
@@ -136,113 +130,144 @@ export default function MyOrdersPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const queryStatus = useMemo(() => parseStatus(searchParams), [searchParams]);
+
+  const [status, setStatus] = useState(queryStatus);
+
+  const [me, setMe] = useState(null);
+  const [meLoading, setMeLoading] = useState(true);
+  const [meErrorInfo, setMeErrorInfo] = useState(null);
+
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-
-  const [status, setStatus] = useState(searchParams.get("status") ?? "");
-
-  const [authChecking, setAuthChecking] = useState(true);
-  const [isAllowed, setIsAllowed] = useState(false);
-  const [authErrorMessage, setAuthErrorMessage] = useState("");
-
-  const pageTitle = useMemo(() => "내 주문/결제 내역", []);
-
-  const fetchOrders = useCallback(async (nextStatus = "") => {
-    setLoading(true);
-    setErrorMessage("");
-
-    try {
-      const params = {};
-      if (nextStatus) params.status = nextStatus;
-
-      const data = await getConsumerOrders(params);
-      setRows(normalizeOrderList(data));
-    } catch (error) {
-      console.error("C3 주문/결제 내역 조회 실패", error);
-      setRows([]);
-      setErrorMessage(buildErrorMessage(error));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const [errorInfo, setErrorInfo] = useState(null);
 
   useEffect(() => {
-    let mounted = true;
+    setStatus(queryStatus);
+  }, [queryStatus]);
 
-    async function checkConsumerRole() {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadMe() {
       try {
-        setAuthChecking(true);
-        setAuthErrorMessage("");
-        setIsAllowed(false);
+        setMeLoading(true);
+        setMeErrorInfo(null);
 
-        const me = await getMe();
-        const role = String(extractRole(me) || "").toUpperCase();
+        const meData = await getMe();
 
-        if (!mounted) return;
+        if (cancelled) return;
 
-        if (role === "CONSUMER") {
-          setIsAllowed(true);
-          return;
+        setMe(meData);
+
+        if (!isConsumerRole(meData)) {
+          setMeErrorInfo({
+            status: 403,
+            message:
+              "Consumer 권한이 필요한 페이지입니다. /auth/dev-login 에서 Consumer 세션으로 다시 로그인해 주세요.",
+          });
         }
-
-        setIsAllowed(false);
-        setAuthErrorMessage(
-          "Consumer 전용 주문/결제 내역 화면입니다. /auth/dev-login 에서 Consumer 세션으로 다시 로그인해 주세요."
-        );
       } catch (error) {
-        if (!mounted) return;
-        setIsAllowed(false);
-        setAuthErrorMessage(buildAuthErrorMessage(error));
+        if (cancelled) return;
+
+        setMe(null);
+        setMeErrorInfo(
+          buildErrorInfo(
+            error,
+            "현재 세션 정보를 불러오지 못했습니다. /auth/dev-login 에서 다시 로그인해 주세요."
+          )
+        );
       } finally {
-        if (mounted) {
-          setAuthChecking(false);
+        if (!cancelled) {
+          setMeLoading(false);
         }
       }
     }
 
-    checkConsumerRole();
+    loadMe();
 
     return () => {
-      mounted = false;
+      cancelled = true;
     };
   }, []);
 
   useEffect(() => {
-    if (!isAllowed) return;
+    if (meLoading || meErrorInfo || !isConsumerRole(me)) {
+      return;
+    }
 
-    const nextStatus = searchParams.get("status") ?? "";
-    setStatus(nextStatus);
-    fetchOrders(nextStatus);
-  }, [searchParams, fetchOrders, isAllowed]);
+    let cancelled = false;
 
-  const handleSearch = (event) => {
+    async function loadOrders() {
+      try {
+        setLoading(true);
+        setErrorInfo(null);
+
+        const params = {};
+        if (queryStatus) {
+          params.status = queryStatus;
+        }
+
+        const data = await getConsumerOrders(params);
+
+        if (cancelled) return;
+
+        setRows(normalizeOrderList(data));
+      } catch (error) {
+        if (cancelled) return;
+
+        setRows([]);
+        setErrorInfo(
+          buildErrorInfo(
+            error,
+            "주문/결제 내역을 불러오지 못했습니다. 백엔드 연결 상태와 응답 구조를 확인해 주세요."
+          )
+        );
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadOrders();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [meLoading, meErrorInfo, me, queryStatus]);
+
+  function handleSearch(event) {
     event.preventDefault();
-    if (!isAllowed) return;
 
     const nextParams = {};
-    if (status) nextParams.status = status;
+    if (status) {
+      nextParams.status = status;
+    }
 
     setSearchParams(nextParams);
-  };
+  }
 
-  const handleReset = () => {
+  function handleReset() {
     setStatus("");
-    if (!isAllowed) return;
     setSearchParams({});
-  };
+  }
 
-  const handleRowClick = (orderId) => {
-    if (!isAllowed || !orderId) return;
+  function handleRefresh() {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      return next;
+    });
+  }
+
+  function handleRowClick(orderId) {
+    if (!orderId) return;
     navigate(`/consumer/orders/${orderId}`);
-  };
+  }
 
-  if (authChecking) {
+  if (meLoading) {
     return (
-      <PageLayout
-        title={pageTitle}
-        description="Consumer 기준으로 주문/결제 내역을 조회하고, pay 이후 PAID와 CONFIRMED 상태를 함께 확인합니다."
-      >
+      <PageLayout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
         <SectionCard title="세션 확인 중">
           <LoadingBlock
             title="세션 확인 중"
@@ -253,45 +278,47 @@ export default function MyOrdersPage() {
     );
   }
 
-  if (!isAllowed) {
+  if (meErrorInfo?.status === 401) {
     return (
-      <PageLayout
-        title={pageTitle}
-        description="Consumer 기준으로 주문/결제 내역을 조회하고, pay 이후 PAID와 CONFIRMED 상태를 함께 확인합니다."
-      >
+      <PageLayout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
+        <RequireLoginNotice
+          title="Consumer 전용 화면"
+          message={meErrorInfo.message}
+        />
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo?.status === 403) {
+    return (
+      <PageLayout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
         <GuardNotice
           title="접근 불가"
-          message={authErrorMessage}
+          message={meErrorInfo.message}
           tone="danger"
         />
-        <ErrorState
-          title="Consumer 전용 화면"
-          description={authErrorMessage}
+      </PageLayout>
+    );
+  }
+
+  if (meErrorInfo) {
+    return (
+      <PageLayout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
+        <GuardNotice
+          title="세션 확인 실패"
+          message={meErrorInfo.message}
+          tone="danger"
         />
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout
-      title={pageTitle}
-      description="Consumer 기준으로 주문/결제 내역을 조회하고, pay 이후 PAID와 CONFIRMED 상태를 함께 확인합니다."
-    >
+    <PageLayout title={PAGE_TITLE} description={PAGE_DESCRIPTION}>
       <SectionCard title="조회 조건">
         <form onSubmit={handleSearch}>
-          <div
-            className="filter-bar"
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              alignItems: "flex-end",
-              gap: "16px",
-            }}
-          >
-            <div
-              className="form-field"
-              style={{ minWidth: "220px", flex: "0 0 220px" }}
-            >
+          <div className="filter-bar">
+            <div className="form-field">
               <label className="form-field__label" htmlFor="status">
                 주문 상태
               </label>
@@ -309,15 +336,7 @@ export default function MyOrdersPage() {
               </select>
             </div>
 
-            <div
-              className="button-row action-panel"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "12px",
-                flexWrap: "wrap",
-              }}
-            >
+            <div className="button-row action-panel">
               <ActionButton type="submit" variant="primary" disabled={loading}>
                 {loading ? "조회 중..." : "조회"}
               </ActionButton>
@@ -341,17 +360,49 @@ export default function MyOrdersPage() {
         message="order.status는 CREATED / PAID 기준으로 보이며, CONFIRMED는 payment_event 파생 상태로 별도 표시합니다."
       />
 
-      {errorMessage ? (
+      {errorInfo ? (
         <>
-          <GuardNotice title="조회 실패" message={errorMessage} tone="danger" />
-          <ErrorState
-            title="주문/결제 내역 조회 실패"
-            description={errorMessage}
+          <GuardNotice
+            title="조회 실패"
+            message={errorInfo.message}
+            tone="danger"
           />
+          <ErrorState message={errorInfo.message} />
         </>
       ) : null}
 
-      <SectionCard title="주문/결제 내역" description={`총 ${rows.length}건`}>
+      <SectionCard title="주문/결제 목록">
+        <div
+          className="table-toolbar"
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            width: "100%",
+            marginBottom: "16px",
+          }}
+        >
+          <div>내 주문/결제 내역</div>
+
+          <div
+            className="action-panel"
+            style={{
+              marginLeft: "auto",
+              display: "flex",
+              justifyContent: "flex-end",
+            }}
+          >
+            <ActionButton
+              type="button"
+              variant="secondary"
+              onClick={handleRefresh}
+              disabled={loading}
+            >
+              새로고침
+            </ActionButton>
+          </div>
+        </div>
+
         {loading ? (
           <LoadingBlock
             title="로딩 중"
@@ -370,12 +421,12 @@ export default function MyOrdersPage() {
                   <th>orderId</th>
                   <th>paymentId</th>
                   <th>itemName</th>
-                  <th style={{ textAlign: "center" }}>amount</th>
-                  <th style={{ textAlign: "center" }}>order status</th>
-                  <th style={{ textAlign: "center" }}>payment status</th>
-                  <th style={{ textAlign: "center" }}>confirmed</th>
-                  <th style={{ textAlign: "center" }}>createdAt</th>
-                  <th style={{ textAlign: "center" }}>상세</th>
+                  <th>amount</th>
+                  <th>order status</th>
+                  <th>payment status</th>
+                  <th>confirmed</th>
+                  <th>createdAt</th>
+                  <th>상세</th>
                 </tr>
               </thead>
               <tbody>
@@ -383,6 +434,7 @@ export default function MyOrdersPage() {
                   const orderId = getOrderId(row, index);
                   const paymentId = getPaymentId(row);
                   const confirmed = isConfirmed(row);
+                  const paymentStatus = getPaymentStatus(row);
 
                   return (
                     <tr
@@ -390,83 +442,38 @@ export default function MyOrdersPage() {
                       onClick={() => handleRowClick(orderId)}
                       style={{ cursor: orderId ? "pointer" : "default" }}
                     >
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
-                      >
+                      <td onClick={(event) => event.stopPropagation()}>
                         <CopyableCell value={orderId} />
                       </td>
 
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
-                      >
+                      <td onClick={(event) => event.stopPropagation()}>
                         <CopyableCell value={paymentId || "-"} />
                       </td>
 
-                      <td style={{ verticalAlign: "middle" }}>
-                        {getItemName(row)}
-                      </td>
+                      <td>{getItemName(row)}</td>
+                      <td>{formatAmount(getAmount(row))}</td>
 
-                      <td
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                        }}
-                      >
-                        {formatAmount(row?.amount)}
-                      </td>
-
-                      <td
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                        }}
-                      >
+                      <td>
                         <StatusBadge status={getOrderStatus(row)} />
                       </td>
 
-                      <td
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                        }}
-                      >
-                        {getPaymentStatus(row) === "-" ? (
+                      <td>
+                        {paymentStatus === "-" ? (
                           "-"
                         ) : (
-                          <StatusBadge status={getPaymentStatus(row)} />
+                          <StatusBadge status={paymentStatus} />
                         )}
                       </td>
 
-                      <td
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                        }}
-                      >
+                      <td>
                         <StatusBadge
                           status={confirmed ? "CONFIRMED" : "UNCONFIRMED"}
                         />
                       </td>
 
-                      <td
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {formatDateTime(getCreatedAt(row))}
-                      </td>
+                      <td>{formatDateTime(getCreatedAt(row))}</td>
 
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{
-                          verticalAlign: "middle",
-                          textAlign: "center",
-                        }}
-                      >
+                      <td onClick={(event) => event.stopPropagation()}>
                         <ActionButton
                           type="button"
                           variant="secondary"
@@ -483,6 +490,32 @@ export default function MyOrdersPage() {
             </table>
           </div>
         )}
+      </SectionCard>
+
+      <SectionCard title="페이지 규칙">
+        <div className="info-list">
+          <div>
+            <strong>역할</strong> Consumer
+          </div>
+          <div>
+            <strong>핵심 이동</strong> C3 row 클릭 → 주문 상세(orderId 전달)
+          </div>
+          <div>
+            <strong>주문 상태</strong> order.status는 CREATED / PAID 사용
+          </div>
+          <div>
+            <strong>결제 상태</strong> payment.status는 별도 컬럼으로 표시
+          </div>
+          <div>
+            <strong>확정 여부</strong> PAYMENT_CONFIRMED 이벤트 존재 여부 기반 파생 표시
+          </div>
+          <div>
+            <strong>검색 기준</strong> status
+          </div>
+          <div>
+            <strong>로그인 주체</strong> {me?.buyerId ?? me?.userId ?? "-"}
+          </div>
+        </div>
       </SectionCard>
     </PageLayout>
   );

--- a/admin-web/src/pages/merchant/SettlementDetailPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementDetailPage.jsx
@@ -9,6 +9,8 @@ import InfoRow from "../../components/display/InfoRow.jsx";
 import GuardNotice from "../../components/common/GuardNotice.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+
 import { getMe } from "../../api/meApi.js";
 import { getMerchantSettlementDetail } from "../../api/merchantSettlementApi.js";
 
@@ -49,9 +51,11 @@ function buildAuthErrorMessage(error) {
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
   }
+
   if (status === 403) {
     return "Merchant 권한이 없어 정산 상세 화면에 접근할 수 없습니다.";
   }
+
   return (
     message ||
     "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
@@ -68,12 +72,15 @@ function mapDetailErrorToMessage(error) {
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
   }
+
   if (status === 403) {
     return "Merchant 권한이 없어 정산 상세를 조회할 수 없습니다.";
   }
+
   if (status === 404) {
     return "정산 정보를 찾을 수 없습니다.";
   }
+
   return message || "정산 상세 조회 중 오류가 발생했습니다.";
 }
 
@@ -125,6 +132,7 @@ export default function SettlementDetailPage() {
         if (error?.name === "AbortError" || error?.code === "ERR_CANCELED") {
           return;
         }
+
         setDetail(null);
         setLoadError(mapDetailErrorToMessage(error));
       } finally {
@@ -191,6 +199,7 @@ export default function SettlementDetailPage() {
 
     const controller = new AbortController();
     fetchDetail(merchantId, controller.signal);
+
     return () => controller.abort();
   }, [isAllowed, merchantId, fetchDetail]);
 
@@ -239,6 +248,20 @@ export default function SettlementDetailPage() {
   }
 
   if (!isAllowed) {
+    if (authErrorMessage.includes("로그인") || authErrorMessage.includes("인증")) {
+      return (
+        <PageLayout
+          title="정산 상세"
+          description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
+        >
+          <RequireLoginNotice
+            title="Merchant 전용 화면"
+            message={authErrorMessage}
+          />
+        </PageLayout>
+      );
+    }
+
     return (
       <PageLayout
         title="정산 상세"
@@ -249,10 +272,7 @@ export default function SettlementDetailPage() {
           message={authErrorMessage}
           tone="danger"
         />
-        <ErrorState
-          title="Merchant 전용 화면"
-          description={authErrorMessage}
-        />
+        <ErrorState message={authErrorMessage} />
       </PageLayout>
     );
   }
@@ -264,12 +284,10 @@ export default function SettlementDetailPage() {
         description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
       >
         <SectionCard title="로딩 중">
-          <div className="state-block">
-            <div className="state-block__title">로딩 중</div>
-            <div className="state-block__description">
-              정산 상세 데이터를 불러오고 있습니다.
-            </div>
-          </div>
+          <LoadingBlock
+            title="로딩 중"
+            description="정산 상세 데이터를 불러오고 있습니다."
+          />
         </SectionCard>
       </PageLayout>
     );
@@ -282,6 +300,7 @@ export default function SettlementDetailPage() {
         description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
       >
         <GuardNotice title="조회 실패" message={loadError} tone="danger" />
+        <ErrorState message={loadError} />
       </PageLayout>
     );
   }
@@ -358,26 +377,23 @@ export default function SettlementDetailPage() {
 
       <div className="page-grid-2">
         <SectionCard title="정산 상세">
-          <InfoRow label="baseDate">{baseDate}</InfoRow>
-          <InfoRow label="gross">{formatAmount(gross)}</InfoRow>
-          <InfoRow label="fee">{formatAmount(fee)}</InfoRow>
-          <InfoRow label="vat">{formatAmount(vat)}</InfoRow>
-          <InfoRow label="net">{formatAmount(net)}</InfoRow>
+          <InfoRow label="baseDate" value={baseDate} />
+          <InfoRow label="gross" value={formatAmount(gross)} />
+          <InfoRow label="fee" value={formatAmount(fee)} />
+          <InfoRow label="vat" value={formatAmount(vat)} />
+          <InfoRow label="net" value={formatAmount(net)} />
         </SectionCard>
 
         <SectionCard title="정산 상태 참고">
           <InfoRow label="hold">
             {hold?.status ? <StatusBadge status={hold.status} /> : "없음"}
           </InfoRow>
-          <InfoRow label="approved refund">
-            {hasApprovedRefund(refund) ? "예" : "아니오"}
-          </InfoRow>
-          <InfoRow label="adjustment pending">
-            {isRefundAdjustmentPending(refund) ? "예" : "아니오"}
-          </InfoRow>
-          <InfoRow label="refund status">
-            <StatusBadge status={refundStatus} />
-          </InfoRow>
+          <InfoRow label="approved refund" value={hasApprovedRefund(refund) ? "예" : "아니오"} />
+          <InfoRow
+            label="adjustment pending"
+            value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
+          />
+          <InfoRow label="refund status" status value={refundStatus} />
         </SectionCard>
       </div>
 
@@ -398,17 +414,8 @@ export default function SettlementDetailPage() {
 
       <SectionCard title="연결 정보">
         <div style={{ display: "grid", gap: "12px" }}>
-          <InfoRow label="settlementId">
-            <CopyableValue value={currentSettlementId} />
-          </InfoRow>
-
-          <InfoRow label="merchantId">
-            {currentMerchantId !== "-" ? (
-              <CopyableValue value={currentMerchantId} />
-            ) : (
-              "-"
-            )}
-          </InfoRow>
+          <InfoRow label="settlementId" copyable value={currentSettlementId} />
+          <InfoRow label="merchantId" copyable value={currentMerchantId} />
 
           <InfoRow label="paymentIds">
             {paymentIds.length === 0 ? (
@@ -450,31 +457,26 @@ export default function SettlementDetailPage() {
           <InfoRow label="status">
             {hold?.status ? <StatusBadge status={hold.status} /> : "-"}
           </InfoRow>
-          <InfoRow label="reason">{hold?.reasonCode || "-"}</InfoRow>
-          <InfoRow label="comment">
-            {hold?.requestedComment || hold?.comment || "-"}
-          </InfoRow>
-          <InfoRow label="approvedBy">
-            {hold?.approvedBy || hold?.decidedBy || "-"}
-          </InfoRow>
-          <InfoRow label="createdAt">
-            {hold?.createdAt || hold?.requestedAt || "-"}
-          </InfoRow>
+          <InfoRow label="reason" value={hold?.reasonCode || "-"} />
+          <InfoRow
+            label="comment"
+            value={hold?.requestedComment || hold?.comment || "-"}
+          />
+          <InfoRow label="approvedBy" value={hold?.approvedBy || hold?.decidedBy || "-"} />
+          <InfoRow label="createdAt" value={hold?.createdAt || hold?.requestedAt || "-"} />
         </SectionCard>
 
         <SectionCard title="Refund 요약">
-          <InfoRow label="approved refund">
-            {hasApprovedRefund(refund) ? "예" : "아니오"}
-          </InfoRow>
-          <InfoRow label="adjustment pending">
-            {isRefundAdjustmentPending(refund) ? "예" : "아니오"}
-          </InfoRow>
-          <InfoRow label="status">
-            <StatusBadge status={refundStatus} />
-          </InfoRow>
-          <InfoRow label="refund line amount">
-            {refundLineAmount > 0 ? formatAmount(refundLineAmount) : "-"}
-          </InfoRow>
+          <InfoRow label="approved refund" value={hasApprovedRefund(refund) ? "예" : "아니오"} />
+          <InfoRow
+            label="adjustment pending"
+            value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
+          />
+          <InfoRow label="status" status value={refundStatus} />
+          <InfoRow
+            label="refund line amount"
+            value={refundLineAmount > 0 ? formatAmount(refundLineAmount) : "-"}
+          />
         </SectionCard>
       </div>
 

--- a/admin-web/src/pages/merchant/SettlementDetailPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementDetailPage.jsx
@@ -7,6 +7,8 @@ import StatusBadge from "../../components/display/StatusBadge.jsx";
 import CopyableId from "../../components/display/CopyableId.jsx";
 import InfoRow from "../../components/display/InfoRow.jsx";
 import GuardNotice from "../../components/common/GuardNotice.jsx";
+import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import ErrorState from "../../components/feedback/ErrorState.jsx";
 import { getMe } from "../../api/meApi.js";
 import { getMerchantSettlementDetail } from "../../api/merchantSettlementApi.js";
 
@@ -15,6 +17,45 @@ function formatAmount(value) {
   const num = Number(value);
   if (Number.isNaN(num)) return String(value);
   return `${num.toLocaleString("ko-KR")}원`;
+}
+
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
+function extractMerchantId(payload) {
+  return (
+    payload?.merchantId ||
+    payload?.data?.merchantId ||
+    payload?.user?.merchantId ||
+    payload?.principal?.merchantId ||
+    null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
+  }
+  if (status === 403) {
+    return "Merchant 권한이 없어 정산 상세 화면에 접근할 수 없습니다.";
+  }
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
+  );
 }
 
 function mapDetailErrorToMessage(error) {
@@ -47,16 +88,6 @@ function hasApprovedRefund(refund) {
   );
 }
 
-function extractMerchantId(payload) {
-  return (
-    payload?.merchantId ||
-    payload?.data?.merchantId ||
-    payload?.user?.merchantId ||
-    payload?.principal?.merchantId ||
-    null
-  );
-}
-
 function CopyableValue({ value }) {
   if (!value || value === "-") {
     return <span>-</span>;
@@ -73,25 +104,15 @@ export default function SettlementDetailPage() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
 
-  const fetchMerchantId = useCallback(async () => {
-    const response = await getMe();
-    const resolvedMerchantId = extractMerchantId(response);
-
-    if (!resolvedMerchantId) {
-      throw new Error("세션에서 merchantId를 확인할 수 없습니다.");
-    }
-
-    return resolvedMerchantId;
-  }, []);
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
 
   const fetchDetail = useCallback(
-    async (signal) => {
+    async (resolvedMerchantId, signal) => {
       try {
         setLoading(true);
         setLoadError("");
-
-        const resolvedMerchantId = merchantId || (await fetchMerchantId());
-        setMerchantId(resolvedMerchantId);
 
         const data = await getMerchantSettlementDetail(
           resolvedMerchantId,
@@ -110,14 +131,68 @@ export default function SettlementDetailPage() {
         setLoading(false);
       }
     },
-    [fetchMerchantId, merchantId, settlementId]
+    [settlementId]
   );
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkMerchantRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+        setMerchantId("");
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+        const resolvedMerchantId = extractMerchantId(me);
+
+        if (!mounted) return;
+
+        if (role !== "MERCHANT") {
+          setIsAllowed(false);
+          setAuthErrorMessage(
+            "Merchant 전용 정산 상세 화면입니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
+          );
+          return;
+        }
+
+        if (!resolvedMerchantId) {
+          setIsAllowed(false);
+          setAuthErrorMessage(
+            "세션에서 merchantId를 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요."
+          );
+          return;
+        }
+
+        setMerchantId(resolvedMerchantId);
+        setIsAllowed(true);
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkMerchantRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed || !merchantId) return;
+
     const controller = new AbortController();
-    fetchDetail(controller.signal);
+    fetchDetail(merchantId, controller.signal);
     return () => controller.abort();
-  }, [fetchDetail]);
+  }, [isAllowed, merchantId, fetchDetail]);
 
   const currentSettlementId = detail?.settlementId || settlementId || "-";
   const currentMerchantId = detail?.merchantId || merchantId || "-";
@@ -146,6 +221,41 @@ export default function SettlementDetailPage() {
     if (hasApprovedRefund(refund)) return "APPROVED";
     return "NONE";
   }, [refund]);
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title="정산 상세"
+        description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title="정산 상세"
+        description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Merchant 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   if (loading) {
     return (

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -51,6 +51,16 @@ function normalizeSettlementList(payload) {
   return [];
 }
 
+function extractRole(payload) {
+  return (
+    payload?.role ||
+    payload?.data?.role ||
+    payload?.user?.role ||
+    payload?.principal?.role ||
+    null
+  );
+}
+
 function extractMerchantId(payload) {
   return (
     payload?.merchantId ||
@@ -58,6 +68,27 @@ function extractMerchantId(payload) {
     payload?.user?.merchantId ||
     payload?.principal?.merchantId ||
     null
+  );
+}
+
+function buildAuthErrorMessage(error) {
+  const status = error?.status;
+  const message =
+    error?.body?.message ||
+    error?.body?.reason ||
+    error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
+  }
+
+  if (status === 403) {
+    return "Merchant 권한이 없어 정산 리스트 화면에 접근할 수 없습니다.";
+  }
+
+  return (
+    message ||
+    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
   );
 }
 
@@ -103,28 +134,20 @@ export default function SettlementListPage() {
     searchParams.get("to") ?? getDefaultTo()
   );
 
+  const [authChecking, setAuthChecking] = useState(true);
+  const [isAllowed, setIsAllowed] = useState(false);
+  const [authErrorMessage, setAuthErrorMessage] = useState("");
+
   const pageTitle = useMemo(() => "정산 리스트", []);
 
-  const fetchMerchantId = useCallback(async () => {
-    const response = await getMe();
-    const resolvedMerchantId = extractMerchantId(response);
-
-    if (!resolvedMerchantId) {
-      throw new Error("세션에서 merchantId를 확인할 수 없습니다.");
-    }
-
-    return resolvedMerchantId;
-  }, []);
-
   const fetchSettlements = useCallback(
-    async (nextStatus, nextFromDate, nextToDate) => {
+    async (resolvedMerchantId, nextStatus, nextFromDate, nextToDate) => {
+      if (!resolvedMerchantId) return;
+
       setLoading(true);
       setErrorMessage("");
 
       try {
-        const resolvedMerchantId = merchantId || (await fetchMerchantId());
-        setMerchantId(resolvedMerchantId);
-
         const params = {};
         if (nextStatus) params.status = nextStatus;
         if (nextFromDate) params.from = nextFromDate;
@@ -140,10 +163,64 @@ export default function SettlementListPage() {
         setLoading(false);
       }
     },
-    [fetchMerchantId, merchantId]
+    []
   );
 
   useEffect(() => {
+    let mounted = true;
+
+    async function checkMerchantRole() {
+      try {
+        setAuthChecking(true);
+        setAuthErrorMessage("");
+        setIsAllowed(false);
+        setMerchantId("");
+
+        const me = await getMe();
+        const role = String(extractRole(me) || "").toUpperCase();
+        const resolvedMerchantId = extractMerchantId(me);
+
+        if (!mounted) return;
+
+        if (role !== "MERCHANT") {
+          setIsAllowed(false);
+          setAuthErrorMessage(
+            "Merchant 전용 정산 리스트 화면입니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
+          );
+          return;
+        }
+
+        if (!resolvedMerchantId) {
+          setIsAllowed(false);
+          setAuthErrorMessage(
+            "세션에서 merchantId를 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요."
+          );
+          return;
+        }
+
+        setMerchantId(resolvedMerchantId);
+        setIsAllowed(true);
+      } catch (error) {
+        if (!mounted) return;
+        setIsAllowed(false);
+        setAuthErrorMessage(buildAuthErrorMessage(error));
+      } finally {
+        if (mounted) {
+          setAuthChecking(false);
+        }
+      }
+    }
+
+    checkMerchantRole();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isAllowed || !merchantId) return;
+
     const nextStatus = searchParams.get("status") ?? "";
     const nextFromDate = searchParams.get("from") ?? getDefaultFrom();
     const nextToDate = searchParams.get("to") ?? getDefaultTo();
@@ -151,11 +228,12 @@ export default function SettlementListPage() {
     setStatus(nextStatus);
     setFromDate(nextFromDate);
     setToDate(nextToDate);
-    fetchSettlements(nextStatus, nextFromDate, nextToDate);
-  }, [searchParams, fetchSettlements]);
+    fetchSettlements(merchantId, nextStatus, nextFromDate, nextToDate);
+  }, [searchParams, fetchSettlements, isAllowed, merchantId]);
 
   const handleSearch = (event) => {
     event.preventDefault();
+    if (!isAllowed) return;
 
     const nextParams = {};
     if (status) nextParams.status = status;
@@ -172,6 +250,9 @@ export default function SettlementListPage() {
     setStatus("");
     setFromDate(nextFrom);
     setToDate(nextTo);
+
+    if (!isAllowed) return;
+
     setSearchParams({
       from: nextFrom,
       to: nextTo,
@@ -179,9 +260,44 @@ export default function SettlementListPage() {
   };
 
   const handleRowClick = (settlementId) => {
-    if (!settlementId) return;
+    if (!isAllowed || !settlementId) return;
     navigate(`/merchant/settlements/${settlementId}`);
   };
+
+  if (authChecking) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
+      >
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
+      >
+        <GuardNotice
+          title="접근 불가"
+          message={authErrorMessage}
+          tone="danger"
+        />
+        <ErrorState
+          title="Merchant 전용 화면"
+          description={authErrorMessage}
+        />
+      </PageLayout>
+    );
+  }
 
   return (
     <PageLayout

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -10,6 +10,8 @@ import GuardNotice from "../../components/common/GuardNotice.jsx";
 import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
+import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+
 import { formatNumber } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
 import { getMerchantSettlements } from "../../api/merchantSettlementApi.js";
@@ -231,7 +233,7 @@ export default function SettlementListPage() {
     fetchSettlements(merchantId, nextStatus, nextFromDate, nextToDate);
   }, [searchParams, fetchSettlements, isAllowed, merchantId]);
 
-  const handleSearch = (event) => {
+  function handleSearch(event) {
     event.preventDefault();
     if (!isAllowed) return;
 
@@ -241,9 +243,9 @@ export default function SettlementListPage() {
     if (toDate) nextParams.to = toDate;
 
     setSearchParams(nextParams);
-  };
+  }
 
-  const handleReset = () => {
+  function handleReset() {
     const nextFrom = getDefaultFrom();
     const nextTo = getDefaultTo();
 
@@ -257,12 +259,12 @@ export default function SettlementListPage() {
       from: nextFrom,
       to: nextTo,
     });
-  };
+  }
 
-  const handleRowClick = (settlementId) => {
+  function handleRowClick(settlementId) {
     if (!isAllowed || !settlementId) return;
     navigate(`/merchant/settlements/${settlementId}`);
-  };
+  }
 
   if (authChecking) {
     return (
@@ -281,6 +283,23 @@ export default function SettlementListPage() {
   }
 
   if (!isAllowed) {
+    if (
+      authErrorMessage.includes("로그인") ||
+      authErrorMessage.includes("인증")
+    ) {
+      return (
+        <PageLayout
+          title={pageTitle}
+          description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
+        >
+          <RequireLoginNotice
+            title="Merchant 전용 화면"
+            message={authErrorMessage}
+          />
+        </PageLayout>
+      );
+    }
+
     return (
       <PageLayout
         title={pageTitle}
@@ -291,10 +310,7 @@ export default function SettlementListPage() {
           message={authErrorMessage}
           tone="danger"
         />
-        <ErrorState
-          title="Merchant 전용 화면"
-          description={authErrorMessage}
-        />
+        <ErrorState message={authErrorMessage} />
       </PageLayout>
     );
   }
@@ -416,15 +432,16 @@ export default function SettlementListPage() {
 
       {errorMessage ? (
         <>
-          <GuardNotice title="조회 실패" message={errorMessage} tone="danger" />
-          <ErrorState
-            title="정산 리스트 조회 실패"
-            description={errorMessage}
+          <GuardNotice
+            title="조회 실패"
+            message={errorMessage}
+            tone="danger"
           />
+          <ErrorState message={errorMessage} />
         </>
       ) : null}
 
-      <SectionCard title="정산 리스트" description={`총 ${rows.length}건`}>
+      <SectionCard title={`정산 리스트 (${rows.length}건)`}>
         {loading ? (
           <LoadingBlock
             title="로딩 중"


### PR DESCRIPTION
## 작업 내용
- A2 BatchPage에 admin 세션 role 가드 추가
- A3 SettlementManagePage에 admin 세션 role 가드 추가
- A4 SettlementDetailAdminPage에 admin 세션 role 가드 추가
- U4 SettlementListPage에 merchant 세션 role + merchantId 확인 가드 추가
- U5 SettlementDetailPage에 merchant 세션 role + merchantId 확인 가드 추가
- C3 MyOrdersPage에 consumer 세션 role 가드 추가

## 변경 목적
- 다른 역할 세션에서 타 역할 페이지가 렌더되는 문제를 프론트 페이지 단에서 우선 차단
- 공통 auth/route 코드는 건드리지 않고, 각 페이지 내부에서 `/api/me` 기반으로 최소 수정 적용
- 직접 URL 입력으로 상세 페이지 접근하는 케이스까지 차단

## 동작 방식
- 페이지 진입 시 `getMe()`로 현재 세션 role 확인
- 허용 role이 아니면 API 호출 전에 차단 화면 렌더
- 허용 role일 때만 기존 조회 로직 실행
- merchant 페이지는 role 확인 후 merchantId까지 확보한 뒤 API 호출

## 영향 범위
- admin-web/src/pages/admin/BatchPage.jsx
- admin-web/src/pages/admin/SettlementManagePage.jsx
- admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
- admin-web/src/pages/merchant/SettlementListPage.jsx
- admin-web/src/pages/merchant/SettlementDetailPage.jsx
- admin-web/src/pages/consumer/MyOrdersPage.jsx

## 확인 포인트
- Admin 세션:
  - `/admin/settlement-batches`, `/admin/settlements`, `/admin/settlements/:settlementId` 정상 접근
  - `/merchant/settlements`, `/merchant/settlements/:settlementId`, `/consumer/orders` 차단
- Merchant 세션:
  - `/merchant/settlements`, `/merchant/settlements/:settlementId` 정상 접근
  - `/admin/*`, `/consumer/orders` 차단
- Consumer 세션:
  - `/consumer/orders` 정상 접근
  - `/admin/*`, `/merchant/*` 차단

## 비고
- 이번 PR은 프론트 페이지 단 가드만 추가
- 최종 권한 보호 SoT는 백엔드 403 검증 유지가 전제