### PR TITLE
fix(frontend): align admin guards and batch header title

### DIFF
--- a/admin-web/src/app/layouts/AppHeader.jsx
+++ b/admin-web/src/app/layouts/AppHeader.jsx
@@ -15,7 +15,7 @@ function resolvePageTitle(pathname) {
   if (pathname === "/merchant/refunds") return "환불 현황";
 
   if (pathname === "/admin/audit") return "Trace / Audit";
-  if (pathname === "/admin/batches") return "배치 실행";
+  if (pathname === "/admin/settlement-batches") return "배치 실행";
   if (pathname === "/admin/settlements") return "정산 관리";
   if (pathname.startsWith("/admin/settlements/")) return "정산 상세";
   if (pathname === "/admin/holds") return "Hold 큐";

--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -386,12 +386,12 @@ export default function BatchPage() {
         title="배치 실행 · 이력"
         description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
       >
-        <SectionCard title="세션 확인 중">
-          <LoadingBlock
-            title="세션 확인 중"
-            description="현재 로그인 세션의 역할을 확인하고 있습니다."
-          />
-        </SectionCard>
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+             Admin 권한이 필요한 페이지입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }
@@ -407,40 +407,20 @@ export default function BatchPage() {
     );
   }
 
-  if (authErrorInfo?.status === 403) {
-    return (
-      <PageLayout
-        title="배치 실행 · 이력"
-        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
-      >
-        <GuardNotice
-          title="접근 불가"
-          message={authErrorInfo.message}
-          tone="danger"
-        />
-        <ErrorState message={authErrorInfo.message} />
-      </PageLayout>
-    );
-  }
-
-  if (authErrorInfo) {
-    return (
-      <PageLayout
-        title="배치 실행 · 이력"
-        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
-      >
-        <GuardNotice
-          title="조회 실패"
-          message={authErrorInfo.message}
-          tone="danger"
-        />
-        <ErrorState message={authErrorInfo.message} />
-      </PageLayout>
-    );
-  }
-
   if (!isAllowed) {
-    return null;
+    return (
+      <PageLayout
+        title="배치 실행 · 이력"
+        description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            Admin 권한이 필요한 페이지입니다.
+          </div>
+        </div>
+      </PageLayout>
+    );
   }
 
   return (

--- a/admin-web/src/pages/admin/BatchPage.jsx
+++ b/admin-web/src/pages/admin/BatchPage.jsx
@@ -386,12 +386,12 @@ export default function BatchPage() {
         title="배치 실행 · 이력"
         description="baseDate 기준으로 정산 배치를 실행하고 OK / FAIL / SKIP 이력을 운영 관점에서 확인합니다."
       >
-        <div className="guard-notice">
-          <div className="guard-notice__title">접근 불가</div>
-          <div className="guard-notice__description">
-             Admin 권한이 필요한 페이지입니다.
-          </div>
-        </div>
+        <SectionCard title="세션 확인 중">
+          <LoadingBlock
+            title="세션 확인 중"
+            description="현재 로그인 세션의 역할을 확인하고 있습니다."
+          />
+        </SectionCard>
       </PageLayout>
     );
   }
