### PR TITLE
feat(frontend): connect A4 hold creation flow to A5 hold queue

### DIFF
--- a/admin-web/src/api/holdsApi.js
+++ b/admin-web/src/api/holdsApi.js
@@ -52,3 +52,10 @@ export async function releaseHold(holdId, comment = "") {
     }),
   });
 }
+
+export async function createHold(payload) {
+  return requestJson("/api/admin/holds", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}

--- a/admin-web/src/pages/admin/AdminHoldPage.jsx
+++ b/admin-web/src/pages/admin/AdminHoldPage.jsx
@@ -7,15 +7,22 @@ import HoldTable from "../../components/hold/HoldTable.jsx";
 import HoldDetailPanel from "../../components/hold/HoldDetailPanel.jsx";
 import {
   fetchHolds,
+  createHold,
   approveHold,
   releaseHold,
 } from "../../api/holdsApi.js";
 import { showToast } from "../../utils/toast.js";
 import { getMe } from "../../api/meApi.js";
 import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+import "../../style/admin-hold-page.css";
 
 const DEFAULT_PAGE = 0;
 const DEFAULT_SIZE = 20;
+
+const HOLD_REASON_OPTIONS = [
+  { value: "MANUAL_REVIEW", label: "MANUAL_REVIEW" },
+  { value: "RISK_SUSPECTED", label: "RISK_SUSPECTED" },
+];
 
 const EMPTY_RESULT = {
   items: [],
@@ -25,6 +32,12 @@ const EMPTY_RESULT = {
   totalPages: 0,
 };
 
+const EMPTY_CREATE_FORM = {
+  settlementId: "",
+  reasonCode: "MANUAL_REVIEW",
+  comment: "",
+};
+
 function parseQuery(search) {
   const params = new URLSearchParams(search);
 
@@ -32,6 +45,7 @@ function parseQuery(search) {
     status: params.get("status") || "",
     settlementId: params.get("settlementId") || "",
     merchantId: params.get("merchantId") || "",
+    mode: params.get("mode") || "",
     page: Number(params.get("page") || DEFAULT_PAGE),
     size: Number(params.get("size") || DEFAULT_SIZE),
   };
@@ -43,6 +57,7 @@ function buildQuery(params) {
   if (params.status) searchParams.set("status", params.status);
   if (params.settlementId) searchParams.set("settlementId", params.settlementId);
   if (params.merchantId) searchParams.set("merchantId", params.merchantId);
+  if (params.mode) searchParams.set("mode", params.mode);
 
   searchParams.set("page", String(params.page ?? DEFAULT_PAGE));
   searchParams.set("size", String(params.size ?? DEFAULT_SIZE));
@@ -71,11 +86,39 @@ function isAdminRole(me) {
 function buildErrorInfo(error, fallbackMessage) {
   return {
     status: error?.status ?? null,
-    message:
-      error?.body?.message ||
-      error?.body?.reason ||
-      fallbackMessage,
+    message: error?.body?.message || error?.body?.reason || fallbackMessage,
   };
+}
+
+function mapCreateHoldErrorMessage(error) {
+  const status = error?.status;
+  const reason = error?.body?.reason;
+  const message = error?.body?.message || error?.message;
+
+  if (status === 401) {
+    return "인증이 만료되었거나 로그인되지 않았습니다. Admin 세션으로 다시 로그인해 주세요.";
+  }
+
+  if (status === 403) {
+    return "Admin 권한이 없어 Hold를 생성할 수 없습니다.";
+  }
+
+  if (status === 409) {
+    switch (reason) {
+      case "PAID_ALREADY":
+        return "이미 지급 완료된 정산에는 Hold를 생성할 수 없습니다.";
+      case "HOLD_ALREADY_EXISTS":
+        return "이미 Hold가 존재하는 정산입니다.";
+      default:
+        return message || "현재 상태에서는 Hold를 생성할 수 없습니다.";
+    }
+  }
+
+  if (status === 400) {
+    return message || "Hold 생성 요청값이 올바르지 않습니다.";
+  }
+
+  return message || "Hold 생성 중 오류가 발생했습니다.";
 }
 
 export default function AdminHoldPage() {
@@ -83,6 +126,7 @@ export default function AdminHoldPage() {
   const navigate = useNavigate();
 
   const queryState = useMemo(() => parseQuery(location.search), [location.search]);
+  const isCreateMode = queryState.mode === "create";
 
   const [me, setMe] = useState(null);
   const [meLoading, setMeLoading] = useState(true);
@@ -96,6 +140,11 @@ export default function AdminHoldPage() {
   const [actionLoading, setActionLoading] = useState(false);
   const [actionErrorMessage, setActionErrorMessage] = useState("");
   const [actionSuccessMessage, setActionSuccessMessage] = useState("");
+
+  const [createForm, setCreateForm] = useState(EMPTY_CREATE_FORM);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [createErrorMessage, setCreateErrorMessage] = useState("");
+  const [createSuccessMessage, setCreateSuccessMessage] = useState("");
 
   const items = Array.isArray(result.items) ? result.items : [];
 
@@ -137,6 +186,20 @@ export default function AdminHoldPage() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    setCreateForm((prev) => ({
+      ...prev,
+      settlementId: queryState.settlementId || "",
+    }));
+  }, [queryState.settlementId]);
+
+  useEffect(() => {
+    if (!isCreateMode) {
+      setCreateErrorMessage("");
+      setCreateSuccessMessage("");
+    }
+  }, [isCreateMode]);
 
   useEffect(() => {
     if (meLoading || meErrorInfo || !isAdminRole(me)) {
@@ -224,6 +287,7 @@ export default function AdminHoldPage() {
   function handlePageChange(nextPage) {
     const nextQuery = buildQuery({
       ...queryState,
+      mode: isCreateMode ? "create" : "",
       page: nextPage,
       size: queryState.size || DEFAULT_SIZE,
     });
@@ -237,6 +301,28 @@ export default function AdminHoldPage() {
     setActionSuccessMessage("");
   }
 
+  function handleCreateFieldChange(event) {
+    const { name, value } = event.target;
+    setCreateForm((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    setCreateErrorMessage("");
+    setCreateSuccessMessage("");
+  }
+
+  function handleCancelCreateMode() {
+    const nextQuery = buildQuery({
+      status: queryState.status,
+      settlementId: queryState.settlementId,
+      merchantId: queryState.merchantId,
+      page: DEFAULT_PAGE,
+      size: queryState.size || DEFAULT_SIZE,
+    });
+
+    navigate(`/admin/holds${nextQuery ? `?${nextQuery}` : ""}`);
+  }
+
   async function reloadCurrentPage() {
     const data = await fetchHolds({
       status: queryState.status || undefined,
@@ -247,6 +333,68 @@ export default function AdminHoldPage() {
     });
 
     setResult(data ?? EMPTY_RESULT);
+    return data ?? EMPTY_RESULT;
+  }
+
+  async function handleCreateHold(event) {
+    event.preventDefault();
+
+    if (createLoading) return;
+
+    const settlementId = createForm.settlementId.trim();
+    const reasonCode = createForm.reasonCode.trim();
+    const comment = createForm.comment.trim();
+
+    if (!settlementId) {
+      setCreateErrorMessage("settlementId는 필수입니다.");
+      return;
+    }
+
+    if (!reasonCode) {
+      setCreateErrorMessage("reasonCode는 필수입니다.");
+      return;
+    }
+
+    if (!comment) {
+      setCreateErrorMessage("comment는 필수입니다.");
+      return;
+    }
+
+    try {
+      setCreateLoading(true);
+      setCreateErrorMessage("");
+      setCreateSuccessMessage("");
+
+      const response = await createHold({
+        settlementId,
+        reasonCode,
+        comment,
+      });
+
+      const successMessage = "Hold 생성이 완료되었습니다.";
+      setCreateSuccessMessage(successMessage);
+      showToast(successMessage);
+
+      const nextQuery = buildQuery({
+        status: queryState.status,
+        settlementId,
+        merchantId: queryState.merchantId,
+        page: DEFAULT_PAGE,
+        size: queryState.size || DEFAULT_SIZE,
+      });
+
+      navigate(`/admin/holds?${nextQuery}`);
+
+      if (response?.holdId) {
+        setSelectedRowKey("");
+      }
+    } catch (error) {
+      const message = mapCreateHoldErrorMessage(error);
+      setCreateErrorMessage(message);
+      showToast(message);
+    } finally {
+      setCreateLoading(false);
+    }
   }
 
   async function handleApprove() {
@@ -378,6 +526,93 @@ export default function AdminHoldPage() {
       title="Hold Queue"
       description="A5 운영통제 큐. Hold 목록을 조회하고 승인/해제를 수행합니다."
     >
+      {isCreateMode ? (
+        <SectionCard title="Hold 생성">
+          <form className="form-stack" onSubmit={handleCreateHold}>
+            <div className="form-field">
+              <label className="form-field__label" htmlFor="hold-settlement-id">
+                settlementId
+              </label>
+              <input
+                id="hold-settlement-id"
+                name="settlementId"
+                className="input"
+                value={createForm.settlementId}
+                onChange={handleCreateFieldChange}
+                placeholder="settlementId를 입력하세요."
+              />
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label" htmlFor="hold-reason-code">
+                reasonCode
+              </label>
+              <select
+                id="hold-reason-code"
+                name="reasonCode"
+                className="select hold-create-select"
+                value={createForm.reasonCode}
+                onChange={handleCreateFieldChange}
+              >
+                {HOLD_REASON_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="form-field">
+              <label className="form-field__label" htmlFor="hold-comment">
+                comment <span className="form-required">(필수)</span>
+              </label>
+              <textarea
+                id="hold-comment"
+                name="comment"
+                className="textarea"
+                value={createForm.comment}
+                onChange={handleCreateFieldChange}
+                placeholder="Hold 생성 사유를 입력하세요."
+                rows={4}
+              />
+            </div>
+
+            {createErrorMessage ? (
+              <div className="guard-notice">
+                <div className="guard-notice__title">생성 실패</div>
+                <div className="guard-notice__description">{createErrorMessage}</div>
+              </div>
+            ) : null}
+
+            {createSuccessMessage ? (
+              <div className="guard-notice">
+                <div className="guard-notice__title">생성 완료</div>
+                <div className="guard-notice__description">{createSuccessMessage}</div>
+              </div>
+            ) : null}
+
+            <div className="button-row action-panel">
+              <button
+                type="submit"
+                className="btn btn--primary"
+                disabled={createLoading}
+              >
+                {createLoading ? "생성 중..." : "Hold 생성"}
+              </button>
+
+              <button
+                type="button"
+                className="btn btn--secondary"
+                onClick={handleCancelCreateMode}
+                disabled={createLoading}
+              >
+                생성 취소
+              </button>
+            </div>
+          </form>
+        </SectionCard>
+      ) : null}
+
       <SectionCard title="검색 조건">
         <HoldSearchForm
           initialValues={{
@@ -390,7 +625,7 @@ export default function AdminHoldPage() {
         />
       </SectionCard>
 
-      <SectionCard title="A5 Hold 큐 목록">
+      <SectionCard title="목록">
         {errorMessage && (
           <div className="info-list" style={{ marginBottom: "16px" }}>
             <div>
@@ -399,15 +634,8 @@ export default function AdminHoldPage() {
           </div>
         )}
 
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "minmax(0, 2fr) minmax(320px, 1fr)",
-            gap: "16px",
-            alignItems: "start",
-          }}
-        >
-          <div>
+        <div className="hold-queue-layout hold-queue-layout--toned">
+          <div className="hold-queue-table-scope">
             <HoldTable
               loading={loading}
               items={items}

--- a/admin-web/src/style/admin-hold-page.css
+++ b/admin-web/src/style/admin-hold-page.css
@@ -1,0 +1,59 @@
+.hold-queue-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.hold-create-select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20' fill='none'><path d='M5 7.5L10 12.5L15 7.5' stroke='%23111827' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 18px 18px;
+  padding-right: 44px;
+  cursor: pointer;
+}
+
+.form-required {
+  color: #dc2626;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.hold-queue-layout--toned .table-toolbar {
+  margin-bottom: 12px;
+}
+
+.hold-queue-table-scope .table-toolbar:first-of-type {
+  color: var(--color-text-muted, #9ca3af);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.hold-queue-table-scope .table-toolbar:first-of-type > div:first-child {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-muted, #9ca3af);
+}
+
+.hold-queue-table-scope .table-toolbar:first-of-type .action-panel {
+  gap: 12px;
+  color: var(--color-text-muted, #9ca3af);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.hold-queue-table-scope .table-toolbar:last-of-type {
+  margin-top: 12px;
+  color: var(--color-text-muted, #9ca3af);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.hold-queue-table-scope .table-toolbar:last-of-type > div {
+  color: var(--color-text-muted, #9ca3af);
+}


### PR DESCRIPTION
## 작업 내용
- A4 정산 상세에서 settlementId를 기준으로 A5 Hold 화면으로 이동하는 흐름을 연결했습니다.
- A5 Hold 화면에 Hold 생성 모드를 추가했습니다.
- Hold 생성 시 settlementId를 쿼리스트링으로 받아 초기값에 반영하도록 구성했습니다.
- Hold 생성 API 연동을 추가했습니다.
- A5 목록/상세 레이아웃과 생성 폼 스타일을 샘플 톤에 맞게 정리했습니다.

## 반영 상세
- `POST /api/admin/holds` 호출용 API 함수 추가
- `/admin/holds?settlementId=...&mode=create` 진입 지원
- 생성 모드에서
  - settlementId 입력
  - reasonCode 선택
  - comment 입력
  - 생성/취소 액션 처리
- 목록 화면에서는 기존 A5 조회/선택/approve/release 흐름 유지
- settlementId 기준으로 A4 상세 화면 재이동 가능하도록 연결 유지

## 확인한 점
- A4에서 Hold 생성 버튼 클릭 시 A5 생성 화면으로 이동
- settlementId가 생성 폼에 반영되는지 확인
- Hold 생성 후 A5 목록으로 복귀하는 흐름 확인
- 기존 Hold approve / release 동작 영향 없도록 분리

## 참고
- 이번 PR은 Hold 생성 및 A4→A5 연결 범위만 포함합니다.
- approve-paid 관련 A4 변경사항은 이번 커밋/푸시 범위에 포함하지 않았습니다.