### PR TITLE
fix(frontend): align A4 settlement detail guardrails and trace entry

### DIFF
--- a/admin-web/src/api/adminSettlementApi.js
+++ b/admin-web/src/api/adminSettlementApi.js
@@ -20,3 +20,10 @@ export function requestAdminSettlementPaid(settlementId) {
     body: JSON.stringify({}),
   });
 }
+
+export function approveAdminSettlementPaid(settlementId) {
+  return requestJson(`/api/admin/settlements/${settlementId}/approve-paid`, {
+    method: "PATCH",
+    body: JSON.stringify({}),
+  });
+}

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -17,6 +17,7 @@ import {
   getAdminSettlementDetail,
   getAdminSettlementTraceEntry,
   requestAdminSettlementPaid,
+  approveAdminSettlementPaid,
 } from "../../api/adminSettlementApi.js";
 
 function formatAmount(value) {
@@ -94,6 +95,19 @@ function mapRequestPaidReasonToMessage(reason) {
   }
 }
 
+function mapApprovePaidReasonToMessage(reason) {
+  switch (reason) {
+    case "SAME_APPROVER_NOT_ALLOWED":
+      return "4-eyes 규칙 위반입니다. 지급 요청자와 다른 Admin이 승인해야 합니다.";
+    case "PAY_REQUESTED_REQUIRED":
+      return "PAY_REQUESTED 상태에서만 지급 승인할 수 있습니다.";
+    case "IN_PROGRESS":
+      return "다른 승인 요청이 처리 중입니다. 잠시 후 다시 시도해 주세요.";
+    default:
+      return "현재 상태에서는 지급 승인이 불가능합니다.";
+  }
+}
+
 function mapTraceEntryErrorToMessage(error) {
   const status = error?.status;
   const message =
@@ -162,6 +176,7 @@ export default function SettlementDetailAdminPage() {
   const [loadError, setLoadError] = useState("");
 
   const [requestPaidLoading, setRequestPaidLoading] = useState(false);
+  const [approvePaidLoading, setApprovePaidLoading] = useState(false);
   const [traceEntryLoading, setTraceEntryLoading] = useState(true);
 
   const [actionMessage, setActionMessage] = useState("");
@@ -325,29 +340,50 @@ export default function SettlementDetailAdminPage() {
     return false;
   }, [status, holdActive, refund]);
 
+  const approvePaidDisabled = useMemo(() => {
+    return status !== "PAY_REQUESTED";
+  }, [status]);
+
   const traceButtonDisabled = useMemo(() => {
     if (traceEntryLoading) return true;
     if (!traceRequestId) return true;
     return false;
   }, [traceEntryLoading, traceRequestId]);
 
+  const primaryActionMode = useMemo(() => {
+    if (status === "PAY_REQUESTED") return "APPROVE";
+    return "REQUEST";
+  }, [status]);
+
   const guardMessages = useMemo(() => {
     const messages = [];
 
-    if (holdActive) {
+    if (status === "READY") {
+      if (holdActive) {
+        messages.push(
+          "Hold가 ACTIVE라 지급요청 불가입니다. Hold 큐(A5)에서 Release 후 다시 시도해야 합니다."
+        );
+      }
+
+      if (isRefundAdjustmentPending(refund)) {
+        messages.push(
+          "승인된 환불이 있어 차감정산 반영 전입니다. 다음 배치 실행 후 다시 시도해야 합니다."
+        );
+      }
+    }
+
+    if (status === "PAY_REQUESTED") {
       messages.push(
-        "Hold가 ACTIVE라 지급요청 불가입니다. Hold 큐(A5)에서 Release 후 다시 시도해야 합니다."
+        "현재 정산 건은 PAY_REQUESTED 상태입니다. 4-eyes 규칙에 따라 지급 요청자와 다른 Admin이 지급 승인해야 합니다."
       );
     }
 
-    if (isRefundAdjustmentPending(refund)) {
-      messages.push(
-        "승인된 환불이 있어 차감정산 반영 전입니다. 다음 배치 실행 후 다시 시도해야 합니다."
-      );
+    if (status !== "READY" && status !== "PAY_REQUESTED" && status !== "PAID") {
+      messages.push("현재 상태에서는 지급 요청/지급 승인을 진행할 수 없습니다.");
     }
 
-    if (status !== "READY") {
-      messages.push("READY 상태에서만 지급 요청이 가능합니다.");
+    if (status === "PAID") {
+      messages.push("이미 지급 완료된 정산입니다.");
     }
 
     return messages;
@@ -382,6 +418,38 @@ export default function SettlementDetailAdminPage() {
       }
     } finally {
       setRequestPaidLoading(false);
+    }
+  }
+
+  async function handleApprovePaid() {
+    if (!isAllowed || !detail?.settlementId) return;
+
+    try {
+      setApprovePaidLoading(true);
+      setActionMessage("");
+      setActionError("");
+
+      await approveAdminSettlementPaid(detail.settlementId);
+
+      setActionMessage("지급 승인이 완료되었습니다.");
+      await reloadPageData();
+    } catch (error) {
+      const statusCode = error?.status;
+      const reason = error?.body?.reason;
+
+      if (statusCode === 401) {
+        setActionError(
+          "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Admin 세션을 다시 생성해 주세요."
+        );
+      } else if (statusCode === 403) {
+        setActionError("Admin 권한이 없어 지급 승인을 수행할 수 없습니다.");
+      } else if (statusCode === 409) {
+        setActionError(mapApprovePaidReasonToMessage(reason));
+      } else {
+        setActionError("지급 승인 중 오류가 발생했습니다.");
+      }
+    } finally {
+      setApprovePaidLoading(false);
     }
   }
 
@@ -501,9 +569,13 @@ export default function SettlementDetailAdminPage() {
         />
       ) : (
         <GuardNotice
-          title="지급 요청 가능"
+          title={status === "PAY_REQUESTED" ? "지급 승인 가능" : "지급 요청 가능"}
           tone="info"
-          message="현재 HOLD_ACTIVE 및 REFUND_ADJUSTMENT_PENDING 조건이 없어 지급 요청이 가능합니다."
+          message={
+            status === "PAY_REQUESTED"
+              ? "현재 정산 건은 지급 승인 단계입니다. 요청자와 다른 Admin 계정으로 승인해야 합니다."
+              : "현재 HOLD_ACTIVE 및 REFUND_ADJUSTMENT_PENDING 조건이 없어 지급 요청이 가능합니다."
+          }
         />
       )}
 
@@ -525,14 +597,25 @@ export default function SettlementDetailAdminPage() {
 
       <SectionCard title="상단 액션">
         <div className="action-panel">
-          <ActionButton
-            type="button"
-            variant="primary"
-            onClick={handleRequestPaid}
-            disabled={requestPaidDisabled || requestPaidLoading}
-          >
-            {requestPaidLoading ? "요청 중…" : "지급 요청"}
-          </ActionButton>
+          {primaryActionMode === "APPROVE" ? (
+            <ActionButton
+              type="button"
+              variant="primary"
+              onClick={handleApprovePaid}
+              disabled={approvePaidDisabled || approvePaidLoading}
+            >
+              {approvePaidLoading ? "승인 중…" : "지급 승인"}
+            </ActionButton>
+          ) : (
+            <ActionButton
+              type="button"
+              variant="primary"
+              onClick={handleRequestPaid}
+              disabled={requestPaidDisabled || requestPaidLoading}
+            >
+              {requestPaidLoading ? "요청 중…" : "지급 요청"}
+            </ActionButton>
+          )}
 
           <ActionButton
             type="button"

--- a/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
+++ b/admin-web/src/pages/admin/SettlementDetailAdminPage.jsx
@@ -372,12 +372,6 @@ export default function SettlementDetailAdminPage() {
       }
     }
 
-    if (status === "PAY_REQUESTED") {
-      messages.push(
-        "현재 정산 건은 PAY_REQUESTED 상태입니다. 4-eyes 규칙에 따라 지급 요청자와 다른 Admin이 지급 승인해야 합니다."
-      );
-    }
-
     if (status !== "READY" && status !== "PAY_REQUESTED" && status !== "PAID") {
       messages.push("현재 상태에서는 지급 요청/지급 승인을 진행할 수 없습니다.");
     }
@@ -555,29 +549,29 @@ export default function SettlementDetailAdminPage() {
       title="정산 상세"
       description="settlementId를 앵커로 settlement / settlement_line / hold / refund를 연결 조회하는 운영 허브입니다."
     >
-      {guardMessages.length > 0 ? (
-        <GuardNotice
-          title="가드레일 안내"
-          tone="warning"
-          message={
-            <div>
-              {guardMessages.map((message) => (
-                <div key={message}>{message}</div>
-              ))}
-            </div>
-          }
-        />
-      ) : (
-        <GuardNotice
-          title={status === "PAY_REQUESTED" ? "지급 승인 가능" : "지급 요청 가능"}
-          tone="info"
-          message={
-            status === "PAY_REQUESTED"
-              ? "현재 정산 건은 지급 승인 단계입니다. 요청자와 다른 Admin 계정으로 승인해야 합니다."
-              : "현재 HOLD_ACTIVE 및 REFUND_ADJUSTMENT_PENDING 조건이 없어 지급 요청이 가능합니다."
-          }
-        />
-      )}
+     {guardMessages.length > 0 ? (
+       <GuardNotice
+         title="가드레일 안내"
+         tone="warning"
+         message={
+           <div>
+             {guardMessages.map((message) => (
+               <div key={message}>{message}</div>
+             ))}
+           </div>
+         }
+       />
+     ) : (
+       <GuardNotice
+         title={status === "PAY_REQUESTED" ? "지급 승인 가능" : "지급 요청 가능"}
+         tone="info"
+         message={
+           status === "PAY_REQUESTED"
+             ? "현재 정산 건은 지급 승인 단계입니다. 요청자와 다른 Admin 계정으로 승인해야 합니다."
+             : "현재 HOLD_ACTIVE 및 REFUND_ADJUSTMENT_PENDING 조건이 없어 지급 요청이 가능합니다."
+         }
+       />
+     )}
 
       {actionMessage ? (
         <GuardNotice title="처리 완료" message={actionMessage} tone="success" />
@@ -657,13 +651,13 @@ export default function SettlementDetailAdminPage() {
             <GuardNotice
               title="Trace 진입 정보"
               tone="info"
-              message="아래 requestId를 복사하거나 ‘Trace로 보기’ 버튼으로 A1에서 요청 단위 재현을 확인할 수 있습니다."
+              message="현재 정산 건 기준 최신 운영 requestId입니다. 연결 정보의 requestId를 복사하거나 ‘Trace로 보기’ 버튼으로 A1에서 요청 단위 재현을 확인할 수 있습니다."
             />
           ) : (
             <GuardNotice
               title="Trace 진입 정보"
               tone="info"
-              message="현재 정산 건의 Trace 진입 requestId를 확인 중이거나, 아직 재현 가능한 requestId가 없습니다."
+              message="현재 정산 건에서 Trace 진입에 사용할 최신 requestId가 아직 없습니다."
             />
           )}
         </div>

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -16,6 +16,9 @@ import { formatNumber } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
 import { getAdminSettlements } from "../../api/adminSettlementListApi.js";
 
+const DEFAULT_PAGE = 0;
+const DEFAULT_SIZE = 20;
+
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
   { value: "READY", label: "READY" },
@@ -31,13 +34,80 @@ function formatAmount(value) {
   return `${formatNumber(num)}원`;
 }
 
-function normalizeSettlementList(payload) {
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.data)) return payload.data;
-  if (Array.isArray(payload?.items)) return payload.items;
-  if (Array.isArray(payload?.content)) return payload.content;
-  if (Array.isArray(payload?.page?.content)) return payload.page.content;
-  return [];
+function normalizeSettlementResponse(payload) {
+  if (Array.isArray(payload)) {
+    return {
+      items: payload,
+      page: DEFAULT_PAGE,
+      size: payload.length || DEFAULT_SIZE,
+      totalElements: payload.length,
+      totalPages: payload.length > 0 ? 1 : 0,
+      hasNext: false,
+      hasPrevious: false,
+    };
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return {
+      items: payload.items,
+      page: Number(payload.page ?? DEFAULT_PAGE),
+      size: Number(payload.size ?? DEFAULT_SIZE),
+      totalElements: Number(payload.totalElements ?? payload.items.length ?? 0),
+      totalPages: Number(payload.totalPages ?? (payload.items.length > 0 ? 1 : 0)),
+      hasNext: Boolean(payload.hasNext),
+      hasPrevious: Boolean(payload.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.content)) {
+    return {
+      items: payload.content,
+      page: Number(payload.number ?? payload.page ?? DEFAULT_PAGE),
+      size: Number(payload.size ?? DEFAULT_SIZE),
+      totalElements: Number(payload.totalElements ?? payload.content.length ?? 0),
+      totalPages: Number(payload.totalPages ?? (payload.content.length > 0 ? 1 : 0)),
+      hasNext: Boolean(payload.hasNext),
+      hasPrevious: Boolean(payload.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.page?.content)) {
+    return {
+      items: payload.page.content,
+      page: Number(payload.page.number ?? DEFAULT_PAGE),
+      size: Number(payload.page.size ?? DEFAULT_SIZE),
+      totalElements: Number(
+        payload.page.totalElements ?? payload.page.content.length ?? 0
+      ),
+      totalPages: Number(
+        payload.page.totalPages ?? (payload.page.content.length > 0 ? 1 : 0)
+      ),
+      hasNext: Boolean(payload.page.hasNext),
+      hasPrevious: Boolean(payload.page.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return {
+      items: payload.data,
+      page: DEFAULT_PAGE,
+      size: payload.data.length || DEFAULT_SIZE,
+      totalElements: payload.data.length,
+      totalPages: payload.data.length > 0 ? 1 : 0,
+      hasNext: false,
+      hasPrevious: false,
+    };
+  }
+
+  return {
+    items: [],
+    page: DEFAULT_PAGE,
+    size: DEFAULT_SIZE,
+    totalElements: 0,
+    totalPages: 0,
+    hasNext: false,
+    hasPrevious: false,
+  };
 }
 
 function extractRole(payload) {
@@ -101,6 +171,13 @@ export default function SettlementManagePage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const [rows, setRows] = useState([]);
+  const [page, setPage] = useState(DEFAULT_PAGE);
+  const [size, setSize] = useState(DEFAULT_SIZE);
+  const [totalElements, setTotalElements] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [hasNext, setHasNext] = useState(false);
+  const [hasPrevious, setHasPrevious] = useState(false);
+
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -116,20 +193,43 @@ export default function SettlementManagePage() {
   const pageTitle = useMemo(() => "A3 정산 관리", []);
 
   const fetchSettlements = useCallback(
-    async (nextStatus = "", nextMerchantId = "") => {
+    async ({
+      nextStatus = "",
+      nextMerchantId = "",
+      nextPage = DEFAULT_PAGE,
+      nextSize = DEFAULT_SIZE,
+    }) => {
       setLoading(true);
       setErrorMessage("");
 
       try {
-        const params = {};
+        const params = {
+          page: nextPage,
+          size: nextSize,
+        };
+
         if (nextStatus) params.status = nextStatus;
         if (nextMerchantId.trim()) params.merchantId = nextMerchantId.trim();
 
         const data = await getAdminSettlements(params);
-        setRows(normalizeSettlementList(data));
+        const normalized = normalizeSettlementResponse(data);
+
+        setRows(normalized.items);
+        setPage(normalized.page);
+        setSize(normalized.size);
+        setTotalElements(normalized.totalElements);
+        setTotalPages(normalized.totalPages);
+        setHasNext(normalized.hasNext);
+        setHasPrevious(normalized.hasPrevious);
       } catch (error) {
         console.error("정산 리스트 조회 실패", error);
         setRows([]);
+        setPage(DEFAULT_PAGE);
+        setSize(DEFAULT_SIZE);
+        setTotalElements(0);
+        setTotalPages(0);
+        setHasNext(false);
+        setHasPrevious(false);
         setErrorMessage(buildErrorMessage(error));
       } finally {
         setLoading(false);
@@ -184,10 +284,18 @@ export default function SettlementManagePage() {
 
     const nextStatus = searchParams.get("status") ?? "";
     const nextMerchantId = searchParams.get("merchantId") ?? "";
+    const nextPage = Number(searchParams.get("page") ?? DEFAULT_PAGE);
+    const nextSize = Number(searchParams.get("size") ?? DEFAULT_SIZE);
 
     setStatus(nextStatus);
     setMerchantId(nextMerchantId);
-    fetchSettlements(nextStatus, nextMerchantId);
+
+    fetchSettlements({
+      nextStatus,
+      nextMerchantId,
+      nextPage,
+      nextSize,
+    });
   }, [searchParams, fetchSettlements, isAllowed]);
 
   function handleSearch(event) {
@@ -196,6 +304,8 @@ export default function SettlementManagePage() {
     const nextParams = {};
     if (status) nextParams.status = status;
     if (merchantId.trim()) nextParams.merchantId = merchantId.trim();
+    nextParams.page = String(DEFAULT_PAGE);
+    nextParams.size = String(size || DEFAULT_SIZE);
 
     setSearchParams(nextParams);
   }
@@ -203,7 +313,20 @@ export default function SettlementManagePage() {
   function handleReset() {
     setStatus("");
     setMerchantId("");
-    setSearchParams({});
+    setSearchParams({
+      page: String(DEFAULT_PAGE),
+      size: String(DEFAULT_SIZE),
+    });
+  }
+
+  function handlePageChange(nextPage) {
+    const nextParams = {};
+    if (status) nextParams.status = status;
+    if (merchantId.trim()) nextParams.merchantId = merchantId.trim();
+    nextParams.page = String(nextPage);
+    nextParams.size = String(size || DEFAULT_SIZE);
+
+    setSearchParams(nextParams);
   }
 
   function handleRowClick(settlementId) {
@@ -265,23 +388,12 @@ export default function SettlementManagePage() {
       title={pageTitle}
       description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
     >
-      <SectionCard title="조회 조건">
+      <SectionCard title="검색 조건">
         <form onSubmit={handleSearch}>
-          <div
-            className="filter-bar"
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              alignItems: "flex-end",
-              gap: "16px",
-            }}
-          >
-            <div
-              className="form-field"
-              style={{ minWidth: "220px", flex: "0 0 220px" }}
-            >
+          <div className="filter-bar">
+            <div className="form-field">
               <label className="form-field__label" htmlFor="status">
-                상태
+                status
               </label>
               <select
                 id="status"
@@ -297,10 +409,7 @@ export default function SettlementManagePage() {
               </select>
             </div>
 
-            <div
-              className="form-field"
-              style={{ minWidth: "240px", flex: "0 0 240px" }}
-            >
+            <div className="form-field">
               <label className="form-field__label" htmlFor="merchantId">
                 merchantId
               </label>
@@ -313,40 +422,29 @@ export default function SettlementManagePage() {
                 placeholder="merchantId 입력"
               />
             </div>
+          </div>
 
-            <div
-              className="button-row action-panel"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "12px",
-                flexWrap: "wrap",
-              }}
+          <div className="button-row action-panel" style={{ marginTop: "16px" }}>
+            <ActionButton
+              type="submit"
+              variant="primary"
+              disabled={loading}
             >
-              <ActionButton
-                type="submit"
-                variant="primary"
-                disabled={loading}
-              >
-                {loading ? "조회 중..." : "조회"}
-              </ActionButton>
+              {loading ? "조회 중..." : "조회"}
+            </ActionButton>
 
-              <ActionButton
-                type="button"
-                variant="secondary"
-                onClick={handleReset}
-                disabled={loading}
-              >
-                초기화
-              </ActionButton>
+            <ActionButton
+              type="button"
+              variant="secondary"
+              onClick={handleReset}
+              disabled={loading}
+            >
+              초기화
+            </ActionButton>
 
-              <Link
-                to="/admin/settlement-batches"
-                className="btn btn--secondary"
-              >
-                배치 콘솔(A2)
-              </Link>
-            </div>
+            <Link to="/admin/settlement-batches" className="btn btn--secondary">
+              배치 콘솔(A2)
+            </Link>
           </div>
         </form>
       </SectionCard>
@@ -358,15 +456,29 @@ export default function SettlementManagePage() {
         </>
       ) : null}
 
-      <SectionCard title="정산 리스트">
-        <div
-          style={{
-            marginBottom: "12px",
-            color: "var(--color-text-muted, #6b7280)",
-            fontSize: "14px",
-          }}
-        >
-          총 {rows.length}건
+      <SectionCard title="목록">
+        <div className="table-toolbar">
+          <div>
+            <div>정산 관리 목록</div>
+            <div
+              style={{
+                marginTop: "4px",
+                color: "var(--color-text-muted, #6b7280)",
+                fontSize: "14px",
+              }}
+            >
+              status / merchantId 기준으로 정산을 조회하고 settlementId 앵커로 A4 상세 화면으로 이동합니다.
+            </div>
+          </div>
+
+          <div
+            style={{
+              color: "var(--color-text-muted, #6b7280)",
+              fontSize: "14px",
+            }}
+          >
+            총 {totalElements}건
+          </div>
         </div>
 
         {loading ? (
@@ -380,87 +492,113 @@ export default function SettlementManagePage() {
             description="검색 조건을 다시 확인하거나 필터를 초기화해 주세요."
           />
         ) : (
-          <div className="table-wrap">
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>settlementId</th>
-                  <th>상태</th>
-                  <th>baseDate</th>
-                  <th>merchantId</th>
-                  <th>gross</th>
-                  <th>fee</th>
-                  <th>vat</th>
-                  <th>net</th>
-                  <th>상세</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row, index) => {
-                  const settlementId =
-                    row?.settlementId ?? row?.id ?? `row-${index}`;
-                  const rowMerchantId = row?.merchantId ?? "-";
+          <>
+            <div className="table-wrap">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>settlementId</th>
+                    <th>status</th>
+                    <th>baseDate</th>
+                    <th>merchantId</th>
+                    <th>gross</th>
+                    <th>fee</th>
+                    <th>vat</th>
+                    <th>net</th>
+                    <th>상세</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row, index) => {
+                    const settlementId =
+                      row?.settlementId ?? row?.id ?? `row-${index}`;
+                    const rowMerchantId = row?.merchantId ?? "-";
 
-                  return (
-                    <tr
-                      key={settlementId}
-                      onClick={() => handleRowClick(settlementId)}
-                      style={{ cursor: settlementId ? "pointer" : "default" }}
-                    >
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
+                    return (
+                      <tr
+                        key={settlementId}
+                        onClick={() => handleRowClick(settlementId)}
+                        style={{ cursor: settlementId ? "pointer" : "default" }}
                       >
-                        <CopyableId value={settlementId} short />
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        <StatusBadge status={row?.status || "UNKNOWN"} />
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {row?.baseDate ?? "-"}
-                      </td>
-
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
-                      >
-                        <CopyableId value={rowMerchantId} short />
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.gross)}
-                      </td>
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.fee)}
-                      </td>
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.vat)}
-                      </td>
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.net)}
-                      </td>
-
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
-                      >
-                        <ActionButton
-                          type="button"
-                          variant="secondary"
-                          onClick={() => handleRowClick(settlementId)}
-                          disabled={!settlementId}
+                        <td
+                          onClick={(event) => event.stopPropagation()}
+                          style={{ verticalAlign: "middle" }}
                         >
-                          상세조회
-                        </ActionButton>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                          <CopyableId value={settlementId} short />
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          <StatusBadge status={row?.status || "UNKNOWN"} />
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {row?.baseDate ?? "-"}
+                        </td>
+
+                        <td
+                          onClick={(event) => event.stopPropagation()}
+                          style={{ verticalAlign: "middle" }}
+                        >
+                          <CopyableId value={rowMerchantId} short />
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.gross)}
+                        </td>
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.fee)}
+                        </td>
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.vat)}
+                        </td>
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.net)}
+                        </td>
+
+                        <td
+                          onClick={(event) => event.stopPropagation()}
+                          style={{ verticalAlign: "middle" }}
+                        >
+                          <ActionButton
+                            type="button"
+                            variant="secondary"
+                            onClick={() => handleRowClick(settlementId)}
+                            disabled={!settlementId}
+                          >
+                            상세조회
+                          </ActionButton>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="pagination">
+              <button
+                type="button"
+                className="btn btn--secondary"
+                onClick={() => handlePageChange(page - 1)}
+                disabled={loading || !hasPrevious || page <= 0}
+              >
+                이전
+              </button>
+
+              <button type="button" className="btn btn--primary" disabled>
+                {page + 1}
+              </button>
+
+              <button
+                type="button"
+                className="btn btn--secondary"
+                onClick={() => handlePageChange(page + 1)}
+                disabled={loading || !hasNext || page + 1 >= totalPages}
+              >
+                다음
+              </button>
+            </div>
+          </>
         )}
       </SectionCard>
     </PageLayout>


### PR DESCRIPTION
## 작업 내용
- A4 정산 상세의 가드레일 문구와 버튼 동작 기준을 정리했습니다.
- PAY_REQUESTED 상태에서 1차 액션을 `지급 요청`이 아니라 `지급 승인` 흐름으로 보이도록 정렬했습니다.
- A4 Trace 진입 문구를 settlement 기준 최신 운영 requestId 의미에 맞게 정리했습니다.
- 최신 `origin/develop`를 merge 반영했습니다.
  - 포함 사항: A4 hold flow → A5 hold queue 연결 관련 최신 변경

## 반영 상세
- `SettlementDetailAdminPage.jsx`
  - guard message 조건 정리
  - PAY_REQUESTED 상태 안내 문구 정리
  - 상단 primary action 표시 기준 정리
  - Trace 진입 안내 문구 정리

## 확인 포인트
- A4에서 상태별 가드레일 문구가 기존 기획 의도와 맞는지
- PAY_REQUESTED 상태에서 primary CTA가 `지급 승인`으로 보이는지
- Trace 안내가 “정산 기준 최신 운영 requestId” 해석과 어긋나지 않는지
- latest develop merge로 들어온 A5 hold 관련 변경과 충돌 없는지

## 참고
- trace-entry의 정확한 최종 정책(정산 기준 최신 운영 requestId의 범위/우선순위)은 화면 문구 수준까지는 맞췄지만,
  팀 차원의 최종 Freeze 문장으로 별도 확정되면 그 표현에 맞춰 추가 정리 가능합니다.