@@ -416,7 +416,7 @@ export default function BatchPage() {
         <div className="guard-notice">
           <div className="guard-notice__title">접근 불가</div>
           <div className="guard-notice__description">
-            Admin 권한이 필요한 페이지입니다.
+            {authErrorInfo?.message || "Admin 권한이 필요한 페이지입니다."}
           </div>
         </div>
       </PageLayout>

--- a/admin-web/src/pages/admin/SettlementManagePage.jsx
+++ b/admin-web/src/pages/admin/SettlementManagePage.jsx
@@ -53,7 +53,9 @@ function normalizeSettlementResponse(payload) {
       page: Number(payload.page ?? DEFAULT_PAGE),
       size: Number(payload.size ?? DEFAULT_SIZE),
       totalElements: Number(payload.totalElements ?? payload.items.length ?? 0),
-      totalPages: Number(payload.totalPages ?? (payload.items.length > 0 ? 1 : 0)),
+      totalPages: Number(
+        payload.totalPages ?? (payload.items.length > 0 ? 1 : 0)
+      ),
       hasNext: Boolean(payload.hasNext),
       hasPrevious: Boolean(payload.hasPrevious),
     };
@@ -64,8 +66,12 @@ function normalizeSettlementResponse(payload) {
       items: payload.content,
       page: Number(payload.number ?? payload.page ?? DEFAULT_PAGE),
       size: Number(payload.size ?? DEFAULT_SIZE),
-      totalElements: Number(payload.totalElements ?? payload.content.length ?? 0),
-      totalPages: Number(payload.totalPages ?? (payload.content.length > 0 ? 1 : 0)),
+      totalElements: Number(
+        payload.totalElements ?? payload.content.length ?? 0
+      ),
+      totalPages: Number(
+        payload.totalPages ?? (payload.content.length > 0 ? 1 : 0)
+      ),
       hasNext: Boolean(payload.hasNext),
       hasPrevious: Boolean(payload.hasPrevious),
     };
@@ -132,7 +138,7 @@ function buildAuthErrorMessage(error) {
   }
 
   if (status === 403) {
-    return "Admin 권한이 없어 정산 관리 화면에 접근할 수 없습니다.";
+    return "Admin 권한이 필요한 페이지입니다.";
   }
 
   return (
@@ -189,6 +195,7 @@ export default function SettlementManagePage() {
   const [authChecking, setAuthChecking] = useState(true);
   const [isAllowed, setIsAllowed] = useState(false);
   const [authErrorMessage, setAuthErrorMessage] = useState("");
+  const [authErrorStatus, setAuthErrorStatus] = useState(null);
 
   const pageTitle = useMemo(() => "A3 정산 관리", []);
 
@@ -245,6 +252,7 @@ export default function SettlementManagePage() {
       try {
         setAuthChecking(true);
         setAuthErrorMessage("");
+        setAuthErrorStatus(null);
         setIsAllowed(false);
 
         const me = await getMe();
@@ -258,12 +266,12 @@ export default function SettlementManagePage() {
         }
 
         setIsAllowed(false);
-        setAuthErrorMessage(
-          "Admin 전용 정산 관리 화면입니다. /auth/dev-login 에서 Admin 세션으로 다시 로그인해 주세요."
-        );
+        setAuthErrorStatus(403);
+        setAuthErrorMessage("Admin 권한이 필요한 페이지입니다.");
       } catch (error) {
         if (!mounted) return;
         setIsAllowed(false);
+        setAuthErrorStatus(error?.status ?? null);
         setAuthErrorMessage(buildAuthErrorMessage(error));
       } finally {
         if (mounted) {
@@ -340,21 +348,18 @@ export default function SettlementManagePage() {
         title={pageTitle}
         description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
       >
-        <SectionCard title="세션 확인 중">
-          <LoadingBlock
-            title="세션 확인 중"
-            description="현재 로그인 세션의 역할을 확인하고 있습니다."
-          />
-        </SectionCard>
+        <div className="guard-notice">
+          <div className="guard-notice__title">로딩 중</div>
+          <div className="guard-notice__description">
+            권한 정보를 확인하는 중입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }
 
   if (!isAllowed) {
-    if (
-      authErrorMessage.includes("로그인") ||
-      authErrorMessage.includes("인증")
-    ) {
+    if (authErrorStatus === 401) {
       return (
         <PageLayout
           title={pageTitle}
@@ -373,12 +378,12 @@ export default function SettlementManagePage() {
         title={pageTitle}
         description="정산 상태와 판매자 기준으로 정산을 조회하고, settlementId 앵커로 A4 상세 화면으로 이동합니다."
       >
-        <GuardNotice
-          title="접근 불가"
-          message={authErrorMessage}
-          tone="danger"
-        />
-        <ErrorState message={authErrorMessage} />
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            Admin 권한이 필요한 페이지입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }


### PR DESCRIPTION
## 변경 내용
- A3 정산 관리 화면의 Admin 가드 UX를 정리했습니다.
  - 401은 RequireLoginNotice 유지
  - 비Admin 로그인 상태는 `접근 불가 / Admin 권한이 필요한 페이지입니다.` 형태의 plain guard-notice로 통일
- A2 배치 실행 화면도 동일한 Admin 가드 UX 기준으로 맞췄습니다.
- AppHeader의 admin batch 경로 제목을 `/admin/settlement-batches` 기준으로 `배치 실행`으로 정리했습니다.

## 의도
- Admin 화면에서 미로그인과 권한 불일치 상태를 분리해 보여주되,
  비Admin 로그인 상태에서는 불필요한 로그인 유도 대신 권한 안내만 노출하도록 정렬했습니다.
- A2/A3 화면의 가드 UX와 헤더 타이틀 기준선을 함께 맞췄습니다.

## 확인 포인트
- 비Admin(consumer/merchant) 세션으로 A2/A3 접근 시 plain guard-notice만 노출되는지
- 미로그인 상태에서는 RequireLoginNotice로 분기되는지
- `/admin/settlement-batches` 진입 시 헤더 타이틀이 `배치 실행`으로 보이는지