### PR TITLE
chore: 배포 도메인 cors origin 주입값 추가

### DIFF
--- a/server/src/main/java/com/settleops/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/settleops/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.settleops.global.config;
 
 import com.settleops.global.auth.SessionAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -21,6 +22,12 @@ import java.util.List;
 @Configuration
 public class SecurityConfig {
 
+    @Value("${app.cors.deploy-origin}")
+    private String deployOrigin;
+
+    @Value("${app.cors.deploy-origin-www}")
+    private String deployOriginWww;
+
     private final SessionAuthenticationFilter sessionAuthenticationFilter;
 
     public SecurityConfig(SessionAuthenticationFilter sessionAuthenticationFilter) {
@@ -37,7 +44,11 @@ public class SecurityConfig {
         http.cors(cors -> cors.configurationSource(request -> {
             CorsConfiguration config = new CorsConfiguration();
 
-            config.setAllowedOriginPatterns(List.of("http://localhost:*"));
+            config.setAllowedOriginPatterns(List.of(
+                    "http://localhost:*",
+                    deployOrigin,
+                    deployOriginWww
+            ));
             config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
             config.setAllowedHeaders(List.of(
                     "Content-Type","X-Request-Id","X-Idempotency-Key","Accept","Origin","X-Requested-With"

--- a/server/src/main/java/com/settleops/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/settleops/global/config/SecurityConfig.java
@@ -17,15 +17,16 @@ import org.springframework.web.cors.CorsConfiguration;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Profile("!test")
 @Configuration
 public class SecurityConfig {
 
-    @Value("${app.cors.deploy-origin}")
+    @Value("${app.cors.deploy-origin:}")
     private String deployOrigin;
 
-    @Value("${app.cors.deploy-origin-www}")
+    @Value("${app.cors.deploy-origin-www:}")
     private String deployOriginWww;
 
     private final SessionAuthenticationFilter sessionAuthenticationFilter;
@@ -44,14 +45,18 @@ public class SecurityConfig {
         http.cors(cors -> cors.configurationSource(request -> {
             CorsConfiguration config = new CorsConfiguration();
 
-            config.setAllowedOriginPatterns(List.of(
-                    "http://localhost:*",
-                    deployOrigin,
-                    deployOriginWww
-            ));
-            config.setAllowedMethods(List.of("GET","POST","PUT","PATCH","DELETE","OPTIONS"));
+            List<String> allowedOriginPatterns = Stream.of(
+                            "http://localhost:*",
+                            deployOrigin,
+                            deployOriginWww
+                    )
+                    .filter(origin -> origin != null && !origin.isBlank())
+                    .toList();
+
+            config.setAllowedOriginPatterns(allowedOriginPatterns);
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
             config.setAllowedHeaders(List.of(
-                    "Content-Type","X-Request-Id","X-Idempotency-Key","Accept","Origin","X-Requested-With"
+                    "Content-Type", "X-Request-Id", "X-Idempotency-Key", "Accept", "Origin", "X-Requested-With"
             ));
             config.setExposedHeaders(List.of("X-Request-Id"));
             config.setAllowCredentials(true);


### PR DESCRIPTION
## what

### SecurityConfig CORS origin 확장
- `SecurityConfig`에 `@Value` 기반 설정값 주입 추가
- `app.cors.deploy-origin` 주입 추가
- `app.cors.deploy-origin-www` 주입 추가
- 기존 localhost 허용 패턴 유지
- 배포 도메인 origin 2종 추가 허용

## why
- 배포 도메인 접속 시 CORS 차단 발생
- 배포 도메인 값을 코드 하드코딩 대신 설정값으로 주입할 필요
- 로컬 개발 origin과 배포 origin을 함께 허용할 필요

## how to test
- 설정 파일에 `app.cors.deploy-origin`, `app.cors.deploy-origin-www` 값 추가
``` 
app:
  cors:
    deploy-origin:
    deploy-origin-www:  
```

- 로컬서버 정상가동 확인 