### PR TITLE
fix: align merchant settlement list/detail filtering and U4/U5 flow

### DIFF
--- a/admin-web/src/app/layouts/AppHeader.jsx
+++ b/admin-web/src/app/layouts/AppHeader.jsx
@@ -12,10 +12,12 @@ function resolvePageTitle(pathname) {
 
   if (pathname === "/merchant/payments") return "결제 조회";
   if (pathname.startsWith("/merchant/payments/")) return "결제 상세";
+  if (pathname === "/merchant/settlements") return "정산 리스트";
+  if (pathname.startsWith("/merchant/settlements/")) return "정산 상세";
   if (pathname === "/merchant/refunds") return "환불 현황";
 
   if (pathname === "/admin/audit") return "Trace / Audit";
-  if (pathname === "/admin/batches") return "배치 실행";
+  if (pathname === "/admin/settlement-batches") return "배치 실행";
   if (pathname === "/admin/settlements") return "정산 관리";
   if (pathname.startsWith("/admin/settlements/")) return "정산 상세";
   if (pathname === "/admin/holds") return "Hold 큐";

--- a/admin-web/src/app/layouts/Sidebar.jsx
+++ b/admin-web/src/app/layouts/Sidebar.jsx
@@ -51,6 +51,7 @@ const menuGroups = [
     title: "Merchant",
     items: [
       groupItem("결제 조회", "/merchant/payments"),
+      groupItem("정산 리스트", "/merchant/settlements"),
       groupItem("환불 현황", "/merchant/refunds"),
     ],
   },

--- a/admin-web/src/pages/merchant/SettlementDetailPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementDetailPage.jsx
@@ -31,6 +31,23 @@ function extractRole(payload) {
   );
 }
 
