### PR TITLE
feat(refund): add refund trace-entry API and no-op decision tests

### DIFF
--- a/admin-web/src/api/refundApi.js
+++ b/admin-web/src/api/refundApi.js
@@ -59,3 +59,9 @@ export function rejectRefund(refundId, comment) {
         body: JSON.stringify({ comment }),
     });
 }
+
+export function getAdminRefundTraceEntry(refundId) {
+    return requestJson(`/api/admin/refunds/${refundId}/trace-entry`, {
+        method: "GET",
+    });
+}

--- a/admin-web/src/api/refundApi.js
+++ b/admin-web/src/api/refundApi.js
@@ -19,11 +19,6 @@ export function getMyRefunds(params = {}) {
     }
     if (params.from) searchParams.set("from", params.from);
     if (params.to) searchParams.set("to", params.to);
-    if (params.keyword) searchParams.set("keyword", params.keyword);
-    if (params.sortKey) searchParams.set("sortKey", params.sortKey);
-    if (params.sortDirection) {
-        searchParams.set("sortDirection", params.sortDirection);
-    }
 
     searchParams.set("page", String(params.page ?? 0));
     searchParams.set("size", String(params.size ?? 20));

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -232,8 +232,6 @@ export default function RefundQueuePage() {
         !acting &&
         String(comment).trim().length > 0;
 
-    const canMoveToSettlement = Boolean(selectedRow?.settlementId);
-
     function handleDraftFilterChange(event) {
         const { name, value } = event.target;
         setDraftFilters((prev) => ({
@@ -367,11 +365,6 @@ export default function RefundQueuePage() {
         } finally {
             setActing(false);
         }
-    }
-
-    function moveToSettlementDetail() {
-        if (!selectedRow?.settlementId) return;
-        navigate(`/admin/settlements/${selectedRow.settlementId}`);
     }
 
     function moveToTrace() {
@@ -743,11 +736,10 @@ export default function RefundQueuePage() {
                     width: 58px;
                 }
 
-                .refund-queue-id-col,
-                .refund-queue-settlement-col {
+                .refund-queue-id-col {
                     width: 190px;
                 }
-
+                
                 .refund-queue-merchant-col {
                     width: 140px;
                 }
@@ -941,17 +933,6 @@ export default function RefundQueuePage() {
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--wide">
-                                    <span className="refund-queue-detail-label">settlementId</span>
-                                    <span className="refund-queue-detail-value">
-                                        {selectedRow?.settlementId ? (
-                                            <CopyableId value={selectedRow.settlementId} />
-                                        ) : (
-                                            "-"
-                                        )}
-                                    </span>
-                                </div>
-
                                 <div className="refund-queue-detail-item refund-queue-detail-item--compact">
                                     <span className="refund-queue-detail-label">refundable</span>
                                     <span className="refund-queue-detail-value">
@@ -995,14 +976,6 @@ export default function RefundQueuePage() {
                             </div>
 
                             <div className="refund-queue-actions">
-                                <ActionButton
-                                    type="button"
-                                    variant="secondary"
-                                    disabled={!canMoveToSettlement}
-                                    onClick={moveToSettlementDetail}
-                                >
-                                    정산 상세(A4)
-                                </ActionButton>
 
                                 <ActionButton
                                     type="button"
@@ -1092,7 +1065,6 @@ export default function RefundQueuePage() {
                                                 </button>
                                             </th>
 
-                                            <th className="refund-queue-settlement-col">settlementId</th>
                                             <th className="refund-queue-merchant-col">merchantId</th>
 
                                             <th className="refund-queue-amount-col">
@@ -1151,10 +1123,6 @@ export default function RefundQueuePage() {
 
                                                     <td className="refund-queue-id-col refund-queue-table-cell-copy">
                                                         <CopyableId value={row.refundId} short />
-                                                    </td>
-
-                                                    <td className="refund-queue-settlement-col refund-queue-table-cell-copy">
-                                                        <CopyableId value={row.settlementId} short />
                                                     </td>
 
                                                     <td className="refund-queue-merchant-col">

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -17,6 +17,7 @@ import {
     getAdminRefunds,
     approveRefund,
     rejectRefund,
+    getAdminRefundTraceEntry,
 } from "../../api/refundApi.js";
 import { formatDateTime } from "../../utils/format.js";
 
@@ -106,6 +107,8 @@ export default function RefundQueuePage() {
     const [selectedRefundId, setSelectedRefundId] = useState("");
     const [comment, setComment] = useState("");
     const [lastActionResult, setLastActionResult] = useState(null);
+    const [traceRequestId, setTraceRequestId] = useState("");
+    const [traceLoading, setTraceLoading] = useState(false);
 
     const [loading, setLoading] = useState(false);
     const [acting, setActing] = useState(false);
@@ -225,6 +228,40 @@ export default function RefundQueuePage() {
     const selectedRow =
         refunds.find((row) => row.refundId === selectedRefundId) || null;
 
+    useEffect(() => {
+        if (!selectedRow?.refundId) {
+            setTraceRequestId("");
+            setTraceLoading(false);
+            return;
+        }
+
+        let cancelled = false;
+
+        async function loadTraceEntry() {
+            try {
+                setTraceLoading(true);
+
+                const response = await getAdminRefundTraceEntry(selectedRow.refundId);
+
+                if (cancelled) return;
+                setTraceRequestId(response?.traceRequestId || "");
+            } catch (error) {
+                if (cancelled) return;
+                setTraceRequestId("");
+            } finally {
+                if (!cancelled) {
+                    setTraceLoading(false);
+                }
+            }
+        }
+
+        loadTraceEntry();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [selectedRow?.refundId]);
+
     const selectedStatus = String(selectedRow?.status || "").toUpperCase();
     const canAct =
         !!selectedRow &&
@@ -262,6 +299,7 @@ export default function RefundQueuePage() {
         setComment("");
         setErrorMessage("");
         setLastActionResult(null);
+        setTraceRequestId("");
     }
 
     function handleClearSelection() {
@@ -269,6 +307,8 @@ export default function RefundQueuePage() {
         setComment("");
         setErrorMessage("");
         setLastActionResult(null);
+        setTraceRequestId("");
+        setTraceLoading(false);
     }
 
     function handleSort(sortKey) {
@@ -368,10 +408,10 @@ export default function RefundQueuePage() {
     }
 
     function moveToTrace() {
-        const requestId = lastActionResult?.requestId;
+        const requestId = lastActionResult?.requestId || traceRequestId;
 
         if (!requestId) {
-            setErrorMessage("방금 처리한 환불의 requestId가 없어 Trace로 이동할 수 없습니다.");
+            setErrorMessage("이 환불 건의 requestId를 찾을 수 없어 Trace로 이동할 수 없습니다.");
             return;
         }
 
@@ -874,16 +914,6 @@ export default function RefundQueuePage() {
                                     </div>
                                 </div>
 
-                                <div className="refund-queue-actions" style={{ marginTop: 0 }}>
-                                    <ActionButton
-                                        type="button"
-                                        variant="secondary"
-                                        onClick={moveToTrace}
-                                        disabled={!lastActionResult?.requestId}
-                                    >
-                                        Trace로 보기(A1)
-                                    </ActionButton>
-                                </div>
                             </div>
                         ) : null}
 
@@ -994,6 +1024,15 @@ export default function RefundQueuePage() {
                                     {acting ? "처리 중..." : "거절(Reject)"}
                                 </ActionButton>
                             </div>
+
+                            <ActionButton
+                                type="button"
+                                variant="secondary"
+                                disabled={!selectedRow || traceLoading || (!lastActionResult?.requestId && !traceRequestId)}
+                                onClick={moveToTrace}
+                            >
+                                {traceLoading ? "Trace 확인 중..." : "Trace로 보기(A1)"}
+                            </ActionButton>
 
                             <div className="refund-queue-meta-note">
                                 * 409 포맷: {"{`{\"code\":\"RULE_VIOLATION\",\"reason\":\"INSUFFICIENT_REFUNDABLE\"}`}"}

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -565,9 +565,9 @@ export default function RefundQueuePage() {
 
                 .refund-queue-detail-grid {
                     display: grid;
-                    grid-template-columns: repeat(4, minmax(0, 1fr));
-                    gap: 8px 10px;
-                    margin-bottom: 10px;
+                    grid-template-columns: repeat(3, minmax(0, 1fr));
+                    gap: 10px;
+                    margin-bottom: 12px;
                 }
 
                 .refund-queue-detail-item {
@@ -575,26 +575,15 @@ export default function RefundQueuePage() {
                     align-items: center;
                     gap: 10px;
                     min-width: 0;
-                    padding: 9px 12px;
+                    min-height: 60px;
+                    padding: 10px 12px;
                     border: 1px solid var(--color-border);
                     border-radius: 10px;
                     background: #fcfcfd;
                 }
 
-                .refund-queue-detail-item--wide {
-                    grid-column: span 2;
-                }
-
-                .refund-queue-detail-item--memo {
-                    grid-column: span 3;
-                }
-
-                .refund-queue-detail-item--compact .refund-queue-detail-value {
-                    white-space: nowrap;
-                }
-
                 .refund-queue-detail-label {
-                    flex: 0 0 88px;
+                    flex: 0 0 92px;
                     font-size: 12px;
                     font-weight: 700;
                     color: #667085;
@@ -602,6 +591,7 @@ export default function RefundQueuePage() {
 
                 .refund-queue-detail-value {
                     min-width: 0;
+                    flex: 1 1 auto;
                     font-size: 14px;
                     font-weight: 700;
                     color: #101828;
@@ -631,10 +621,6 @@ export default function RefundQueuePage() {
 
                 .refund-queue-detail-value .amount-text {
                     font-size: 14px;
-                }
-
-                .refund-queue-detail-value .status-badge {
-                    vertical-align: middle;
                 }
 
                 .refund-queue-comment-block {
@@ -779,7 +765,7 @@ export default function RefundQueuePage() {
                 .refund-queue-id-col {
                     width: 190px;
                 }
-                
+
                 .refund-queue-merchant-col {
                     width: 140px;
                 }
@@ -842,11 +828,6 @@ export default function RefundQueuePage() {
                     .refund-queue-detail-grid {
                         grid-template-columns: repeat(2, minmax(0, 1fr));
                     }
-
-                    .refund-queue-detail-item--wide,
-                    .refund-queue-detail-item--memo {
-                        grid-column: 1 / -1;
-                    }
                 }
 
                 @media (max-width: 1080px) {
@@ -871,12 +852,6 @@ export default function RefundQueuePage() {
 
                     .refund-queue-detail-grid {
                         grid-template-columns: 1fr;
-                    }
-
-                    .refund-queue-detail-item,
-                    .refund-queue-detail-item--wide,
-                    .refund-queue-detail-item--memo {
-                        grid-column: auto;
                     }
 
                     .refund-queue-table {
@@ -909,24 +884,23 @@ export default function RefundQueuePage() {
                                         <span>{lastActionResult.status || "-"}</span>
                                     </div>
                                     <div className="refund-queue-result-item">
-                                        <strong>decidedAt</strong>
-                                        <span>{renderDate(lastActionResult.decidedAt)}</span>
+                                        <strong>requestId</strong>
+                                        <span>{lastActionResult.requestId || "-"}</span>
                                     </div>
                                 </div>
-
                             </div>
                         ) : null}
 
                         <div className="refund-queue-card">
                             <div className="refund-queue-detail-grid">
-                                <div className="refund-queue-detail-item refund-queue-detail-item--wide">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">refundId</span>
                                     <span className="refund-queue-detail-value">
                                         {selectedRow ? <CopyableId value={selectedRow.refundId} /> : "-"}
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">captured</span>
                                     <span className="refund-queue-detail-value">
                                         <AmountText value={getAmountValue(selectedRow, "capturedAmount")} />
@@ -940,14 +914,14 @@ export default function RefundQueuePage() {
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--wide">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">paymentId</span>
                                     <span className="refund-queue-detail-value">
                                         {selectedRow ? <CopyableId value={selectedRow.paymentId} /> : "-"}
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">refund</span>
                                     <span className="refund-queue-detail-value">
                                         <AmountText
@@ -956,38 +930,31 @@ export default function RefundQueuePage() {
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">status</span>
                                     <span className="refund-queue-detail-value">
                                         {selectedRow ? <StatusBadge status={selectedRow.status} /> : "-"}
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
-                                    <span className="refund-queue-detail-label">refundable</span>
-                                    <span className="refund-queue-detail-value">
-                                        <AmountText value={getAmountValue(selectedRow, "refundableAmount")} />
-                                    </span>
-                                </div>
-
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
-                                    <span className="refund-queue-detail-label">requestedAt</span>
-                                    <span className="refund-queue-detail-value">
-                                        {renderDate(selectedRow?.requestedAt)}
-                                    </span>
-                                </div>
-
-                                <div className="refund-queue-detail-item refund-queue-detail-item--memo">
+                                <div className="refund-queue-detail-item">
                                     <span className="refund-queue-detail-label">요청 메모</span>
                                     <span className="refund-queue-detail-value">
                                         {renderText(selectedRow?.reasonText)}
                                     </span>
                                 </div>
 
-                                <div className="refund-queue-detail-item refund-queue-detail-item--compact">
-                                    <span className="refund-queue-detail-label">decidedAt</span>
+                                <div className="refund-queue-detail-item">
+                                    <span className="refund-queue-detail-label">refundable</span>
                                     <span className="refund-queue-detail-value">
-                                        {renderDate(selectedRow?.decidedAt)}
+                                        <AmountText value={getAmountValue(selectedRow, "refundableAmount")} />
+                                    </span>
+                                </div>
+
+                                <div className="refund-queue-detail-item">
+                                    <span className="refund-queue-detail-label">requestedAt</span>
+                                    <span className="refund-queue-detail-value">
+                                        {renderDate(selectedRow?.requestedAt)}
                                     </span>
                                 </div>
                             </div>
@@ -1006,6 +973,18 @@ export default function RefundQueuePage() {
                             </div>
 
                             <div className="refund-queue-actions">
+                                <ActionButton
+                                    type="button"
+                                    variant="secondary"
+                                    disabled={
+                                        !selectedRow ||
+                                        traceLoading ||
+                                        (!lastActionResult?.requestId && !traceRequestId)
+                                    }
+                                    onClick={moveToTrace}
+                                >
+                                    {traceLoading ? "Trace 확인 중..." : "Trace로 보기(A1)"}
+                                </ActionButton>
 
                                 <ActionButton
                                     type="button"
@@ -1024,15 +1003,6 @@ export default function RefundQueuePage() {
                                     {acting ? "처리 중..." : "거절(Reject)"}
                                 </ActionButton>
                             </div>
-
-                            <ActionButton
-                                type="button"
-                                variant="secondary"
-                                disabled={!selectedRow || traceLoading || (!lastActionResult?.requestId && !traceRequestId)}
-                                onClick={moveToTrace}
-                            >
-                                {traceLoading ? "Trace 확인 중..." : "Trace로 보기(A1)"}
-                            </ActionButton>
 
                             <div className="refund-queue-meta-note">
                                 * 409 포맷: {"{`{\"code\":\"RULE_VIOLATION\",\"reason\":\"INSUFFICIENT_REFUNDABLE\"}`}"}
@@ -1099,8 +1069,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     refundId
                                                     <span className="refund-queue-sort-arrow">
-                                                            {renderSortArrow("refundId")}
-                                                        </span>
+                                                        {renderSortArrow("refundId")}
+                                                    </span>
                                                 </button>
                                             </th>
 
@@ -1114,8 +1084,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     amount
                                                     <span className="refund-queue-sort-arrow">
-                                                            {renderSortArrow("amount")}
-                                                        </span>
+                                                        {renderSortArrow("amount")}
+                                                    </span>
                                                 </button>
                                             </th>
 
@@ -1130,8 +1100,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     requestedAt
                                                     <span className="refund-queue-sort-arrow">
-                                                            {renderSortArrow("requestedAt")}
-                                                        </span>
+                                                        {renderSortArrow("requestedAt")}
+                                                    </span>
                                                 </button>
                                             </th>
                                         </tr>

--- a/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
@@ -3,6 +3,8 @@ package com.settleops.domain.refund.api;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionRequestDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionResponseDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
 import com.settleops.global.auth.annotation.LoginAdmin;
@@ -31,6 +33,7 @@ public class AdminRefundController {
     private final RefundAdminService refundAdminService;
     private final RefundAdminQueryService refundAdminQueryService;
     private final RequestIdResolver requestIdResolver;
+    private final RefundTraceEntryQueryService refundTraceEntryQueryService;
 
     /**
      * A6 운영 큐 조회(READ).
@@ -51,6 +54,15 @@ public class AdminRefundController {
                 refundAdminQueryService.list(status, from, to, pageable);
 
         return ResponseEntity.ok(PageResponse.from(result));
+    }
+
+    @GetMapping("/{refundId}/trace-entry")
+    public ResponseEntity<RefundTraceEntryResponseDTO> getRefundTraceEntry(
+            @PathVariable String refundId
+    ) {
+        return ResponseEntity.ok(
+                refundTraceEntryQueryService.getRefundTraceEntry(refundId)
+        );
     }
 
     @PatchMapping("/{refundId}/approve")

--- a/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
@@ -4,9 +4,9 @@ import com.settleops.domain.refund.api.dto.AdminRefundDecisionRequestDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionResponseDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
 import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
-import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.global.auth.annotation.LoginAdmin;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -26,9 +26,6 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 @RequestMapping("/api/admin/refunds")
 public class AdminRefundController {
-    //GET /api/admin/refunds?status=&from=&to=
-    //PATCH /api/admin/refunds/{refundId}/approve
-    //PATCH /api/admin/refunds/{refundId}/reject
 
     private final RefundAdminService refundAdminService;
     private final RefundAdminQueryService refundAdminQueryService;
@@ -38,7 +35,7 @@ public class AdminRefundController {
     /**
      * A6 운영 큐 조회(READ).
      * - status/from/to는 옵션.
-     * - 기준 시각: requestedAt (DB requested_at)
+     * - 기준 시각: requestedAt
      */
     @GetMapping
     public ResponseEntity<PageResponse<AdminRefundListItemDTO>> list(
@@ -56,6 +53,10 @@ public class AdminRefundController {
         return ResponseEntity.ok(PageResponse.from(result));
     }
 
+    /**
+     * A6 상세에서 A1 Trace 진입용 requestId를 조회한다.
+     * 기본 기준은 최신 non-no-op refund audit requestId 이다.
+     */
     @GetMapping("/{refundId}/trace-entry")
     public ResponseEntity<RefundTraceEntryResponseDTO> getRefundTraceEntry(
             @PathVariable String refundId

--- a/server/src/main/java/com/settleops/domain/refund/api/dto/RefundTraceEntryResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/dto/RefundTraceEntryResponseDTO.java
@@ -1,0 +1,10 @@
+package com.settleops.domain.refund.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefundTraceEntryResponseDTO {
+    private final String traceRequestId;
+}

--- a/server/src/main/java/com/settleops/domain/refund/application/RefundTraceEntryQueryService.java
+++ b/server/src/main/java/com/settleops/domain/refund/application/RefundTraceEntryQueryService.java
@@ -1,0 +1,37 @@
+package com.settleops.domain.refund.application;
+
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
+import com.settleops.domain.refund.infra.RefundTraceQueryRepository;
+import com.settleops.global.error.BadRequestException;
+import com.settleops.global.error.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RefundTraceEntryQueryService {
+
+    private final RefundTraceQueryRepository refundTraceQueryRepository;
+
+    public RefundTraceEntryResponseDTO getRefundTraceEntry(String refundId) {
+        if (refundId == null || refundId.isBlank()) {
+            throw new BadRequestException("refundId must not be null/blank");
+        }
+
+        boolean exists = refundTraceQueryRepository.existsRefund(refundId);
+        if (!exists) {
+            throw new NotFoundException("refund not found");
+        }
+
+        String traceRequestId =
+                refundTraceQueryRepository.findLatestNonNoOpRefundRequestId(refundId);
+
+        if (traceRequestId == null || traceRequestId.isBlank()) {
+            throw new NotFoundException("trace entry not found");
+        }
+
+        return new RefundTraceEntryResponseDTO(traceRequestId);
+    }
+}

--- a/server/src/main/java/com/settleops/domain/refund/infra/RefundTraceQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/refund/infra/RefundTraceQueryRepository.java
@@ -1,5 +1,7 @@
 package com.settleops.domain.refund.infra;
 
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.settleops.global.audit.EntityType;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +26,28 @@ public class RefundTraceQueryRepository {
         return result != null;
     }
 
+    /**
+     * refundId 기준으로 audit_log에서 최신 non-no-op requestId를 조회한다.
+     * no-op 여부는 audit_log.meta_json.noOp=false 로 판정한다.
+     */
     public String findLatestNonNoOpRefundRequestId(String refundId) {
+        StringExpression noOpValue = Expressions.stringTemplate(
+                "coalesce(function('json_unquote', function('json_extract', {0}, '$.noOp')), 'false')",
+                auditLog.metaJson
+        );
+
         return queryFactory
                 .select(auditLog.requestId)
                 .from(auditLog)
                 .where(
                         auditLog.entityType.eq(EntityType.REFUND),
-                        auditLog.entityId.eq(refundId)
+                        auditLog.entityId.eq(refundId),
+                        noOpValue.eq("false")
                 )
-                .orderBy(auditLog.occurredAt.desc(), auditLog.auditId.desc())
+                .orderBy(
+                        auditLog.occurredAt.desc(),
+                        auditLog.auditId.desc()
+                )
                 .fetchFirst();
     }
 }

--- a/server/src/main/java/com/settleops/domain/refund/infra/RefundTraceQueryRepository.java
+++ b/server/src/main/java/com/settleops/domain/refund/infra/RefundTraceQueryRepository.java
@@ -1,0 +1,38 @@
+package com.settleops.domain.refund.infra;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.settleops.global.audit.EntityType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.settleops.domain.refund.domain.QRefund.refund;
+import static com.settleops.global.audit.QAuditLog.auditLog;
+
+@Repository
+@RequiredArgsConstructor
+public class RefundTraceQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public boolean existsRefund(String refundId) {
+        Integer result = queryFactory
+                .selectOne()
+                .from(refund)
+                .where(refund.refundId.eq(refundId))
+                .fetchFirst();
+
+        return result != null;
+    }
+
+    public String findLatestNonNoOpRefundRequestId(String refundId) {
+        return queryFactory
+                .select(auditLog.requestId)
+                .from(auditLog)
+                .where(
+                        auditLog.entityType.eq(EntityType.REFUND),
+                        auditLog.entityId.eq(refundId)
+                )
+                .orderBy(auditLog.occurredAt.desc(), auditLog.auditId.desc())
+                .fetchFirst();
+    }
+}

--- a/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/SettlementAdminCommandServiceImpl.java
@@ -218,6 +218,11 @@ public class SettlementAdminCommandServiceImpl implements SettlementAdminCommand
 
             settlementLineRepository.saveAll(refundLines);
 
+            // LOCKED:
+            // - C(RefundSettlementAssembler)는 "approved refund -> next batch input set"만 산출한다.
+            // - A(batch)는 그 입력을 소비해 settlement_line(REFUND)와 refund_settlement_link를 동일 트랜잭션으로 적재한다.
+            // - 반영 완료 증거 SoT는 refund_settlement_link 단일이다.
+
             List<RefundSettlementLink> refundLinks = refundAdjustments.stream()
                     .map(refund -> {
                         String settlementId = settlementIdByMerchant.get(refund.merchantId());

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerNoOpIT.java
@@ -157,6 +157,68 @@ class AdminRefundControllerNoOpIT {
                 .andExpect(status().isBadRequest());
     }
 
+    @Test
+    @WithMockUser(username = "admin01", roles = "ADMIN")
+    void reject_noOp200_whenAlreadyApproved_returnsApprovedStatusAndKeepsDecidedAt() throws Exception {
+        String refundId = uuid();
+        String paymentId = uuid();
+        String merchantId = "MRC_0001";
+        String buyerId = "BUY_0001";
+        long amount = 1000L;
+
+        LocalDateTime requestedAt = LocalDateTime.of(2026, 3, 5, 10, 0, 0, 0);
+        LocalDateTime decidedAt = LocalDateTime.of(2026, 3, 5, 11, 0, 0, 0);
+
+        insertRefund(refundId, paymentId, merchantId, buyerId, amount,
+                "APPROVED", requestedAt, decidedAt);
+
+        String requestId = uuid();
+
+        mockMvc.perform(
+                        patch("/api/admin/refunds/{refundId}/reject", refundId)
+                                .header("X-Request-Id", requestId)
+                                .contentType(APPLICATION_JSON)
+                                .content("""
+                                    { "comment": "retry reject on approved refund" }
+                                    """)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("APPROVED"))
+                .andExpect(jsonPath("$.decidedAt").isNotEmpty())
+                .andExpect(jsonPath("$.requestId").value(requestId));
+    }
+
+    @Test
+    @WithMockUser(username = "admin01", roles = "ADMIN")
+    void approve_noOp200_whenAlreadyRejected_returnsRejectedStatusAndKeepsDecidedAt() throws Exception {
+        String refundId = uuid();
+        String paymentId = uuid();
+        String merchantId = "MRC_0001";
+        String buyerId = "BUY_0001";
+        long amount = 1000L;
+
+        LocalDateTime requestedAt = LocalDateTime.of(2026, 3, 5, 10, 0, 0, 0);
+        LocalDateTime decidedAt = LocalDateTime.of(2026, 3, 5, 11, 0, 0, 0);
+
+        insertRefund(refundId, paymentId, merchantId, buyerId, amount,
+                "REJECTED", requestedAt, decidedAt);
+
+        String requestId = uuid();
+
+        mockMvc.perform(
+                        patch("/api/admin/refunds/{refundId}/approve", refundId)
+                                .header("X-Request-Id", requestId)
+                                .contentType(APPLICATION_JSON)
+                                .content("""
+                                    { "comment": "retry approve on rejected refund" }
+                                    """)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"))
+                .andExpect(jsonPath("$.decidedAt").isNotEmpty())
+                .andExpect(jsonPath("$.requestId").value(requestId));
+    }
+
     private void insertRefund(
             String refundId,
             String paymentId,

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
@@ -3,6 +3,7 @@ package com.settleops.domain.refund.api;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.domain.refund.domain.RefundStatus;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -17,18 +18,26 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class AdminRefundControllerPaginationTest {
 
     @Test
     @DisplayName("환불 큐 조회는 PageResponse 형태로 반환한다")
     void list_returnsPageResponse() {
-        RefundAdminService refundAdminService = Mockito.mock(RefundAdminService.class);
-        RefundAdminQueryService refundAdminQueryService = Mockito.mock(RefundAdminQueryService.class);
-        RequestIdResolver requestIdResolver = Mockito.mock(RequestIdResolver.class);
+        RefundAdminService refundAdminService = mock(RefundAdminService.class);
+        RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
+        RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
+        RefundTraceEntryQueryService refundTraceEntryQueryService =
+                mock(RefundTraceEntryQueryService.class);
 
         AdminRefundController controller =
-                new AdminRefundController(refundAdminService, refundAdminQueryService, requestIdResolver);
+                new AdminRefundController(
+                        refundAdminService,
+                        refundAdminQueryService,
+                        requestIdResolver,
+                        refundTraceEntryQueryService
+                );
 
         AdminRefundListItemDTO item = new AdminRefundListItemDTO(
                 "rfd-1",

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerTraceEntryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerTraceEntryTest.java
@@ -1,0 +1,49 @@
+package com.settleops.domain.refund.api;
+
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
+import com.settleops.domain.refund.application.RefundAdminQueryService;
+import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
+import com.settleops.global.web.RequestIdResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AdminRefundControllerTraceEntryTest {
+
+    @Test
+    @DisplayName("관리자 refund trace-entry 조회 API는 refundId 기준 최신 non-no-op traceRequestId 응답을 반환한다")
+    void getRefundTraceEntry_withRefundId() {
+        RefundAdminService refundAdminService = Mockito.mock(RefundAdminService.class);
+        RefundAdminQueryService refundAdminQueryService = Mockito.mock(RefundAdminQueryService.class);
+        RequestIdResolver requestIdResolver = Mockito.mock(RequestIdResolver.class);
+        RefundTraceEntryQueryService refundTraceEntryQueryService = Mockito.mock(RefundTraceEntryQueryService.class);
+
+        AdminRefundController controller =
+                new AdminRefundController(
+                        refundAdminService,
+                        refundAdminQueryService,
+                        requestIdResolver,
+                        refundTraceEntryQueryService
+                );
+
+        RefundTraceEntryResponseDTO traceEntryResponse =
+                new RefundTraceEntryResponseDTO("request-1");
+
+        Mockito.when(refundTraceEntryQueryService.getRefundTraceEntry("refund-1"))
+                .thenReturn(traceEntryResponse);
+
+        ResponseEntity<RefundTraceEntryResponseDTO> response =
+                controller.getRefundTraceEntry("refund-1");
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTraceRequestId()).isEqualTo("request-1");
+
+        Mockito.verify(refundTraceEntryQueryService)
+                .getRefundTraceEntry("refund-1");
+    }
+}

--- a/server/src/test/java/com/settleops/domain/refund/application/RefundTraceEntryQueryServiceTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/application/RefundTraceEntryQueryServiceTest.java
@@ -1,0 +1,127 @@
+package com.settleops.domain.refund.application;
+
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
+import com.settleops.domain.refund.infra.RefundTraceQueryRepository;
+import com.settleops.global.error.BadRequestException;
+import com.settleops.global.error.NotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RefundTraceEntryQueryServiceTest {
+
+    @Test
+    @DisplayName("환불이 존재하고 최신 non-no-op traceRequestId가 있으면 Trace entry를 반환한다")
+    void getRefundTraceEntry_returnsTraceRequestId() {
+        RefundTraceQueryRepository repository =
+                Mockito.mock(RefundTraceQueryRepository.class);
+
+        RefundTraceEntryQueryService service =
+                new RefundTraceEntryQueryService(repository);
+
+        Mockito.when(repository.existsRefund("refund-1"))
+                .thenReturn(true);
+        Mockito.when(repository.findLatestNonNoOpRefundRequestId("refund-1"))
+                .thenReturn("request-1");
+
+        RefundTraceEntryResponseDTO response =
+                service.getRefundTraceEntry("refund-1");
+
+        assertThat(response.getTraceRequestId()).isEqualTo("request-1");
+
+        Mockito.verify(repository).existsRefund("refund-1");
+        Mockito.verify(repository).findLatestNonNoOpRefundRequestId("refund-1");
+    }
+
+    @Test
+    @DisplayName("refundId가 null 또는 blank면 BadRequestException을 던진다")
+    void getRefundTraceEntry_throwsBadRequest_whenRefundIdIsBlank() {
+        RefundTraceQueryRepository repository =
+                Mockito.mock(RefundTraceQueryRepository.class);
+
+        RefundTraceEntryQueryService service =
+                new RefundTraceEntryQueryService(repository);
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry(null))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("refundId must not be null/blank");
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry(""))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("refundId must not be null/blank");
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry("   "))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("refundId must not be null/blank");
+
+        Mockito.verifyNoInteractions(repository);
+    }
+
+    @Test
+    @DisplayName("환불이 존재하지 않으면 refund not found NotFoundException을 던진다")
+    void getRefundTraceEntry_throwsNotFound_whenRefundDoesNotExist() {
+        RefundTraceQueryRepository repository =
+                Mockito.mock(RefundTraceQueryRepository.class);
+
+        RefundTraceEntryQueryService service =
+                new RefundTraceEntryQueryService(repository);
+
+        Mockito.when(repository.existsRefund("refund-1"))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry("refund-1"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("refund not found");
+
+        Mockito.verify(repository).existsRefund("refund-1");
+        Mockito.verify(repository, Mockito.never())
+                .findLatestNonNoOpRefundRequestId(Mockito.anyString());
+    }
+
+    @Test
+    @DisplayName("환불은 존재하지만 Trace entry용 requestId가 없으면 trace entry not found NotFoundException을 던진다")
+    void getRefundTraceEntry_throwsNotFound_whenTraceEntryDoesNotExist() {
+        RefundTraceQueryRepository repository =
+                Mockito.mock(RefundTraceQueryRepository.class);
+
+        RefundTraceEntryQueryService service =
+                new RefundTraceEntryQueryService(repository);
+
+        Mockito.when(repository.existsRefund("refund-1"))
+                .thenReturn(true);
+        Mockito.when(repository.findLatestNonNoOpRefundRequestId("refund-1"))
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry("refund-1"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("trace entry not found");
+
+        Mockito.verify(repository).existsRefund("refund-1");
+        Mockito.verify(repository).findLatestNonNoOpRefundRequestId("refund-1");
+    }
+
+    @Test
+    @DisplayName("requestId가 blank면 trace entry not found NotFoundException을 던진다")
+    void getRefundTraceEntry_throwsNotFound_whenRequestIdIsBlank() {
+        RefundTraceQueryRepository repository =
+                Mockito.mock(RefundTraceQueryRepository.class);
+
+        RefundTraceEntryQueryService service =
+                new RefundTraceEntryQueryService(repository);
+
+        Mockito.when(repository.existsRefund("refund-1"))
+                .thenReturn(true);
+        Mockito.when(repository.findLatestNonNoOpRefundRequestId("refund-1"))
+                .thenReturn("   ");
+
+        assertThatThrownBy(() -> service.getRefundTraceEntry("refund-1"))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessage("trace entry not found");
+
+        Mockito.verify(repository).existsRefund("refund-1");
+        Mockito.verify(repository).findLatestNonNoOpRefundRequestId("refund-1");
+    }
+}

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 import com.settleops.domain.settlement.entity.SettlementLine;
 import com.settleops.domain.settlement.enums.SettlementLineType;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Transactional
 @DataJpaTest
 @ActiveProfiles("test-db")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundTraceQueryRepositoryMySqlIT.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundTraceQueryRepositoryMySqlIT.java
@@ -1,0 +1,207 @@
+package com.settleops.domain.refund.infra;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test-db")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@SpringBootTest
+class RefundTraceQueryRepositoryMySqlIT {
+
+    @Autowired
+    private RefundTraceQueryRepository refundTraceQueryRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private static final DateTimeFormatter MYSQL_DT6 =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSSSS");
+
+    @BeforeEach
+    void cleanup() {
+        jdbcTemplate.update("delete from audit_log");
+        jdbcTemplate.update("delete from refund");
+    }
+
+    @Test
+    @DisplayName("최신 refund audit가 no-op이면 이전 non-no-op requestId를 반환한다")
+    void findLatestNonNoOpRefundRequestId_skipsLatestNoOpAudit() {
+        String refundId = uuid();
+        String paymentId = uuid();
+        String merchantId = "MRC_0001";
+        String buyerId = "BUY_0001";
+
+        insertRefund(
+                refundId,
+                paymentId,
+                merchantId,
+                buyerId,
+                1000L,
+                "APPROVED",
+                LocalDateTime.of(2026, 3, 24, 10, 0, 0),
+                LocalDateTime.of(2026, 3, 24, 10, 10, 0)
+        );
+
+        insertAuditLog(
+                "request-non-noop",
+                LocalDateTime.of(2026, 3, 24, 10, 10, 0),
+                "ADMIN",
+                "admin01",
+                "REFUND_APPROVED",
+                "REFUND",
+                refundId,
+                "REQUESTED",
+                "APPROVED",
+                merchantId,
+                """
+                {"noOp":false,"comment":"approved","before":{"status":"REQUESTED"},"after":{"status":"APPROVED"}}
+                """
+        );
+
+        insertAuditLog(
+                "request-noop-latest",
+                LocalDateTime.of(2026, 3, 24, 10, 20, 0),
+                "ADMIN",
+                "admin01",
+                "REFUND_APPROVED",
+                "REFUND",
+                refundId,
+                "APPROVED",
+                "APPROVED",
+                merchantId,
+                """
+                {"noOp":true,"noOpReason":"ALREADY_APPROVED","comment":"retry","before":{"status":"APPROVED"},"after":{"status":"APPROVED"}}
+                """
+        );
+
+        String traceRequestId =
+                refundTraceQueryRepository.findLatestNonNoOpRefundRequestId(refundId);
+
+        assertThat(traceRequestId).isEqualTo("request-non-noop");
+    }
+
+    @Test
+    @DisplayName("refund audit가 모두 no-op이면 null을 반환한다")
+    void findLatestNonNoOpRefundRequestId_returnsNull_whenAllAuditsAreNoOp() {
+        String refundId = uuid();
+        String paymentId = uuid();
+        String merchantId = "MRC_0001";
+        String buyerId = "BUY_0001";
+
+        insertRefund(
+                refundId,
+                paymentId,
+                merchantId,
+                buyerId,
+                1000L,
+                "APPROVED",
+                LocalDateTime.of(2026, 3, 24, 10, 0, 0),
+                LocalDateTime.of(2026, 3, 24, 10, 10, 0)
+        );
+
+        insertAuditLog(
+                "request-noop-only",
+                LocalDateTime.of(2026, 3, 24, 10, 20, 0),
+                "ADMIN",
+                "admin01",
+                "REFUND_APPROVED",
+                "REFUND",
+                refundId,
+                "APPROVED",
+                "APPROVED",
+                merchantId,
+                """
+                {"noOp":true,"noOpReason":"ALREADY_APPROVED","comment":"retry","before":{"status":"APPROVED"},"after":{"status":"APPROVED"}}
+                """
+        );
+
+        String traceRequestId =
+                refundTraceQueryRepository.findLatestNonNoOpRefundRequestId(refundId);
+
+        assertThat(traceRequestId).isNull();
+    }
+
+    private void insertRefund(
+            String refundId,
+            String paymentId,
+            String merchantId,
+            String buyerId,
+            long amount,
+            String status,
+            LocalDateTime requestedAt,
+            LocalDateTime decidedAt
+    ) {
+        String now = LocalDateTime.now().format(MYSQL_DT6);
+
+        jdbcTemplate.update("""
+                insert into refund (
+                    refund_id, payment_id, merchant_id, buyer_id,
+                    amount, currency, status, reason_text,
+                    requested_at, decided_at, created_at, updated_at
+                )
+                values (?, ?, ?, ?, ?, 'KRW', ?, 'test reason', ?, ?, ?, ?)
+                """,
+                refundId,
+                paymentId,
+                merchantId,
+                buyerId,
+                amount,
+                status,
+                requestedAt.format(MYSQL_DT6),
+                decidedAt == null ? null : decidedAt.format(MYSQL_DT6),
+                now,
+                now
+        );
+    }
+
+    private void insertAuditLog(
+            String requestId,
+            LocalDateTime occurredAt,
+            String actorType,
+            String actorId,
+            String action,
+            String entityType,
+            String entityId,
+            String statusBefore,
+            String statusAfter,
+            String merchantId,
+            String metaJson
+    ) {
+        jdbcTemplate.update("""
+                insert into audit_log (
+                    request_id, occurred_at, actor_type, actor_id,
+                    action, entity_type, entity_id,
+                    status_before, status_after, merchant_id, meta_json
+                )
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? as json))
+                """,
+                requestId,
+                occurredAt.format(MYSQL_DT6),
+                actorType,
+                actorId,
+                action,
+                entityType,
+                entityId,
+                statusBefore,
+                statusAfter,
+                merchantId,
+                metaJson
+        );
+    }
+
+    private static String uuid() {
+        return UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
## What
GET /api/admin/refunds/{refundId}/trace-entry 추가
RefundTraceEntryQueryService / Repository 추가
RefundQueuePage trace-entry 연동
approve/reject no-op 200 테스트 추가
A6 Trace 이동 시 lastActionResult → traceEntry fallback 적용

## Why
requestId 기반 Trace 재현 요구사항 대응
audit_log 기준 Trace SoT 유지
no-op 200 최소필드 규칙 테스트 보강
A6 → A1 Trace 진입 경로 기획서 정합성 확보

## Scope
Refund 도메인(C 파트)
Trace/Audit 조회 범위
no-op 정책 테스트 보강
UI Trace 이동 로직 수정