### PR TITLE
feat(refund): A4→A6 settlement 앵커 연동 및 환불 큐 필터 추가

### DIFF
--- a/admin-web/src/api/refundApi.js
+++ b/admin-web/src/api/refundApi.js
@@ -11,6 +11,10 @@ export function createRefund(payload) {
     });
 }
 
+export function requestRefund(payload) {
+    return createRefund(payload);
+}
+
 export function getMyRefunds(params = {}) {
     const searchParams = new URLSearchParams();
 
@@ -19,12 +23,21 @@ export function getMyRefunds(params = {}) {
     }
     if (params.from) searchParams.set("from", params.from);
     if (params.to) searchParams.set("to", params.to);
+    if (params.keyword) searchParams.set("keyword", params.keyword);
+    if (params.sortKey) searchParams.set("sortKey", params.sortKey);
+    if (params.sortDirection) {
+        searchParams.set("sortDirection", params.sortDirection);
+    }
 
     searchParams.set("page", String(params.page ?? 0));
     searchParams.set("size", String(params.size ?? 20));
 
     const query = searchParams.toString();
     return requestJson(`/api/me/refunds?${query}`);
+}
+
+export function getRefundContextByPaymentId(paymentId) {
+    return getRefundContext(paymentId);
 }
 
 export function getAdminRefunds(params = {}) {
@@ -34,6 +47,7 @@ export function getAdminRefunds(params = {}) {
     if (params.from) searchParams.set("from", params.from);
     if (params.to) searchParams.set("to", params.to);
     if (params.keyword) searchParams.set("keyword", params.keyword);
+    if (params.settlementId) searchParams.set("settlementId", params.settlementId);
     if (params.sortKey) searchParams.set("sortKey", params.sortKey);
     if (params.sortDirection) {
         searchParams.set("sortDirection", params.sortDirection);
@@ -61,7 +75,5 @@ export function rejectRefund(refundId, comment) {
 }
 
 export function getAdminRefundTraceEntry(refundId) {
-    return requestJson(`/api/admin/refunds/${refundId}/trace-entry`, {
-        method: "GET",
-    });
+    return requestJson(`/api/admin/refunds/${refundId}/trace-entry`);
 }

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -300,7 +300,14 @@ export default function RefundQueuePage() {
                 const response = await getAdminRefundTraceEntry(selectedRow.refundId);
 
                 if (cancelled) return;
-                setTraceRequestId(response?.traceRequestId || "");
+
+                const requestId =
+                    response?.traceRequestId ||
+                    response?.requestId ||
+                    response?.resolvedRequestId ||
+                    "";
+
+                setTraceRequestId(requestId);
             } catch (error) {
                 if (cancelled) return;
                 setTraceRequestId("");
@@ -462,6 +469,7 @@ export default function RefundQueuePage() {
             setComment("");
             await reloadCurrentPage();
             setSelectedRefund(null);
+            setTraceRequestId(result?.requestId || "");
         } catch (error) {
             if (error?.body?.reason) {
                 setErrorMessage(`환불 처리 실패: ${error.body.reason}`);
@@ -1257,7 +1265,9 @@ export default function RefundQueuePage() {
                                                     </td>
 
                                                     <td className="refund-queue-captured-col">
-                                                        <AmountText value={getAmountValue(row, "capturedAmount")} />
+                                                        <AmountText
+                                                            value={getAmountValue(row, "capturedAmount")}
+                                                        />
                                                     </td>
 
                                                     <td className="refund-queue-refundable-col">

--- a/admin-web/src/pages/admin/RefundQueuePage.jsx
+++ b/admin-web/src/pages/admin/RefundQueuePage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { getMe } from "../../api/meApi.js";
 import RequireLoginNotice from "../../components/feedback/RequireLoginNotice.jsx";
 import PageLayout from "../../components/layout/PageLayout.jsx";
@@ -50,10 +50,7 @@ function isAdminRole(me) {
 function buildErrorInfo(error, fallbackMessage) {
     return {
         status: error?.status ?? null,
-        message:
-            error?.body?.message ||
-            error?.body?.reason ||
-            fallbackMessage,
+        message: error?.body?.message || error?.body?.reason || fallbackMessage,
     };
 }
 
@@ -84,7 +81,13 @@ function renderDate(value) {
 
 export default function RefundQueuePage() {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const { page, size, setPage, resetPage } = usePagination(0, 7);
+
+    const anchorSettlementId = useMemo(() => {
+        const value = searchParams.get("settlementId");
+        return value && value.trim() ? value.trim() : "";
+    }, [searchParams]);
 
     const [draftFilters, setDraftFilters] = useState(INITIAL_FILTERS);
     const [appliedFilters, setAppliedFilters] = useState(INITIAL_FILTERS);
@@ -104,7 +107,8 @@ export default function RefundQueuePage() {
         hasPrevious: false,
     });
 
-    const [selectedRefundId, setSelectedRefundId] = useState("");
+    const [selectedRefund, setSelectedRefund] = useState(null);
+
     const [comment, setComment] = useState("");
     const [lastActionResult, setLastActionResult] = useState(null);
     const [traceRequestId, setTraceRequestId] = useState("");
@@ -113,6 +117,12 @@ export default function RefundQueuePage() {
     const [loading, setLoading] = useState(false);
     const [acting, setActing] = useState(false);
     const [errorMessage, setErrorMessage] = useState("");
+
+    const selectedRow = selectedRefund;
+    const selectedRefundId = selectedRefund?.refundId || "";
+    const selectedStatus = String(selectedRow?.status || "").toUpperCase();
+
+    const prevAnchorSettlementIdRef = useRef(anchorSettlementId);
 
     useEffect(() => {
         let cancelled = false;
@@ -154,6 +164,37 @@ export default function RefundQueuePage() {
     }, []);
 
     useEffect(() => {
+        const prevAnchorSettlementId = prevAnchorSettlementIdRef.current;
+
+        if (prevAnchorSettlementId === anchorSettlementId) {
+            return;
+        }
+
+        prevAnchorSettlementIdRef.current = anchorSettlementId;
+
+        setSelectedRefund(null);
+        setComment("");
+        setLastActionResult(null);
+        setTraceRequestId("");
+        setTraceLoading(false);
+        setErrorMessage("");
+
+        setDraftFilters((prev) => ({
+            ...prev,
+            keyword: "",
+        }));
+
+        setAppliedFilters((prev) => ({
+            ...prev,
+            keyword: "",
+        }));
+
+        if (page !== 0) {
+            resetPage();
+        }
+    }, [anchorSettlementId, page, resetPage]);
+
+    useEffect(() => {
         if (meLoading || meErrorInfo || !isAdminRole(me)) {
             return;
         }
@@ -169,6 +210,7 @@ export default function RefundQueuePage() {
                     status: appliedFilters.status,
                     from: appliedFilters.from,
                     to: appliedFilters.to,
+                    settlementId: anchorSettlementId || undefined,
                     keyword: appliedFilters.keyword,
                     sortKey: sortState.key,
                     sortDirection: sortState.direction,
@@ -190,27 +232,35 @@ export default function RefundQueuePage() {
                     hasPrevious: response?.hasPrevious ?? false,
                 });
 
-                if (selectedRefundId) {
-                    const exists = items.some((row) => row.refundId === selectedRefundId);
-                    if (!exists) {
-                        setSelectedRefundId("");
-                        setComment("");
+                setSelectedRefund((prev) => {
+                    if (prev?.refundId) {
+                        const matched = items.find((row) => row.refundId === prev.refundId);
+                        return matched || null;
                     }
-                }
+
+                    if (anchorSettlementId && items.length === 1) {
+                        return items[0];
+                    }
+
+                    return null;
+                });
             } catch (error) {
                 if (cancelled) return;
 
                 setErrorMessage(error?.body?.message || "환불 큐 조회에 실패했습니다.");
                 setRefunds([]);
                 setPageInfo({
-                    page,
+                    page: targetPage,
                     size,
                     totalElements: 0,
                     totalPages: 0,
                     hasNext: false,
                     hasPrevious: false,
                 });
-                setSelectedRefundId("");
+                setSelectedRefund(null);
+                setComment("");
+                setTraceRequestId("");
+                setTraceLoading(false);
             } finally {
                 if (!cancelled) {
                     setLoading(false);
@@ -223,10 +273,16 @@ export default function RefundQueuePage() {
         return () => {
             cancelled = true;
         };
-    }, [meLoading, meErrorInfo, me, page, size, appliedFilters, sortState, selectedRefundId]);
-
-    const selectedRow =
-        refunds.find((row) => row.refundId === selectedRefundId) || null;
+    }, [
+        meLoading,
+        meErrorInfo,
+        me,
+        page,
+        size,
+        appliedFilters,
+        sortState,
+        anchorSettlementId,
+    ]);
 
     useEffect(() => {
         if (!selectedRow?.refundId) {
@@ -262,7 +318,6 @@ export default function RefundQueuePage() {
         };
     }, [selectedRow?.refundId]);
 
-    const selectedStatus = String(selectedRow?.status || "").toUpperCase();
     const canAct =
         !!selectedRow &&
         selectedStatus === "REQUESTED" &&
@@ -279,14 +334,14 @@ export default function RefundQueuePage() {
 
     function handleSearch(event) {
         event.preventDefault();
-        setErrorMessage("");
-        setLastActionResult(null);
 
         const nextFilters = {
             ...draftFilters,
             keyword: String(draftFilters.keyword || "").trim(),
         };
 
+        setErrorMessage("");
+        setLastActionResult(null);
         setAppliedFilters(nextFilters);
 
         if (page !== 0) {
@@ -295,7 +350,7 @@ export default function RefundQueuePage() {
     }
 
     function handleSelectRefund(row) {
-        setSelectedRefundId(row.refundId);
+        setSelectedRefund(row);
         setComment("");
         setErrorMessage("");
         setLastActionResult(null);
@@ -303,7 +358,7 @@ export default function RefundQueuePage() {
     }
 
     function handleClearSelection() {
-        setSelectedRefundId("");
+        setSelectedRefund(null);
         setComment("");
         setErrorMessage("");
         setLastActionResult(null);
@@ -325,6 +380,10 @@ export default function RefundQueuePage() {
                 direction: sortKey === "requestedAt" ? "desc" : "asc",
             };
         });
+
+        if (page !== 0) {
+            resetPage();
+        }
     }
 
     function renderSortArrow(sortKey) {
@@ -337,6 +396,7 @@ export default function RefundQueuePage() {
             status: appliedFilters.status,
             from: appliedFilters.from,
             to: appliedFilters.to,
+            settlementId: anchorSettlementId || undefined,
             keyword: appliedFilters.keyword,
             sortKey: sortState.key,
             sortDirection: sortState.direction,
@@ -353,6 +413,12 @@ export default function RefundQueuePage() {
             totalPages: response?.totalPages ?? 0,
             hasNext: response?.hasNext ?? false,
             hasPrevious: response?.hasPrevious ?? false,
+        });
+
+        setSelectedRefund((prev) => {
+            if (!prev?.refundId) return null;
+            const matched = items.find((row) => row.refundId === prev.refundId);
+            return matched || null;
         });
     }
 
@@ -395,7 +461,7 @@ export default function RefundQueuePage() {
 
             setComment("");
             await reloadCurrentPage();
-            setSelectedRefundId("");
+            setSelectedRefund(null);
         } catch (error) {
             if (error?.body?.reason) {
                 setErrorMessage(`환불 처리 실패: ${error.body.reason}`);
@@ -692,6 +758,30 @@ export default function RefundQueuePage() {
                     flex: 0 0 auto;
                 }
 
+                .refund-queue-anchor-banner {
+                    display: flex;
+                    align-items: center;
+                    justify-content: space-between;
+                    gap: 12px;
+                    margin-bottom: 12px;
+                    padding: 12px 14px;
+                    border: 1px solid var(--color-border);
+                    border-radius: 10px;
+                    background: #f8fafc;
+                }
+
+                .refund-queue-anchor-banner strong {
+                    font-size: 13px;
+                    font-weight: 700;
+                    color: #344054;
+                }
+
+                .refund-queue-anchor-banner span {
+                    flex: 1 1 auto;
+                    font-size: 13px;
+                    color: #475467;
+                }
+
                 .refund-queue-table-wrap {
                     width: 100%;
                     overflow-x: auto;
@@ -834,6 +924,11 @@ export default function RefundQueuePage() {
                     .refund-queue-result-grid,
                     .refund-queue-actions {
                         grid-template-columns: 1fr;
+                    }
+
+                    .refund-queue-anchor-banner {
+                        flex-direction: column;
+                        align-items: flex-start;
                     }
                 }
 
@@ -1010,6 +1105,23 @@ export default function RefundQueuePage() {
                         </div>
                     </SectionCard>
 
+                    {anchorSettlementId ? (
+                        <div className="refund-queue-anchor-banner">
+                            <strong>A4 정산 상세에서 이동됨</strong>
+                            <span>
+                                settlementId 기준으로 연결된 환불만 표시 중{" "}
+                                <CopyableId value={anchorSettlementId} short />
+                            </span>
+                            <ActionButton
+                                type="button"
+                                variant="secondary"
+                                onClick={() => navigate("/admin/refunds")}
+                            >
+                                전체 환불 큐 보기
+                            </ActionButton>
+                        </div>
+                    ) : null}
+
                     <SectionCard title="대기 큐(REQUESTED)">
                         <form onSubmit={handleSearch}>
                             <div className="refund-queue-toolbar">
@@ -1069,8 +1181,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     refundId
                                                     <span className="refund-queue-sort-arrow">
-                                                        {renderSortArrow("refundId")}
-                                                    </span>
+                                                            {renderSortArrow("refundId")}
+                                                        </span>
                                                 </button>
                                             </th>
 
@@ -1084,8 +1196,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     amount
                                                     <span className="refund-queue-sort-arrow">
-                                                        {renderSortArrow("amount")}
-                                                    </span>
+                                                            {renderSortArrow("amount")}
+                                                        </span>
                                                 </button>
                                             </th>
 
@@ -1100,8 +1212,8 @@ export default function RefundQueuePage() {
                                                 >
                                                     requestedAt
                                                     <span className="refund-queue-sort-arrow">
-                                                        {renderSortArrow("requestedAt")}
-                                                    </span>
+                                                            {renderSortArrow("requestedAt")}
+                                                        </span>
                                                 </button>
                                             </th>
                                         </tr>
@@ -1149,7 +1261,9 @@ export default function RefundQueuePage() {
                                                     </td>
 
                                                     <td className="refund-queue-refundable-col">
-                                                        <AmountText value={getAmountValue(row, "refundableAmount")} />
+                                                        <AmountText
+                                                            value={getAmountValue(row, "refundableAmount")}
+                                                        />
                                                     </td>
 
                                                     <td className="refund-queue-datetime-col">

--- a/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
@@ -3,10 +3,8 @@ package com.settleops.domain.refund.api;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionRequestDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionResponseDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
-import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
-import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.global.auth.annotation.LoginAdmin;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -30,40 +28,33 @@ public class AdminRefundController {
     private final RefundAdminService refundAdminService;
     private final RefundAdminQueryService refundAdminQueryService;
     private final RequestIdResolver requestIdResolver;
-    private final RefundTraceEntryQueryService refundTraceEntryQueryService;
 
-    /**
-     * A6 운영 큐 조회(READ).
-     * - status/from/to는 옵션.
-     * - 기준 시각: requestedAt
-     */
     @GetMapping
     public ResponseEntity<PageResponse<AdminRefundListItemDTO>> list(
             @RequestParam(required = false) String status,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) String settlementId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false, defaultValue = "requestedAt") String sortKey,
+            @RequestParam(required = false, defaultValue = "desc") String sortDirection,
             @RequestParam(required = false, defaultValue = "0") Integer page,
             @RequestParam(required = false, defaultValue = "20") Integer size
     ) {
         Pageable pageable = PageableUtils.validateAndCreate(page, size);
 
-        Page<AdminRefundListItemDTO> result =
-                refundAdminQueryService.list(status, from, to, pageable);
+        Page<AdminRefundListItemDTO> result = refundAdminQueryService.list(
+                status,
+                from,
+                to,
+                settlementId,
+                keyword,
+                sortKey,
+                sortDirection,
+                pageable
+        );
 
         return ResponseEntity.ok(PageResponse.from(result));
-    }
-
-    /**
-     * A6 상세에서 A1 Trace 진입용 requestId를 조회한다.
-     * 기본 기준은 최신 non-no-op refund audit requestId 이다.
-     */
-    @GetMapping("/{refundId}/trace-entry")
-    public ResponseEntity<RefundTraceEntryResponseDTO> getRefundTraceEntry(
-            @PathVariable String refundId
-    ) {
-        return ResponseEntity.ok(
-                refundTraceEntryQueryService.getRefundTraceEntry(refundId)
-        );
     }
 
     @PatchMapping("/{refundId}/approve")

--- a/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
@@ -1,10 +1,14 @@
+// 수정 파일: server/src/main/java/com/settleops/domain/refund/api/AdminRefundController.java
+
 package com.settleops.domain.refund.api;
 
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionRequestDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundDecisionResponseDTO;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.global.auth.annotation.LoginAdmin;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -28,6 +32,7 @@ public class AdminRefundController {
     private final RefundAdminService refundAdminService;
     private final RefundAdminQueryService refundAdminQueryService;
     private final RequestIdResolver requestIdResolver;
+    private final RefundTraceEntryQueryService refundTraceEntryQueryService;
 
     @GetMapping
     public ResponseEntity<PageResponse<AdminRefundListItemDTO>> list(
@@ -57,31 +62,40 @@ public class AdminRefundController {
         return ResponseEntity.ok(PageResponse.from(result));
     }
 
+    @GetMapping("/{refundId}/trace-entry")
+    public ResponseEntity<RefundTraceEntryResponseDTO> getRefundTraceEntry(
+            @PathVariable String refundId
+    ) {
+        return ResponseEntity.ok(
+                refundTraceEntryQueryService.getRefundTraceEntry(refundId)
+        );
+    }
+
     @PatchMapping("/{refundId}/approve")
     public ResponseEntity<AdminRefundDecisionResponseDTO> approve(
             @PathVariable String refundId,
-            @RequestBody @Valid AdminRefundDecisionRequestDTO req,
+            @Valid @RequestBody AdminRefundDecisionRequestDTO request,
             @LoginAdmin String adminId,
-            HttpServletRequest request
+            HttpServletRequest httpServletRequest
     ) {
-        String requestId = requestIdResolver.resolve(request);
+        String requestId = requestIdResolver.resolve(httpServletRequest);
 
         return ResponseEntity.ok(
-                refundAdminService.approve(refundId, adminId, req.getComment(), requestId)
+                refundAdminService.approve(refundId, adminId, request.getComment(), requestId)
         );
     }
 
     @PatchMapping("/{refundId}/reject")
     public ResponseEntity<AdminRefundDecisionResponseDTO> reject(
             @PathVariable String refundId,
-            @RequestBody @Valid AdminRefundDecisionRequestDTO req,
+            @Valid @RequestBody AdminRefundDecisionRequestDTO request,
             @LoginAdmin String adminId,
-            HttpServletRequest request
+            HttpServletRequest httpServletRequest
     ) {
-        String requestId = requestIdResolver.resolve(request);
+        String requestId = requestIdResolver.resolve(httpServletRequest);
 
         return ResponseEntity.ok(
-                refundAdminService.reject(refundId, adminId, req.getComment(), requestId)
+                refundAdminService.reject(refundId, adminId, request.getComment(), requestId)
         );
     }
 }

--- a/server/src/main/java/com/settleops/domain/refund/api/dto/RefundTraceEntryResponseDTO.java
+++ b/server/src/main/java/com/settleops/domain/refund/api/dto/RefundTraceEntryResponseDTO.java
@@ -2,9 +2,11 @@ package com.settleops.domain.refund.api.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 public class RefundTraceEntryResponseDTO {
-    private final String traceRequestId;
+    private String traceRequestId;
 }

--- a/server/src/main/java/com/settleops/domain/refund/application/RefundAdminQueryService.java
+++ b/server/src/main/java/com/settleops/domain/refund/application/RefundAdminQueryService.java
@@ -13,12 +13,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Locale;
 
-/**
- * A6 운영 큐 조회(READ).
- * - status/from/to 옵션 파라미터를 "조회 조건"으로 정리해서 QueryDSL Repository로 전달한다.
- * - 기준 시각 SoT: refund.requestedAt (DB: requested_at)
- * - status는 enum(@Enumerated STRING)이라 enum으로 파싱 후 전달한다.
- */
 @Service
 @RequiredArgsConstructor
 public class RefundAdminQueryService {
@@ -29,6 +23,10 @@ public class RefundAdminQueryService {
             String status,
             LocalDate from,
             LocalDate to,
+            String settlementId,
+            String keyword,
+            String sortKey,
+            String sortDirection,
             Pageable pageable
     ) {
         RefundStatus parsedStatus = parseStatus(status);
@@ -37,10 +35,26 @@ public class RefundAdminQueryService {
             throw new BadRequestException("from must be <= to");
         }
 
+        String normalizedSettlementId = settlementId == null ? null : settlementId.trim();
+        String normalizedKeyword = keyword == null ? null : keyword.trim();
+
+        if (normalizedSettlementId != null && normalizedSettlementId.isEmpty()) {
+            throw new BadRequestException("settlementId is invalid");
+        }
+
         LocalDateTime fromDt = (from == null) ? null : from.atStartOfDay();
         LocalDateTime toDt = (to == null) ? null : to.atTime(23, 59, 59, 999_999_000);
 
-        return refundReadRepository.findAdminRefundQueue(parsedStatus, fromDt, toDt, pageable);
+        return refundReadRepository.findAdminRefundQueue(
+                parsedStatus,
+                fromDt,
+                toDt,
+                normalizedSettlementId,
+                normalizedKeyword,
+                sortKey,
+                sortDirection,
+                pageable
+        );
     }
 
     private RefundStatus parseStatus(String status) {

--- a/server/src/main/java/com/settleops/domain/refund/application/RefundTraceEntryQueryService.java
+++ b/server/src/main/java/com/settleops/domain/refund/application/RefundTraceEntryQueryService.java
@@ -16,12 +16,12 @@ public class RefundTraceEntryQueryService {
     private final RefundTraceQueryRepository refundTraceQueryRepository;
 
     public RefundTraceEntryResponseDTO getRefundTraceEntry(String refundId) {
+
         if (refundId == null || refundId.isBlank()) {
             throw new BadRequestException("refundId must not be null/blank");
         }
 
-        boolean exists = refundTraceQueryRepository.existsRefund(refundId);
-        if (!exists) {
+        if (!refundTraceQueryRepository.existsRefund(refundId)) {
             throw new NotFoundException("refund not found");
         }
 

--- a/server/src/main/java/com/settleops/domain/refund/infra/RefundReadRepository.java
+++ b/server/src/main/java/com/settleops/domain/refund/infra/RefundReadRepository.java
@@ -37,6 +37,10 @@ public class RefundReadRepository {
             RefundStatus status,
             LocalDateTime from,
             LocalDateTime to,
+            String settlementId,
+            String keyword,
+            String sortKey,
+            String sortDirection,
             Pageable pageable
     ) {
         BooleanBuilder where = new BooleanBuilder();
@@ -53,9 +57,31 @@ public class RefundReadRepository {
             where.and(refund.requestedAt.loe(to));
         }
 
+        if (keyword != null && !keyword.isBlank()) {
+            String trimmedKeyword = keyword.trim();
+            where.and(
+                    refund.refundId.containsIgnoreCase(trimmedKeyword)
+                            .or(refund.paymentId.containsIgnoreCase(trimmedKeyword))
+            );
+        }
+
         QPayment payment = QPayment.payment;
         QSettlementLine settlementLine = QSettlementLine.settlementLine;
         QRefund approvedRefund = new QRefund("approvedRefund");
+
+        if (settlementId != null && !settlementId.isBlank()) {
+            where.and(
+                    refund.paymentId.in(
+                            JPAExpressions
+                                    .select(settlementLine.paymentId)
+                                    .from(settlementLine)
+                                    .where(
+                                            settlementLine.settlementId.eq(settlementId),
+                                            settlementLine.lineType.eq(SettlementLineType.PAYMENT)
+                                    )
+                    )
+            );
+        }
 
         List<AdminRefundListItemDTO> content =
                 queryFactory
@@ -89,7 +115,7 @@ public class RefundReadRepository {
                         .from(refund)
                         .join(payment).on(payment.paymentId.eq(refund.paymentId))
                         .where(where)
-                        .orderBy(refund.requestedAt.desc())
+                        .orderBy(resolveAdminRefundSort(sortKey, sortDirection))
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize())
                         .fetch();
@@ -173,7 +199,7 @@ public class RefundReadRepository {
         );
     }
 
-    private OrderSpecifier<?> resolveMyRefundSort(String sortKey, String sortDirection) {
+    private OrderSpecifier<?> resolveAdminRefundSort(String sortKey, String sortDirection) {
         boolean asc = "asc".equalsIgnoreCase(sortDirection);
         Order order = asc ? Order.ASC : Order.DESC;
 
@@ -188,4 +214,18 @@ public class RefundReadRepository {
         return new OrderSpecifier<>(order, expression);
     }
 
+    private OrderSpecifier<?> resolveMyRefundSort(String sortKey, String sortDirection) {
+        boolean asc = "asc".equalsIgnoreCase(sortDirection);
+        Order order = asc ? Order.ASC : Order.DESC;
+
+        ComparableExpressionBase<?> expression = switch (sortKey) {
+            case "refundId" -> refund.refundId;
+            case "amount", "refundAmount" -> refund.amount;
+            case "requestedAt" -> refund.requestedAt;
+            case "decidedAt" -> refund.decidedAt;
+            default -> refund.requestedAt;
+        };
+
+        return new OrderSpecifier<>(order, expression);
+    }
 }

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
@@ -1,8 +1,10 @@
 package com.settleops.domain.refund.api;
 
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
+import com.settleops.domain.refund.api.dto.RefundTraceEntryResponseDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
+import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.domain.refund.domain.RefundStatus;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -22,30 +24,32 @@ import static org.mockito.Mockito.mock;
 class AdminRefundControllerPaginationTest {
 
     @Test
-    @DisplayName("환불 큐 조회는 PageResponse 형태로 반환한다")
+    @DisplayName("환불 큐 조회는 페이지 응답을 반환한다")
     void list_returnsPageResponse() {
         RefundAdminService refundAdminService = mock(RefundAdminService.class);
         RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
         RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
+        RefundTraceEntryQueryService refundTraceEntryQueryService = mock(RefundTraceEntryQueryService.class);
 
         AdminRefundController controller =
                 new AdminRefundController(
                         refundAdminService,
                         refundAdminQueryService,
-                        requestIdResolver
+                        requestIdResolver,
+                        refundTraceEntryQueryService
                 );
 
         AdminRefundListItemDTO item = new AdminRefundListItemDTO(
-                "rfd-1",
-                "pay-1",
-                "stl-1",
+                "refund-1",
+                "payment-1",
+                "settlement-1",
                 "merchant-1",
                 1000L,
-                10000L,
-                9000L,
+                1000L,
+                1000L,
                 RefundStatus.REQUESTED,
-                "test reason",
-                LocalDateTime.now(),
+                "reason-text",
+                LocalDateTime.of(2026, 3, 25, 1, 0),
                 null
         );
 
@@ -94,12 +98,14 @@ class AdminRefundControllerPaginationTest {
         RefundAdminService refundAdminService = mock(RefundAdminService.class);
         RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
         RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
+        RefundTraceEntryQueryService refundTraceEntryQueryService = mock(RefundTraceEntryQueryService.class);
 
         AdminRefundController controller =
                 new AdminRefundController(
                         refundAdminService,
                         refundAdminQueryService,
-                        requestIdResolver
+                        requestIdResolver,
+                        refundTraceEntryQueryService
                 );
 
         PageRequest pageable = PageRequest.of(0, 20);
@@ -140,5 +146,32 @@ class AdminRefundControllerPaginationTest {
                 "desc",
                 pageable
         );
+    }
+
+    @Test
+    @DisplayName("A6 trace-entry 조회는 traceRequestId를 반환한다")
+    void getRefundTraceEntry_returnsTraceRequestId() {
+        RefundAdminService refundAdminService = mock(RefundAdminService.class);
+        RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
+        RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
+        RefundTraceEntryQueryService refundTraceEntryQueryService = mock(RefundTraceEntryQueryService.class);
+
+        AdminRefundController controller =
+                new AdminRefundController(
+                        refundAdminService,
+                        refundAdminQueryService,
+                        requestIdResolver,
+                        refundTraceEntryQueryService
+                );
+
+        Mockito.when(refundTraceEntryQueryService.getRefundTraceEntry("refund-1"))
+                .thenReturn(new RefundTraceEntryResponseDTO("req-123"));
+
+        ResponseEntity<RefundTraceEntryResponseDTO> response =
+                controller.getRefundTraceEntry("refund-1");
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTraceRequestId()).isEqualTo("req-123");
     }
 }

--- a/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/api/AdminRefundControllerPaginationTest.java
@@ -3,7 +3,6 @@ package com.settleops.domain.refund.api;
 import com.settleops.domain.refund.api.dto.AdminRefundListItemDTO;
 import com.settleops.domain.refund.application.RefundAdminQueryService;
 import com.settleops.domain.refund.application.RefundAdminService;
-import com.settleops.domain.refund.application.RefundTraceEntryQueryService;
 import com.settleops.domain.refund.domain.RefundStatus;
 import com.settleops.global.web.RequestIdResolver;
 import com.settleops.global.web.pagination.PageResponse;
@@ -28,15 +27,12 @@ class AdminRefundControllerPaginationTest {
         RefundAdminService refundAdminService = mock(RefundAdminService.class);
         RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
         RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
-        RefundTraceEntryQueryService refundTraceEntryQueryService =
-                mock(RefundTraceEntryQueryService.class);
 
         AdminRefundController controller =
                 new AdminRefundController(
                         refundAdminService,
                         refundAdminQueryService,
-                        requestIdResolver,
-                        refundTraceEntryQueryService
+                        requestIdResolver
                 );
 
         AdminRefundListItemDTO item = new AdminRefundListItemDTO(
@@ -55,11 +51,29 @@ class AdminRefundControllerPaginationTest {
 
         PageRequest pageable = PageRequest.of(0, 20);
 
-        Mockito.when(refundAdminQueryService.list(null, null, null, pageable))
-                .thenReturn(new PageImpl<>(List.of(item), pageable, 1));
+        Mockito.when(refundAdminQueryService.list(
+                null,
+                null,
+                null,
+                null,
+                null,
+                "requestedAt",
+                "desc",
+                pageable
+        )).thenReturn(new PageImpl<>(List.of(item), pageable, 1));
 
         ResponseEntity<PageResponse<AdminRefundListItemDTO>> response =
-                controller.list(null, null, null, 0, 20);
+                controller.list(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "requestedAt",
+                        "desc",
+                        0,
+                        20
+                );
 
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(response.getBody()).isNotNull();
@@ -72,5 +86,59 @@ class AdminRefundControllerPaginationTest {
         assertThat(body.totalPages()).isEqualTo(1);
         assertThat(body.hasNext()).isFalse();
         assertThat(body.hasPrevious()).isFalse();
+    }
+
+    @Test
+    @DisplayName("환불 큐 조회는 settlementId를 service로 그대로 전달한다")
+    void list_should_pass_settlementId() {
+        RefundAdminService refundAdminService = mock(RefundAdminService.class);
+        RefundAdminQueryService refundAdminQueryService = mock(RefundAdminQueryService.class);
+        RequestIdResolver requestIdResolver = mock(RequestIdResolver.class);
+
+        AdminRefundController controller =
+                new AdminRefundController(
+                        refundAdminService,
+                        refundAdminQueryService,
+                        requestIdResolver
+                );
+
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        Mockito.when(refundAdminQueryService.list(
+                null,
+                null,
+                null,
+                "S1",
+                null,
+                "requestedAt",
+                "desc",
+                pageable
+        )).thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        ResponseEntity<PageResponse<AdminRefundListItemDTO>> response =
+                controller.list(
+                        null,
+                        null,
+                        null,
+                        "S1",
+                        null,
+                        "requestedAt",
+                        "desc",
+                        0,
+                        20
+                );
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+
+        Mockito.verify(refundAdminQueryService).list(
+                null,
+                null,
+                null,
+                "S1",
+                null,
+                "requestedAt",
+                "desc",
+                pageable
+        );
     }
 }

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundReadRepositoryTest.java
@@ -40,7 +40,6 @@ class RefundReadRepositoryTest {
     @Test
     @DisplayName("A6 환불 큐 조회는 offset/limit/count 기준으로 pagination 된다")
     void findAdminRefundQueue_appliesPagination() {
-        // given
         LocalDateTime base = LocalDateTime.of(2026, 3, 22, 10, 0, 0);
 
         insertPaymentAndRefund(
@@ -64,25 +63,23 @@ class RefundReadRepositoryTest {
                 base.minusMinutes(5), null
         );
 
-        PageRequest pageable = PageRequest.of(1, 2); // 두 번째 페이지, 2개씩
+        PageRequest pageable = PageRequest.of(1, 2);
 
-        // when
         Page<AdminRefundListItemDTO> result = refundReadRepository.findAdminRefundQueue(
                 RefundStatus.REQUESTED,
                 null,
                 null,
+                null,
+                null,
+                "requestedAt",
+                "desc",
                 pageable
         );
 
-        // then
-        // total count
         assertThat(result.getTotalElements()).isEqualTo(5);
         assertThat(result.getTotalPages()).isEqualTo(3);
-
-        // limit
         assertThat(result.getContent()).hasSize(2);
 
-        // offset + 정렬(requestedAt desc) 기준
         List<AdminRefundListItemDTO> content = result.getContent();
         assertThat(content.get(0).getRefundId()).isEqualTo("refund-003");
         assertThat(content.get(1).getRefundId()).isEqualTo("refund-004");
@@ -91,7 +88,6 @@ class RefundReadRepositoryTest {
     @Test
     @DisplayName("A6 환불 큐 조회는 status 조건과 pagination을 함께 적용한다")
     void findAdminRefundQueue_filtersByStatus_withPagination() {
-        // given
         LocalDateTime base = LocalDateTime.of(2026, 3, 22, 11, 0, 0);
 
         insertPaymentAndRefund(
@@ -117,15 +113,17 @@ class RefundReadRepositoryTest {
 
         PageRequest pageable = PageRequest.of(0, 2);
 
-        // when
         Page<AdminRefundListItemDTO> result = refundReadRepository.findAdminRefundQueue(
                 RefundStatus.REQUESTED,
                 null,
                 null,
+                null,
+                null,
+                "requestedAt",
+                "desc",
                 pageable
         );
 
-        // then
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getTotalPages()).isEqualTo(2);
         assertThat(result.getContent()).hasSize(2);
@@ -137,6 +135,94 @@ class RefundReadRepositoryTest {
         assertThat(result.getContent())
                 .extracting(AdminRefundListItemDTO::getRefundId)
                 .containsExactly("refund-a1", "refund-a2");
+    }
+
+    @Test
+    @DisplayName("A4→A6 settlementId 앵커 조회는 settlement_line PAYMENT 기준으로 refund 후보를 필터한다")
+    void findAdminRefundQueue_filtersBySettlementId_anchor() {
+        LocalDateTime base = LocalDateTime.now();
+
+        insertPaymentAndRefund(
+                "refund-s1",
+                "payment-s1",
+                "merchant-1",
+                "buyer-1",
+                1000L,
+                "REQUESTED",
+                base,
+                null
+        );
+
+        insertPaymentAndRefund(
+                "refund-s2",
+                "payment-s2",
+                "merchant-1",
+                "buyer-2",
+                1000L,
+                "REQUESTED",
+                base.minusMinutes(1),
+                null
+        );
+
+        insertSettlementLinePayment("S1", "payment-s1", 1000L);
+        insertSettlementLinePayment("S2", "payment-s2", 1000L);
+
+        Page<AdminRefundListItemDTO> result =
+                refundReadRepository.findAdminRefundQueue(
+                        RefundStatus.REQUESTED,
+                        null,
+                        null,
+                        "S1",
+                        null,
+                        "requestedAt",
+                        "desc",
+                        PageRequest.of(0, 10)
+                );
+
+        assertThat(result.getContent())
+                .extracting(AdminRefundListItemDTO::getRefundId)
+                .containsExactly("refund-s1");
+    }
+
+    @Test
+    @DisplayName("U6 내 환불 목록 조회는 로그인 merchant 범위만 반환한다")
+    void findMyRefunds_filtersByMerchantId() {
+        LocalDateTime base = LocalDateTime.of(2026, 3, 22, 12, 0, 0);
+
+        insertPaymentAndRefund(
+                "refund-m1-1", "payment-m1-1", "merchant-1", "buyer-1", 1000L, "REQUESTED",
+                base.minusMinutes(1), null
+        );
+        insertPaymentAndRefund(
+                "refund-m1-2", "payment-m1-2", "merchant-1", "buyer-2", 2000L, "APPROVED",
+                base.minusMinutes(2), base.minusMinutes(1)
+        );
+        insertPaymentAndRefund(
+                "refund-m2-1", "payment-m2-1", "merchant-2", "buyer-3", 3000L, "REQUESTED",
+                base.minusMinutes(3), null
+        );
+
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Page<RefundRowDTO> result = refundReadRepository.findMyRefunds(
+                "merchant-1",
+                null,
+                null,
+                null,
+                null,
+                "requestedAt",
+                "desc",
+                pageable
+        );
+
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent())
+                .extracting(RefundRowDTO::getMerchantId)
+                .containsOnly("merchant-1");
+
+        assertThat(result.getContent())
+                .extracting(RefundRowDTO::getRefundId)
+                .containsExactly("refund-m1-1", "refund-m1-2");
     }
 
     private void insertPaymentAndRefund(
@@ -190,48 +276,24 @@ class RefundReadRepositoryTest {
         );
     }
 
-    @Test
-    @DisplayName("U6 내 환불 목록 조회는 로그인 merchant 범위만 반환한다")
-    void findMyRefunds_filtersByMerchantId() {
-        // given
-        LocalDateTime base = LocalDateTime.of(2026, 3, 22, 12, 0, 0);
+    private void insertSettlementLinePayment(
+            String settlementId,
+            String paymentId,
+            long amount
+    ) {
+        String now = LocalDateTime.now().format(MYSQL_DT6);
 
-        insertPaymentAndRefund(
-                "refund-m1-1", "payment-m1-1", "merchant-1", "buyer-1", 1000L, "REQUESTED",
-                base.minusMinutes(1), null
+        jdbcTemplate.update("""
+            insert into settlement_line (
+                settlement_id, line_type, payment_id, amount, created_at
+            )
+            values (?, 'PAYMENT', ?, ?, ?)
+            """,
+                settlementId,
+                paymentId,
+                amount,
+                now
         );
-        insertPaymentAndRefund(
-                "refund-m1-2", "payment-m1-2", "merchant-1", "buyer-2", 2000L, "APPROVED",
-                base.minusMinutes(2), base.minusMinutes(1)
-        );
-        insertPaymentAndRefund(
-                "refund-m2-1", "payment-m2-1", "merchant-2", "buyer-3", 3000L, "REQUESTED",
-                base.minusMinutes(3), null
-        );
-
-        PageRequest pageable = PageRequest.of(0, 10);
-
-        // when
-        Page<RefundRowDTO> result = refundReadRepository.findMyRefunds(
-                "merchant-1",
-                null,
-                null,
-                null,
-                null,
-                "requestedAt",
-                "desc",
-                pageable
-        );
-
-        // then
-        assertThat(result.getTotalElements()).isEqualTo(2);
-        assertThat(result.getContent())
-                .extracting(RefundRowDTO::getMerchantId)
-                .containsOnly("merchant-1");
-
-        assertThat(result.getContent())
-                .extracting(RefundRowDTO::getRefundId)
-                .containsExactly("refund-m1-1", "refund-m1-2");
     }
 
     @SuppressWarnings("unused")

--- a/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
+++ b/server/src/test/java/com/settleops/domain/refund/infra/RefundSettlementReadRepositoryTest.java
@@ -6,9 +6,12 @@ import com.settleops.domain.refund.domain.Refund;
 import com.settleops.domain.refund.domain.RefundSettlementLink;
 import com.settleops.domain.refund.domain.RefundStatus;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import com.settleops.domain.settlement.entity.SettlementLine;
 import com.settleops.domain.settlement.enums.SettlementLineType;
@@ -32,6 +35,8 @@ class RefundSettlementReadRepositoryTest {
 
     @jakarta.annotation.Resource
     private RefundSettlementReadRepository repository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @org.springframework.boot.test.context.TestConfiguration
     static class TestConfig {
@@ -425,4 +430,12 @@ class RefundSettlementReadRepositoryTest {
 
         assertThat(result).isFalse();
     }
+
+    @BeforeEach
+    void cleanUp() {
+        jdbcTemplate.update("delete from refund_settlement_link");
+        jdbcTemplate.update("delete from refund");
+        jdbcTemplate.update("delete from payment");
+    }
+
 }


### PR DESCRIPTION
## What

A4 정산 상세 → A6 환불 큐 이동 시 settlementId 앵커 전달 연동
A6 환불 큐 조회 API에 settlementId, keyword, sortKey, sortDirection 필터 추가
A6 QueryDSL 조회에서 settlement_line(PAYMENT)의 payment_id 기준으로 refund 후보 필터 추가
RefundQueuePage에 앵커 배너 추가 및 settlementId 기준 목록 조회 반영
앵커 변경 시 선택 환불/코멘트/traceRequestId/오류 상태 초기화
A6 pagination/controller/repository 테스트 시그니처 최신화 및 settlement 앵커 테스트 추가

## Why

settlementId는 운영팀 작업 시작점(앵커)이며 A4 정산 상세에서 A6 환불 큐로 이어지는 흐름이 필요함
A4/A6의 refund 후보 식별은 settlement의 PAYMENT line(payment_id) 기준으로 수행해야 함
A6는 목록 조회형 API이므로 page/size와 추가 query param을 camelCase로 유지하고 QueryDSL 읽기 전용 조회 규칙을 따라야 함
request_id 책임은 Filter/Resolver에 두고, 이번 변경은 조회 앵커 연동만 추가해 책임 경계를 유지함

## Scope

Refund 도메인(C 파트) A6 환불 큐 조회/프론트 앵커 연동 범위
프론트: refundApi.js, RefundQueuePage.jsx
백엔드: AdminRefundController, RefundAdminQueryService, RefundReadRepository
테스트: AdminRefundControllerPaginationTest, RefundReadRepositoryTest
refund 반영 완료 SoT(refund_settlement_link) 판정 로직 변경 없음
approve/reject no-op 200 최소필드/감사 로그 정책 변경 없음