+function isMerchantRole(payload) {
+  const role = String(extractRole(payload) || "").toUpperCase();
+
+  if (role === "MERCHANT" || role === "ROLE_MERCHANT") {
+    return true;
+  }
+
+  if (
+    Array.isArray(payload?.authorities) &&
+    payload.authorities.includes("ROLE_MERCHANT")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 function extractMerchantId(payload) {
   return (
     payload?.merchantId ||
@@ -43,17 +60,14 @@ function extractMerchantId(payload) {
 
 function buildAuthErrorMessage(error) {
   const status = error?.status;
-  const message =
-    error?.body?.message ||
-    error?.body?.reason ||
-    error?.message;
+  const message = error?.body?.message || error?.body?.reason || error?.message;
 
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
   }
 
   if (status === 403) {
-    return "Merchant 권한이 없어 정산 상세 화면에 접근할 수 없습니다.";
+    return "Merchant 권한이 필요한 페이지입니다.";
   }
 
   return (
@@ -64,10 +78,7 @@ function buildAuthErrorMessage(error) {
 
 function mapDetailErrorToMessage(error) {
   const status = error?.status;
-  const message =
-    error?.body?.message ||
-    error?.body?.reason ||
-    error?.message;
+  const message = error?.body?.message || error?.body?.reason || error?.message;
 
   if (status === 401) {
     return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
@@ -82,17 +93,6 @@ function mapDetailErrorToMessage(error) {
   }
 
   return message || "정산 상세 조회 중 오류가 발생했습니다.";
-}
-
-function isRefundAdjustmentPending(refund) {
-  return refund?.refundAdjustmentPending === true;
-}
-
-function hasApprovedRefund(refund) {
-  return (
-    refund?.hasApprovedRefund === true ||
-    refund?.approvedRefundExists === true
-  );
 }
 
 function CopyableValue({ value }) {
@@ -153,16 +153,13 @@ export default function SettlementDetailPage() {
         setMerchantId("");
 
         const me = await getMe();
-        const role = String(extractRole(me) || "").toUpperCase();
         const resolvedMerchantId = extractMerchantId(me);
 
         if (!mounted) return;
 
-        if (role !== "MERCHANT") {
+        if (!isMerchantRole(me)) {
           setIsAllowed(false);
-          setAuthErrorMessage(
-            "Merchant 전용 정산 상세 화면입니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
-          );
+          setAuthErrorMessage("Merchant 권한이 필요한 페이지입니다.");
           return;
         }
 
@@ -204,7 +201,7 @@ export default function SettlementDetailPage() {
   }, [isAllowed, merchantId, fetchDetail]);
 
   const currentSettlementId = detail?.settlementId || settlementId || "-";
-  const currentMerchantId = detail?.merchantId || merchantId || "-";
+  const currentMerchantId = merchantId || "-";
   const baseDate = detail?.baseDate || "-";
   const status = detail?.status || "UNKNOWN";
   const gross = detail?.gross ?? null;
@@ -212,8 +209,6 @@ export default function SettlementDetailPage() {
   const vat = detail?.vat ?? null;
   const net = detail?.net ?? null;
   const lines = Array.isArray(detail?.lines) ? detail.lines : [];
-  const hold = detail?.hold ?? null;
-  const refund = detail?.refund ?? null;
 
   const refundLineAmount = useMemo(() => {
     return lines
@@ -224,12 +219,6 @@ export default function SettlementDetailPage() {
   const paymentIds = useMemo(() => {
     return [...new Set(lines.map((line) => line?.paymentId).filter(Boolean))];
   }, [lines]);
-
-  const refundStatus = useMemo(() => {
-    if (isRefundAdjustmentPending(refund)) return "REFUND_ADJUSTMENT_PENDING";
-    if (hasApprovedRefund(refund)) return "APPROVED";
-    return "NONE";
-  }, [refund]);
 
   if (authChecking) {
     return (
@@ -248,7 +237,10 @@ export default function SettlementDetailPage() {
   }
 
   if (!isAllowed) {
-    if (authErrorMessage.includes("로그인") || authErrorMessage.includes("인증")) {
+    if (
+      authErrorMessage.includes("로그인") ||
+      authErrorMessage.includes("인증")
+    ) {
       return (
         <PageLayout
           title="정산 상세"
@@ -267,12 +259,12 @@ export default function SettlementDetailPage() {
         title="정산 상세"
         description="판매자 기준으로 settlement 상세와 라인 내역을 조회하는 화면입니다."
       >
-        <GuardNotice
-          title="접근 불가"
-          message={authErrorMessage}
-          tone="danger"
-        />
-        <ErrorState message={authErrorMessage} />
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            Merchant 권한이 필요한 페이지입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }
@@ -375,27 +367,29 @@ export default function SettlementDetailPage() {
         </div>
       </SectionCard>
 
-      <div className="page-grid-2">
-        <SectionCard title="정산 상세">
-          <InfoRow label="baseDate" value={baseDate} />
-          <InfoRow label="gross" value={formatAmount(gross)} />
-          <InfoRow label="fee" value={formatAmount(fee)} />
-          <InfoRow label="vat" value={formatAmount(vat)} />
-          <InfoRow label="net" value={formatAmount(net)} />
-        </SectionCard>
+      <SectionCard title="정산 상세">
+        <div className="page-grid-2">
+          <div>
+            <InfoRow label="baseDate" value={baseDate} />
+            <InfoRow label="gross" value={formatAmount(gross)} />
+            <InfoRow label="fee" value={formatAmount(fee)} />
+            <InfoRow label="vat" value={formatAmount(vat)} />
+            <InfoRow label="net" value={formatAmount(net)} />
+          </div>
 
-        <SectionCard title="정산 상태 참고">
-          <InfoRow label="hold">
-            {hold?.status ? <StatusBadge status={hold.status} /> : "없음"}
-          </InfoRow>
-          <InfoRow label="approved refund" value={hasApprovedRefund(refund) ? "예" : "아니오"} />
-          <InfoRow
-            label="adjustment pending"
-            value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
-          />
-          <InfoRow label="refund status" status value={refundStatus} />
-        </SectionCard>
-      </div>
+          <div>
+            <InfoRow label="status">
+              <StatusBadge status={status} />
+            </InfoRow>
+            <InfoRow label="settlementId">
+              <CopyableValue value={currentSettlementId} />
+            </InfoRow>
+            <InfoRow label="merchantId">
+              <CopyableValue value={currentMerchantId} />
+            </InfoRow>
+          </div>
+        </div>
+      </SectionCard>
 
       <SectionCard title="정산 수식 뷰">
         <div className="info-list">
@@ -411,74 +405,6 @@ export default function SettlementDetailPage() {
           </div>
         </div>
       </SectionCard>
-
-      <SectionCard title="연결 정보">
-        <div style={{ display: "grid", gap: "12px" }}>
-          <InfoRow label="settlementId" copyable value={currentSettlementId} />
-          <InfoRow label="merchantId" copyable value={currentMerchantId} />
-
-          <InfoRow label="paymentIds">
-            {paymentIds.length === 0 ? (
-              "-"
-            ) : (
-              <div
-                style={{
-                  display: "flex",
-                  flexWrap: "wrap",
-                  gap: "8px",
-                }}
-              >
-                {paymentIds.map((paymentId) => (
-                  <CopyableValue key={paymentId} value={paymentId} />
-                ))}
-              </div>
-            )}
-          </InfoRow>
-
-          <InfoRow label="hold">
-            {hold?.holdId ? <CopyableValue value={hold.holdId} /> : "없음"}
-          </InfoRow>
-
-          <InfoRow label="refund">
-            {hasApprovedRefund(refund) ? (
-              <StatusBadge status={refundStatus} />
-            ) : (
-              "없음"
-            )}
-          </InfoRow>
-        </div>
-      </SectionCard>
-
-      <div className="page-grid-2">
-        <SectionCard title="Hold 요약">
-          <InfoRow label="holdId">
-            {hold?.holdId ? <CopyableValue value={hold.holdId} /> : "-"}
-          </InfoRow>
-          <InfoRow label="status">
-            {hold?.status ? <StatusBadge status={hold.status} /> : "-"}
-          </InfoRow>
-          <InfoRow label="reason" value={hold?.reasonCode || "-"} />
-          <InfoRow
-            label="comment"
-            value={hold?.requestedComment || hold?.comment || "-"}
-          />
-          <InfoRow label="approvedBy" value={hold?.approvedBy || hold?.decidedBy || "-"} />
-          <InfoRow label="createdAt" value={hold?.createdAt || hold?.requestedAt || "-"} />
-        </SectionCard>
-
-        <SectionCard title="Refund 요약">
-          <InfoRow label="approved refund" value={hasApprovedRefund(refund) ? "예" : "아니오"} />
-          <InfoRow
-            label="adjustment pending"
-            value={isRefundAdjustmentPending(refund) ? "예" : "아니오"}
-          />
-          <InfoRow label="status" status value={refundStatus} />
-          <InfoRow
-            label="refund line amount"
-            value={refundLineAmount > 0 ? formatAmount(refundLineAmount) : "-"}
-          />
-        </SectionCard>
-      </div>
 
       <SectionCard title="라인 목록">
         <div className="table-wrap">

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -51,18 +51,6 @@ function getDefaultTo() {
 }
 
 function normalizeSettlementPage(payload) {
-  if (Array.isArray(payload)) {
-    return {
-      items: payload,
-      page: DEFAULT_PAGE,
-      size: DEFAULT_SIZE,
-      totalElements: payload.length,
-      totalPages: payload.length > 0 ? 1 : 0,
-      hasNext: false,
-      hasPrevious: false,
-    };
-  }
-
   if (Array.isArray(payload?.items)) {
     return {
       items: payload.items,
@@ -312,16 +300,8 @@ export default function SettlementListPage() {
     if (nextFromDate) params.from = nextFromDate;
     if (nextToDate) params.to = nextToDate;
 
-    console.log("[U4] request merchantId =", resolvedMerchantId);
-    console.log("[U4] request params =", params);
-
     const data = await getMerchantSettlements(resolvedMerchantId, params);
-
-    console.log("[U4] raw response =", data);
-
     const normalized = normalizeSettlementPage(data);
-
-    console.log("[U4] normalized response =", normalized);
 
     applyPageResponse(normalized, nextSize);
   }

--- a/admin-web/src/pages/merchant/SettlementListPage.jsx
+++ b/admin-web/src/pages/merchant/SettlementListPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 
 import PageLayout from "../../components/layout/PageLayout.jsx";
@@ -11,10 +11,15 @@ import EmptyState from "../../components/feedback/EmptyState.jsx";
 import ErrorState from "../../components/feedback/ErrorState.jsx";
 import LoadingBlock from "../../components/feedback/LoadingBlock.jsx";
 import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
+import Pagination from "../../components/table/Pagination.jsx";
+import usePagination from "../../hooks/usePagination.js";
 
 import { formatNumber } from "../../utils/format.js";
 import { getMe } from "../../api/meApi.js";
 import { getMerchantSettlements } from "../../api/merchantSettlementApi.js";
+
+const DEFAULT_PAGE = 0;
+const DEFAULT_SIZE = 20;
 
 const STATUS_OPTIONS = [
   { value: "", label: "전체" },
@@ -37,7 +42,7 @@ function formatDate(date) {
 
 function getDefaultFrom() {
   const date = new Date();
-  date.setMonth(date.getMonth() - 1);
+  date.setDate(date.getDate() - 7);
   return formatDate(date);
 }
 
@@ -45,12 +50,86 @@ function getDefaultTo() {
   return formatDate(new Date());
 }
 
-function normalizeSettlementList(payload) {
-  if (Array.isArray(payload)) return payload;
-  if (Array.isArray(payload?.data)) return payload.data;
-  if (Array.isArray(payload?.items)) return payload.items;
-  if (Array.isArray(payload?.content)) return payload.content;
-  return [];
+function normalizeSettlementPage(payload) {
+  if (Array.isArray(payload)) {
+    return {
+      items: payload,
+      page: DEFAULT_PAGE,
+      size: DEFAULT_SIZE,
+      totalElements: payload.length,
+      totalPages: payload.length > 0 ? 1 : 0,
+      hasNext: false,
+      hasPrevious: false,
+    };
+  }
+
+  if (Array.isArray(payload?.items)) {
+    return {
+      items: payload.items,
+      page: Number(payload.page ?? DEFAULT_PAGE),
+      size: Number(payload.size ?? DEFAULT_SIZE),
+      totalElements: Number(payload.totalElements ?? payload.items.length ?? 0),
+      totalPages: Number(
+        payload.totalPages ?? (payload.items.length > 0 ? 1 : 0)
+      ),
+      hasNext: Boolean(payload.hasNext),
+      hasPrevious: Boolean(payload.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.content)) {
+    return {
+      items: payload.content,
+      page: Number(payload.number ?? payload.page ?? DEFAULT_PAGE),
+      size: Number(payload.size ?? DEFAULT_SIZE),
+      totalElements: Number(
+        payload.totalElements ?? payload.content.length ?? 0
+      ),
+      totalPages: Number(
+        payload.totalPages ?? (payload.content.length > 0 ? 1 : 0)
+      ),
+      hasNext: Boolean(payload.hasNext),
+      hasPrevious: Boolean(payload.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.page?.content)) {
+    return {
+      items: payload.page.content,
+      page: Number(payload.page.number ?? DEFAULT_PAGE),
+      size: Number(payload.page.size ?? DEFAULT_SIZE),
+      totalElements: Number(
+        payload.page.totalElements ?? payload.page.content.length ?? 0
+      ),
+      totalPages: Number(
+        payload.page.totalPages ?? (payload.page.content.length > 0 ? 1 : 0)
+      ),
+      hasNext: Boolean(payload.page.hasNext),
+      hasPrevious: Boolean(payload.page.hasPrevious),
+    };
+  }
+
+  if (Array.isArray(payload?.data)) {
+    return {
+      items: payload.data,
+      page: DEFAULT_PAGE,
+      size: DEFAULT_SIZE,
+      totalElements: payload.data.length,
+      totalPages: payload.data.length > 0 ? 1 : 0,
+      hasNext: false,
+      hasPrevious: false,
+    };
+  }
+
+  return {
+    items: [],
+    page: DEFAULT_PAGE,
+    size: DEFAULT_SIZE,
+    totalElements: 0,
+    totalPages: 0,
+    hasNext: false,
+    hasPrevious: false,
+  };
 }
 
 function extractRole(payload) {
@@ -63,6 +142,23 @@ function extractRole(payload) {
   );
 }
 
+function isMerchantRole(payload) {
+  const role = String(extractRole(payload) || "").toUpperCase();
+
+  if (role === "MERCHANT" || role === "ROLE_MERCHANT") {
+    return true;
+  }
+
+  if (
+    Array.isArray(payload?.authorities) &&
+    payload.authorities.includes("ROLE_MERCHANT")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
 function extractMerchantId(payload) {
   return (
     payload?.merchantId ||
@@ -73,25 +169,34 @@ function extractMerchantId(payload) {
   );
 }
 
-function buildAuthErrorMessage(error) {
-  const status = error?.status;
+function buildAuthErrorInfo(error) {
+  const status = error?.status ?? null;
   const message =
     error?.body?.message ||
     error?.body?.reason ||
     error?.message;
 
   if (status === 401) {
-    return "인증이 만료되었거나 로그인되지 않았습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.";
+    return {
+      status: 401,
+      message:
+        "로그인이 필요합니다. 개발용 로그인 페이지에서 세션을 생성해주세요.",
+    };
   }
 
   if (status === 403) {
-    return "Merchant 권한이 없어 정산 리스트 화면에 접근할 수 없습니다.";
+    return {
+      status: 403,
+      message: "Merchant 권한이 필요한 페이지입니다.",
+    };
   }
 
-  return (
-    message ||
-    "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
-  );
+  return {
+    status,
+    message:
+      message ||
+      "현재 세션의 역할을 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요.",
+  };
 }
 
 function buildErrorMessage(error) {
@@ -123,147 +228,290 @@ export default function SettlementListPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
+  const initialStatus = searchParams.get("status") ?? "";
+  const initialFrom = searchParams.get("from") ?? getDefaultFrom();
+  const initialTo = searchParams.get("to") ?? getDefaultTo();
+  const initialPage = Number(searchParams.get("page") ?? DEFAULT_PAGE);
+  const initialSize = Number(searchParams.get("size") ?? DEFAULT_SIZE);
+
+  const safeInitialPage = Number.isNaN(initialPage) ? DEFAULT_PAGE : initialPage;
+  const safeInitialSize = Number.isNaN(initialSize) ? DEFAULT_SIZE : initialSize;
+
+  const { page, size, setPage, setSize, resetPage } = usePagination(
+    safeInitialPage,
+    safeInitialSize
+  );
+
   const [rows, setRows] = useState([]);
   const [merchantId, setMerchantId] = useState("");
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
 
-  const [status, setStatus] = useState(searchParams.get("status") ?? "");
-  const [fromDate, setFromDate] = useState(
-    searchParams.get("from") ?? getDefaultFrom()
-  );
-  const [toDate, setToDate] = useState(
-    searchParams.get("to") ?? getDefaultTo()
-  );
+  const [pageInfo, setPageInfo] = useState({
+    page: DEFAULT_PAGE,
+    size: DEFAULT_SIZE,
+    totalElements: 0,
+    totalPages: 0,
+    hasNext: false,
+    hasPrevious: false,
+  });
+
+  const [status, setStatus] = useState(initialStatus);
+  const [fromDate, setFromDate] = useState(initialFrom);
+  const [toDate, setToDate] = useState(initialTo);
 
   const [authChecking, setAuthChecking] = useState(true);
   const [isAllowed, setIsAllowed] = useState(false);
-  const [authErrorMessage, setAuthErrorMessage] = useState("");
+  const [authErrorInfo, setAuthErrorInfo] = useState(null);
 
   const pageTitle = useMemo(() => "정산 리스트", []);
 
-  const fetchSettlements = useCallback(
-    async (resolvedMerchantId, nextStatus, nextFromDate, nextToDate) => {
-      if (!resolvedMerchantId) return;
+  function applyPageResponse(response, fallbackSize = size) {
+    setRows(response?.items ?? []);
+    setPageInfo({
+      page: response?.page ?? DEFAULT_PAGE,
+      size: response?.size ?? fallbackSize,
+      totalElements: response?.totalElements ?? 0,
+      totalPages: response?.totalPages ?? 0,
+      hasNext: response?.hasNext ?? false,
+      hasPrevious: response?.hasPrevious ?? false,
+    });
+  }
 
+  function clearPageResponse(nextSize = size) {
+    setRows([]);
+    setPageInfo({
+      page: DEFAULT_PAGE,
+      size: nextSize,
+      totalElements: 0,
+      totalPages: 0,
+      hasNext: false,
+      hasPrevious: false,
+    });
+  }
+
+  async function loadSettlements(
+    resolvedMerchantId,
+    nextStatus = status,
+    nextFromDate = fromDate,
+    nextToDate = toDate,
+    nextPage = page,
+    nextSize = size
+  ) {
+    if (!resolvedMerchantId) {
+      clearPageResponse(nextSize);
+      return;
+    }
+
+    const params = {
+      page: nextPage,
+      size: nextSize,
+    };
+
+    if (nextStatus) params.status = nextStatus;
+    if (nextFromDate) params.from = nextFromDate;
+    if (nextToDate) params.to = nextToDate;
+
+    console.log("[U4] request merchantId =", resolvedMerchantId);
+    console.log("[U4] request params =", params);
+
+    const data = await getMerchantSettlements(resolvedMerchantId, params);
+
+    console.log("[U4] raw response =", data);
+
+    const normalized = normalizeSettlementPage(data);
+
+    console.log("[U4] normalized response =", normalized);
+
+    applyPageResponse(normalized, nextSize);
+  }
+
+  async function runSettlementsLoad(
+    resolvedMerchantId,
+    nextStatus = status,
+    nextFromDate = fromDate,
+    nextToDate = toDate,
+    nextPage = page,
+    nextSize = size
+  ) {
+    try {
       setLoading(true);
       setErrorMessage("");
+      await loadSettlements(
+        resolvedMerchantId,
+        nextStatus,
+        nextFromDate,
+        nextToDate,
+        nextPage,
+        nextSize
+      );
+    } catch (error) {
+      console.error("U4 정산 리스트 조회 실패", error);
+      clearPageResponse(nextSize);
+      setErrorMessage(buildErrorMessage(error));
+    } finally {
+      setLoading(false);
+    }
+  }
 
-      try {
-        const params = {};
-        if (nextStatus) params.status = nextStatus;
-        if (nextFromDate) params.from = nextFromDate;
-        if (nextToDate) params.to = nextToDate;
-
-        const data = await getMerchantSettlements(resolvedMerchantId, params);
-        setRows(normalizeSettlementList(data));
-      } catch (error) {
-        console.error("U4 정산 리스트 조회 실패", error);
-        setRows([]);
-        setErrorMessage(buildErrorMessage(error));
-      } finally {
-        setLoading(false);
-      }
-    },
-    []
-  );
+  function syncSearchParams(
+    nextStatus,
+    nextFromDate,
+    nextToDate,
+    nextPage,
+    nextSize
+  ) {
+    const nextParams = {};
+    if (nextStatus) nextParams.status = nextStatus;
+    if (nextFromDate) nextParams.from = nextFromDate;
+    if (nextToDate) nextParams.to = nextToDate;
+    nextParams.page = String(nextPage);
+    nextParams.size = String(nextSize);
+    setSearchParams(nextParams);
+  }
 
   useEffect(() => {
-    let mounted = true;
-
-    async function checkMerchantRole() {
+    async function loadPage() {
       try {
         setAuthChecking(true);
-        setAuthErrorMessage("");
+        setAuthErrorInfo(null);
         setIsAllowed(false);
         setMerchantId("");
+        setErrorMessage("");
 
         const me = await getMe();
-        const role = String(extractRole(me) || "").toUpperCase();
         const resolvedMerchantId = extractMerchantId(me);
 
-        if (!mounted) return;
-
-        if (role !== "MERCHANT") {
+        if (!isMerchantRole(me)) {
           setIsAllowed(false);
-          setAuthErrorMessage(
-            "Merchant 전용 정산 리스트 화면입니다. /auth/dev-login 에서 Merchant 세션으로 다시 로그인해 주세요."
-          );
+          setAuthErrorInfo({
+            status: 403,
+            message: "Merchant 권한이 필요한 페이지입니다.",
+          });
+          clearPageResponse(size);
           return;
         }
 
         if (!resolvedMerchantId) {
           setIsAllowed(false);
-          setAuthErrorMessage(
-            "세션에서 merchantId를 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요."
-          );
+          setAuthErrorInfo({
+            status: 403,
+            message:
+              "세션에서 merchantId를 확인할 수 없습니다. /auth/dev-login 에서 Merchant 세션을 다시 생성해 주세요.",
+          });
+          clearPageResponse(size);
           return;
         }
 
         setMerchantId(resolvedMerchantId);
         setIsAllowed(true);
+
+        await runSettlementsLoad(
+          resolvedMerchantId,
+          initialStatus,
+          initialFrom,
+          initialTo,
+          safeInitialPage,
+          safeInitialSize
+        );
       } catch (error) {
-        if (!mounted) return;
         setIsAllowed(false);
-        setAuthErrorMessage(buildAuthErrorMessage(error));
+        setMerchantId("");
+        setAuthErrorInfo(buildAuthErrorInfo(error));
+        clearPageResponse(size);
       } finally {
-        if (mounted) {
-          setAuthChecking(false);
-        }
+        setAuthChecking(false);
       }
     }
 
-    checkMerchantRole();
-
-    return () => {
-      mounted = false;
-    };
+    loadPage();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  useEffect(() => {
+  async function handleSearch(event) {
+    event.preventDefault();
     if (!isAllowed || !merchantId) return;
 
-    const nextStatus = searchParams.get("status") ?? "";
-    const nextFromDate = searchParams.get("from") ?? getDefaultFrom();
-    const nextToDate = searchParams.get("to") ?? getDefaultTo();
+    const nextPage = DEFAULT_PAGE;
+    const nextSize = size;
 
-    setStatus(nextStatus);
-    setFromDate(nextFromDate);
-    setToDate(nextToDate);
-    fetchSettlements(merchantId, nextStatus, nextFromDate, nextToDate);
-  }, [searchParams, fetchSettlements, isAllowed, merchantId]);
-
-  function handleSearch(event) {
-    event.preventDefault();
-    if (!isAllowed) return;
-
-    const nextParams = {};
-    if (status) nextParams.status = status;
-    if (fromDate) nextParams.from = fromDate;
-    if (toDate) nextParams.to = toDate;
-
-    setSearchParams(nextParams);
+    resetPage();
+    await runSettlementsLoad(
+      merchantId,
+      status,
+      fromDate,
+      toDate,
+      nextPage,
+      nextSize
+    );
+    syncSearchParams(status, fromDate, toDate, nextPage, nextSize);
   }
 
-  function handleReset() {
+  async function handleReset() {
+    if (!isAllowed || !merchantId) return;
+
+    const nextStatus = "";
     const nextFrom = getDefaultFrom();
     const nextTo = getDefaultTo();
+    const nextPage = DEFAULT_PAGE;
+    const nextSize = DEFAULT_SIZE;
 
-    setStatus("");
+    setStatus(nextStatus);
     setFromDate(nextFrom);
     setToDate(nextTo);
+    setSize(nextSize);
+    setPage(nextPage);
+    resetPage();
 
-    if (!isAllowed) return;
-
-    setSearchParams({
-      from: nextFrom,
-      to: nextTo,
-    });
+    await runSettlementsLoad(
+      merchantId,
+      nextStatus,
+      nextFrom,
+      nextTo,
+      nextPage,
+      nextSize
+    );
+    syncSearchParams(nextStatus, nextFrom, nextTo, nextPage, nextSize);
   }
 
   function handleRowClick(settlementId) {
     if (!isAllowed || !settlementId) return;
     navigate(`/merchant/settlements/${settlementId}`);
+  }
+
+  async function handlePageChange(nextPage) {
+    if (!isAllowed || !merchantId) return;
+
+    setPage(nextPage);
+    await runSettlementsLoad(
+      merchantId,
+      status,
+      fromDate,
+      toDate,
+      nextPage,
+      size
+    );
+    syncSearchParams(status, fromDate, toDate, nextPage, size);
+  }
+
+  async function handleSizeChange(event) {
+    if (!isAllowed || !merchantId) return;
+
+    const nextSize = Number(event.target.value);
+    const nextPage = DEFAULT_PAGE;
+
+    setSize(nextSize);
+    resetPage();
+
+    await runSettlementsLoad(
+      merchantId,
+      status,
+      fromDate,
+      toDate,
+      nextPage,
+      nextSize
+    );
+    syncSearchParams(status, fromDate, toDate, nextPage, nextSize);
   }
 
   if (authChecking) {
@@ -272,45 +520,42 @@ export default function SettlementListPage() {
         title={pageTitle}
         description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
       >
-        <SectionCard title="세션 확인 중">
-          <LoadingBlock
-            title="세션 확인 중"
-            description="현재 로그인 세션의 역할을 확인하고 있습니다."
-          />
-        </SectionCard>
+        <div className="guard-notice">
+          <div className="guard-notice__title">로딩 중</div>
+          <div className="guard-notice__description">
+            권한 정보를 확인하는 중입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }
 
-  if (!isAllowed) {
-    if (
-      authErrorMessage.includes("로그인") ||
-      authErrorMessage.includes("인증")
-    ) {
-      return (
-        <PageLayout
-          title={pageTitle}
-          description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
-        >
-          <RequireLoginNotice
-            title="Merchant 전용 화면"
-            message={authErrorMessage}
-          />
-        </PageLayout>
-      );
-    }
-
+  if (authErrorInfo?.status === 401) {
     return (
       <PageLayout
         title={pageTitle}
         description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
       >
-        <GuardNotice
-          title="접근 불가"
-          message={authErrorMessage}
-          tone="danger"
+        <RequireLoginNotice
+          title="인증 필요"
+          message={authErrorInfo.message}
         />
-        <ErrorState message={authErrorMessage} />
+      </PageLayout>
+    );
+  }
+
+  if (!isAllowed) {
+    return (
+      <PageLayout
+        title={pageTitle}
+        description="판매자 기준으로 정산 내역을 조회하고 settlementId 앵커로 상세 화면(U5)으로 이동합니다."
+      >
+        <div className="guard-notice">
+          <div className="guard-notice__title">접근 불가</div>
+          <div className="guard-notice__description">
+            Merchant 권한이 필요한 페이지입니다.
+          </div>
+        </div>
       </PageLayout>
     );
   }
@@ -441,7 +686,19 @@ export default function SettlementListPage() {
         </>
       ) : null}
 
-      <SectionCard title={`정산 리스트 (${rows.length}건)`}>
+      <SectionCard title="정산 리스트">
+        <div className="table-toolbar">
+          <div>정산 리스트 · 총 {formatNumber(pageInfo.totalElements)}건</div>
+
+          <div className="action-panel">
+            <select className="select" value={size} onChange={handleSizeChange}>
+              <option value={10}>10개</option>
+              <option value={20}>20개</option>
+              <option value={50}>50개</option>
+            </select>
+          </div>
+        </div>
+
         {loading ? (
           <LoadingBlock
             title="로딩 중"
@@ -453,81 +710,90 @@ export default function SettlementListPage() {
             description="검색 조건을 다시 확인하거나 기간을 넓혀 주세요."
           />
         ) : (
-          <div className="table-wrap">
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>settlementId</th>
-                  <th>상태</th>
-                  <th>baseDate</th>
-                  <th>gross</th>
-                  <th>fee</th>
-                  <th>vat</th>
-                  <th>net</th>
-                  <th>상세</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((row, index) => {
-                  const settlementId =
-                    row?.settlementId ?? row?.id ?? `row-${index}`;
+          <>
+            <div className="table-wrap">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>settlementId</th>
+                    <th>상태</th>
+                    <th>baseDate</th>
+                    <th>gross</th>
+                    <th>fee</th>
+                    <th>vat</th>
+                    <th>net</th>
+                    <th>상세</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((row, index) => {
+                    const settlementId =
+                      row?.settlementId ?? row?.id ?? `row-${index}`;
 
-                  return (
-                    <tr
-                      key={settlementId}
-                      onClick={() => handleRowClick(settlementId)}
-                      style={{ cursor: settlementId ? "pointer" : "default" }}
-                    >
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
+                    return (
+                      <tr
+                        key={settlementId}
+                        onClick={() => handleRowClick(settlementId)}
+                        style={{ cursor: settlementId ? "pointer" : "default" }}
                       >
-                        <CopyableId value={settlementId} short />
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        <StatusBadge status={row?.status || "UNKNOWN"} />
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {row?.baseDate ?? "-"}
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.gross)}
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.fee)}
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.vat)}
-                      </td>
-
-                      <td style={{ verticalAlign: "middle" }}>
-                        {formatAmount(row?.net)}
-                      </td>
-
-                      <td
-                        onClick={(event) => event.stopPropagation()}
-                        style={{ verticalAlign: "middle" }}
-                      >
-                        <ActionButton
-                          type="button"
-                          variant="secondary"
-                          onClick={() => handleRowClick(settlementId)}
-                          disabled={!settlementId}
+                        <td
+                          onClick={(event) => event.stopPropagation()}
+                          style={{ verticalAlign: "middle" }}
                         >
-                          상세조회
-                        </ActionButton>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                          <CopyableId value={settlementId} short />
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          <StatusBadge status={row?.status || "UNKNOWN"} />
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {row?.baseDate ?? "-"}
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.gross)}
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.fee)}
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.vat)}
+                        </td>
+
+                        <td style={{ verticalAlign: "middle" }}>
+                          {formatAmount(row?.net)}
+                        </td>
+
+                        <td
+                          onClick={(event) => event.stopPropagation()}
+                          style={{ verticalAlign: "middle" }}
+                        >
+                          <ActionButton
+                            type="button"
+                            variant="secondary"
+                            onClick={() => handleRowClick(settlementId)}
+                            disabled={!settlementId}
+                          >
+                            상세조회
+                          </ActionButton>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+
+            <Pagination
+              page={pageInfo.page}
+              totalPages={pageInfo.totalPages}
+              onPageChange={handlePageChange}
+              disabled={loading}
+            />
+          </>
         )}
       </SectionCard>
     </PageLayout>

--- a/server/src/main/java/com/settleops/domain/settlement/api/MerchantSettlementQueryController.java
+++ b/server/src/main/java/com/settleops/domain/settlement/api/MerchantSettlementQueryController.java
@@ -3,14 +3,18 @@ package com.settleops.domain.settlement.api;
 import com.settleops.domain.settlement.application.MerchantSettlementQueryService;
 import com.settleops.domain.settlement.dto.MerchantSettlementDetailResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
 import com.settleops.global.auth.annotation.LoginMerchant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +26,11 @@ public class MerchantSettlementQueryController {
     @GetMapping
     public ResponseEntity<Page<MerchantSettlementListItemResponse>> getMerchantSettlements(
             @PathVariable String merchantId,
+            @RequestParam(required = false) SettlementStatus status,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
             @PageableDefault(size = 20) Pageable pageable,
             @LoginMerchant String loginMerchantId
     ) {
@@ -34,6 +43,9 @@ public class MerchantSettlementQueryController {
                 merchantSettlementQueryService.getMerchantSettlements(
                         loginMerchantId,
                         merchantId,
+                        status,
+                        from,
+                        to,
                         fixedPageable
                 )
         );

--- a/server/src/main/java/com/settleops/domain/settlement/application/MerchantSettlementQueryService.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/MerchantSettlementQueryService.java
@@ -2,14 +2,20 @@ package com.settleops.domain.settlement.application;
 
 import com.settleops.domain.settlement.dto.MerchantSettlementDetailResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
 
 public interface MerchantSettlementQueryService {
 
     Page<MerchantSettlementListItemResponse> getMerchantSettlements(
             String loginMerchantId,
             String merchantId,
+            SettlementStatus status,
+            LocalDate from,
+            LocalDate to,
             Pageable pageable
     );
 

--- a/server/src/main/java/com/settleops/domain/settlement/application/MerchantSettlementQueryServiceImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/application/MerchantSettlementQueryServiceImpl.java
@@ -2,6 +2,7 @@ package com.settleops.domain.settlement.application;
 
 import com.settleops.domain.settlement.dto.MerchantSettlementDetailResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
+import com.settleops.domain.settlement.enums.SettlementStatus;
 import com.settleops.domain.settlement.infra.SettlementRepository;
 import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.ForbiddenException;
@@ -12,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -20,13 +23,32 @@ public class MerchantSettlementQueryServiceImpl implements MerchantSettlementQue
     private final SettlementRepository settlementRepository;
 
     @Override
-    public Page<MerchantSettlementListItemResponse> getMerchantSettlements(String loginMerchantId, String merchantId, Pageable pageable) {
+    public Page<MerchantSettlementListItemResponse> getMerchantSettlements(
+            String loginMerchantId,
+            String merchantId,
+            SettlementStatus status,
+            LocalDate from,
+            LocalDate to,
+            Pageable pageable
+    ) {
         validateMerchantAccess(loginMerchantId, merchantId);
-        return settlementRepository.searchMerchantSettlements(merchantId, pageable);
+        validateDateRange(from, to);
+
+        return settlementRepository.searchMerchantSettlements(
+                merchantId,
+                status,
+                from,
+                to,
+                pageable
+        );
     }
 
     @Override
-    public MerchantSettlementDetailResponse getMerchantSettlementDetail(String loginMerchantId, String merchantId, String settlementId) {
+    public MerchantSettlementDetailResponse getMerchantSettlementDetail(
+            String loginMerchantId,
+            String merchantId,
+            String settlementId
+    ) {
         validateMerchantAccess(loginMerchantId, merchantId);
 
         if (settlementId == null || settlementId.isBlank()) {
@@ -56,11 +78,17 @@ public class MerchantSettlementQueryServiceImpl implements MerchantSettlementQue
         }
 
         if (merchantId == null || merchantId.isBlank()) {
-            throw new BadRequestException("merchantId must not be a null/blank");
+            throw new BadRequestException("merchantId must not be null/blank");
         }
 
         if (!loginMerchantId.equals(merchantId)) {
             throw new ForbiddenException("merchant mismatch");
+        }
+    }
+
+    private void validateDateRange(LocalDate from, LocalDate to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BadRequestException("from must be before or equal to to");
         }
     }
 }

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryCustom.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryCustom.java
@@ -7,6 +7,7 @@ import com.settleops.domain.settlement.enums.SettlementStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface SettlementRepositoryCustom {
@@ -18,6 +19,9 @@ public interface SettlementRepositoryCustom {
 
     Page<MerchantSettlementListItemResponse> searchMerchantSettlements(
             String merchantId,
+            SettlementStatus status,
+            LocalDate from,
+            LocalDate to,
             Pageable pageable
     );
 

--- a/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryImpl.java
+++ b/server/src/main/java/com/settleops/domain/settlement/infra/SettlementRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.settleops.domain.settlement.infra;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.settleops.domain.settlement.dto.AdminSettlementListItemResponse;
 import com.settleops.domain.settlement.dto.MerchantSettlementDetailResponse;
@@ -18,6 +17,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -78,8 +78,29 @@ public class SettlementRepositoryImpl implements SettlementRepositoryCustom {
     }
 
     @Override
-    public Page<MerchantSettlementListItemResponse> searchMerchantSettlements(String merchantId, Pageable pageable) {
+    public Page<MerchantSettlementListItemResponse> searchMerchantSettlements(
+            String merchantId,
+            SettlementStatus status,
+            LocalDate from,
+            LocalDate to,
+            Pageable pageable
+    ) {
         QSettlement settlement = QSettlement.settlement;
+
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(settlement.merchantId.eq(merchantId));
+
+        if (status != null) {
+            where.and(settlement.status.eq(status));
+        }
+
+        if (from != null) {
+            where.and(settlement.baseDate.goe(from));
+        }
+
+        if (to != null) {
+            where.and(settlement.baseDate.loe(to));
+        }
 
         List<MerchantSettlementListItemResponse> content = queryFactory
                 .select(Projections.constructor(
@@ -94,7 +115,7 @@ public class SettlementRepositoryImpl implements SettlementRepositoryCustom {
                         settlement.createdAt
                 ))
                 .from(settlement)
-                .where(settlement.merchantId.eq(merchantId))
+                .where(where)
                 .orderBy(
                         settlement.baseDate.desc(),
                         settlement.createdAt.desc(),
@@ -107,7 +128,7 @@ public class SettlementRepositoryImpl implements SettlementRepositoryCustom {
         var countQuery = queryFactory
                 .select(settlement.count())
                 .from(settlement)
-                .where(settlement.merchantId.eq(merchantId));
+                .where(where);
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }

--- a/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerTest.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MerchantSettlementQueryControllerTest {
 
     @Test
-    @DisplayName("Merchant 정산 리스트 조회 시 loginMerchantId와 path merchantId를 서비스로 전달한다")
-    void getMerchantSettlements_passesLoginMerchantIdAndPathMerchantId() {
+    @DisplayName("Merchant 정산 리스트 조회 시 loginMerchantId, path merchantId, 필터값을 서비스로 전달한다")
+    void getMerchantSettlements_passesLoginMerchantIdPathMerchantIdAndFilters() {
         MerchantSettlementQueryService merchantSettlementQueryService = Mockito.mock(MerchantSettlementQueryService.class);
         MerchantSettlementQueryController controller =
                 new MerchantSettlementQueryController(merchantSettlementQueryService);
@@ -44,11 +44,17 @@ public class MerchantSettlementQueryControllerTest {
         Mockito.when(merchantSettlementQueryService.getMerchantSettlements(
                 "merchant-1",
                 "merchant-1",
+                SettlementStatus.READY,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
                 PageRequest.of(0, 20)
         )).thenReturn(new PageImpl<>(List.of(item), pageable, 1));
 
         ResponseEntity<?> response = controller.getMerchantSettlements(
                 "merchant-1",
+                SettlementStatus.READY,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
                 pageable,
                 "merchant-1"
         );
@@ -59,6 +65,9 @@ public class MerchantSettlementQueryControllerTest {
         Mockito.verify(merchantSettlementQueryService).getMerchantSettlements(
                 "merchant-1",
                 "merchant-1",
+                SettlementStatus.READY,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
                 PageRequest.of(0, 20)
         );
     }

--- a/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerWebMvcTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/api/MerchantSettlementQueryControllerWebMvcTest.java
@@ -198,7 +198,7 @@ class MerchantSettlementQueryControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("Merchant 정산 리스트 조회 성공 시 200과 페이지 응답을 반환한다")
+    @DisplayName("Merchant 정산 리스트 조회 성공 시 status/from/to 필터를 포함해 200과 페이지 응답을 반환한다")
     void getMerchantSettlements_success() throws Exception {
         MerchantSettlementListItemResponse item1 = new MerchantSettlementListItemResponse(
                 "settlement-1",
@@ -211,32 +211,27 @@ class MerchantSettlementQueryControllerWebMvcTest {
                 LocalDateTime.of(2026, 3, 11, 10, 0)
         );
 
-        MerchantSettlementListItemResponse item2 = new MerchantSettlementListItemResponse(
-                "settlement-2",
-                LocalDate.of(2026, 3, 11),
-                SettlementStatus.PAID,
-                20000L,
-                2000L,
-                200L,
-                17800L,
-                LocalDateTime.of(2026, 3, 12, 11, 0)
-        );
-
         when(sessionAuthProvider.getCurrentMerchantId()).thenReturn(MERCHANT_ID);
         when(merchantSettlementQueryService.getMerchantSettlements(
                 eq(MERCHANT_ID),
                 eq(MERCHANT_ID),
+                eq(SettlementStatus.READY),
+                eq(LocalDate.of(2026, 3, 1)),
+                eq(LocalDate.of(2026, 3, 31)),
                 eq(PageRequest.of(0, 20))
-        )).thenReturn(new PageImpl<>(List.of(item1, item2), PageRequest.of(0, 20), 2));
+        )).thenReturn(new PageImpl<>(List.of(item1), PageRequest.of(0, 20), 1));
 
         mockMvc.perform(get("/api/merchants/{merchantId}/settlements", MERCHANT_ID)
                         .sessionAttr(MeController.SessionKeys.ROLE, "MERCHANT")
                         .sessionAttr(MeController.SessionKeys.MERCHANT_ID, MERCHANT_ID)
+                        .param("status", "READY")
+                        .param("from", "2026-03-01")
+                        .param("to", "2026-03-31")
                         .param("page", "0")
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content.length()").value(1))
                 .andExpect(jsonPath("$.content[0].settlementId").value("settlement-1"))
                 .andExpect(jsonPath("$.content[0].baseDate").value("2026-03-10"))
                 .andExpect(jsonPath("$.content[0].status").value("READY"))
@@ -244,15 +239,16 @@ class MerchantSettlementQueryControllerWebMvcTest {
                 .andExpect(jsonPath("$.content[0].fee").value(1000))
                 .andExpect(jsonPath("$.content[0].vat").value(100))
                 .andExpect(jsonPath("$.content[0].net").value(8900))
-                .andExpect(jsonPath("$.content[1].settlementId").value("settlement-2"))
-                .andExpect(jsonPath("$.content[1].status").value("PAID"))
                 .andExpect(jsonPath("$.number").value(0))
                 .andExpect(jsonPath("$.size").value(20))
-                .andExpect(jsonPath("$.totalElements").value(2));
+                .andExpect(jsonPath("$.totalElements").value(1));
 
         verify(merchantSettlementQueryService).getMerchantSettlements(
                 MERCHANT_ID,
                 MERCHANT_ID,
+                SettlementStatus.READY,
+                LocalDate.of(2026, 3, 1),
+                LocalDate.of(2026, 3, 31),
                 PageRequest.of(0, 20)
         );
     }

--- a/server/src/test/java/com/settleops/domain/settlement/application/MerchantSettlementQueryServiceImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/application/MerchantSettlementQueryServiceImplTest.java
@@ -6,6 +6,7 @@ import com.settleops.domain.settlement.dto.MerchantSettlementListItemResponse;
 import com.settleops.domain.settlement.enums.SettlementLineType;
 import com.settleops.domain.settlement.enums.SettlementStatus;
 import com.settleops.domain.settlement.infra.SettlementRepository;
+import com.settleops.global.error.BadRequestException;
 import com.settleops.global.error.ForbiddenException;
 import com.settleops.global.error.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,9 @@ public class MerchantSettlementQueryServiceImplTest {
                 service.getMerchantSettlements(
                         "merchant-1",
                         "merchant-2",
+                        SettlementStatus.READY,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 3, 31),
                         PageRequest.of(0, 20)
                 )
         )
@@ -65,18 +69,59 @@ public class MerchantSettlementQueryServiceImplTest {
 
         Page<MerchantSettlementListItemResponse> page = new PageImpl<>(List.of(item), pageable, 1);
 
-        Mockito.when(settlementRepository.searchMerchantSettlements("merchant-1", pageable))
-                .thenReturn(page);
+        Mockito.when(
+                settlementRepository.searchMerchantSettlements(
+                        "merchant-1",
+                        SettlementStatus.READY,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 3, 31),
+                        pageable
+                )
+        ).thenReturn(page);
 
         Page<MerchantSettlementListItemResponse> result =
-                service.getMerchantSettlements("merchant-1", "merchant-1", pageable);
+                service.getMerchantSettlements(
+                        "merchant-1",
+                        "merchant-1",
+                        SettlementStatus.READY,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 3, 31),
+                        pageable
+                );
 
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).settlementId()).isEqualTo("settlement-1");
 
         Mockito.verify(settlementRepository)
-                .searchMerchantSettlements("merchant-1", pageable);
+                .searchMerchantSettlements(
+                        "merchant-1",
+                        SettlementStatus.READY,
+                        LocalDate.of(2026, 3, 1),
+                        LocalDate.of(2026, 3, 31),
+                        pageable
+                );
+    }
+
+    @Test
+    @DisplayName("Merchant 정산 리스트 조회 시 from이 to보다 크면 400을 반환한다")
+    void getMerchantSettlements_badRequestWhenFromAfterTo() {
+        SettlementRepository settlementRepository = Mockito.mock(SettlementRepository.class);
+        MerchantSettlementQueryServiceImpl service = new MerchantSettlementQueryServiceImpl(settlementRepository);
+
+        assertThatThrownBy(() ->
+                service.getMerchantSettlements(
+                        "merchant-1",
+                        "merchant-1",
+                        SettlementStatus.READY,
+                        LocalDate.of(2026, 4, 1),
+                        LocalDate.of(2026, 3, 1),
+                        PageRequest.of(0, 20)
+                )
+        )
+                .isInstanceOf(BadRequestException.class);
+
+        Mockito.verifyNoInteractions(settlementRepository);
     }
 
     @Test

--- a/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
+++ b/server/src/test/java/com/settleops/domain/settlement/infra/SettlementRepositoryImplTest.java
@@ -194,39 +194,69 @@ class SettlementRepositoryImplTest {
     }
 
     @Test
-    @DisplayName("Merchant 정산 리스트 조회 시 해당 merchant의 데이터만 반환한다")
-    void searchMerchantSettlements_filtersByMerchantId() {
+    @DisplayName("Merchant 정산 리스트 조회 시 merchantId, status, from, to 조건을 함께 적용한다")
+    void searchMerchantSettlements_filtersByMerchantIdStatusAndDateRange() {
         // given
-        LocalDate date1 = LocalDate.of(2099, 12, 23);
-        LocalDate date2 = LocalDate.of(2099, 12, 22);
-        LocalDate date3 = LocalDate.of(2099, 12, 21);
+        LocalDate includedDate1 = LocalDate.of(2099, 12, 23);
+        LocalDate includedDate2 = LocalDate.of(2099, 12, 22);
+        LocalDate excludedOldDate = LocalDate.of(2099, 12, 21);
+        LocalDate excludedOtherMerchantDate = LocalDate.of(2099, 12, 23);
+        LocalDate excludedOtherStatusDate = LocalDate.of(2099, 12, 24);
+
+        Long batchIdIncludedDate1 = createBatchId(includedDate1);
+        Long batchIdIncludedDate2 = createBatchId(includedDate2);
+        Long batchIdExcludedOldDate = createBatchId(excludedOldDate);
+        Long batchIdExcludedOtherStatusDate = createBatchId(excludedOtherStatusDate);
 
         Settlement target1 = createSettlement(
-                createBatchId(date1),
+                batchIdIncludedDate1,
                 "merchant-1",
-                date1,
+                includedDate1,
                 10000L
         );
         Settlement target2 = createSettlement(
-                createBatchId(date2),
+                batchIdIncludedDate2,
                 "merchant-1",
-                date2,
+                includedDate2,
                 9000L
         );
+        Settlement excludedOldDateSettlement = createSettlement(
+                batchIdExcludedOldDate,
+                "merchant-1",
+                excludedOldDate,
+                8000L
+        );
         Settlement otherMerchant = createSettlement(
-                createBatchId(date3),
+                batchIdIncludedDate1,
                 "merchant-2",
-                date3,
+                includedDate1,
                 11000L
         );
+        Settlement otherStatus = createSettlement(
+                batchIdExcludedOtherStatusDate,
+                "merchant-1",
+                excludedOtherStatusDate,
+                12000L
+        );
 
-        settlementRepository.saveAll(List.of(target1, target2, otherMerchant));
+        settlementRepository.saveAll(List.of(
+                target1,
+                target2,
+                excludedOldDateSettlement,
+                otherMerchant,
+                otherStatus
+        ));
         entityManager.flush();
+
+        forceStatus(otherStatus.getSettlementId(), SettlementStatus.PAY_REQUESTED);
         entityManager.clear();
 
         // when
         Page<MerchantSettlementListItemResponse> result = settlementRepository.searchMerchantSettlements(
                 "merchant-1",
+                SettlementStatus.READY,
+                LocalDate.of(2099, 12, 22),
+                LocalDate.of(2099, 12, 24),
                 PageRequest.of(0, 20)
         );
 
@@ -238,7 +268,11 @@ class SettlementRepositoryImplTest {
 
         assertThat(result.getContent())
                 .extracting(MerchantSettlementListItemResponse::baseDate)
-                .containsExactly(date1, date2);
+                .containsExactly(includedDate1, includedDate2);
+
+        assertThat(result.getContent())
+                .extracting(MerchantSettlementListItemResponse::status)
+                .containsOnly(SettlementStatus.READY);
     }
 
     @Test


### PR DESCRIPTION
## 변경 내용
- Merchant U4 정산 리스트 조회 흐름 정리
  - status / from / to 필터를 서버 조회 조건과 정렬
  - 조회 / 초기화 / 페이지 이동 시 search param 동기화 정리
  - 기본 기간을 최근 7일 기준으로 정리
- Merchant U5 정산 상세 흐름 정리
  - settlementId 앵커 기준 상세 진입/조회 흐름 정리
  - merchant 세션 기준 권한 확인 및 가드 메시지 정리
  - 현재 Merchant 상세 SoT 범위에 맞춰 settlement 요약 + line 목록 중심으로 정리
- 백엔드 Merchant settlement 조회 API 정리
  - Controller / Service / Repository에 status / from / to 필터 반영
  - Merchant list 조회 조건을 서버 SoT 기준으로 일치시킴
- 관련 테스트 정리
  - controller / webmvc / service / repository 테스트를 필터 시나리오 기준으로 보강

## 확인한 사항
- MerchantSettlementQueryControllerTest 통과
- MerchantSettlementQueryControllerWebMvcTest 통과
- MerchantSettlementQueryServiceImplTest 통과
- SettlementRepositoryImplTest 통과

## 참고
- develop merge 이후 전체 test에서는 refund 영역 기존 테스트 2건이 suite 전체 실행에서만 실패
- 해당 테스트는 단독 clean 실행 시 통과
- 이번 PR 변경 범위의 settlement 관련 테스트는 정상 확인