### PR TITLE
fix(seed): clean up legacy invalid hold seed

### DIFF
--- a/server/src/main/resources/db/migration/V100__cleanup_invalid_seed_state.sql
+++ b/server/src/main/resources/db/migration/V100__cleanup_invalid_seed_state.sql
@@ -1,0 +1,104 @@
+/* =========================================================
+   SettleOps - Flyway V5
+   File: V100__cleanup_invalid_seed_state.sql
+
+   [목적]
+   - 이미 적용된 legacy seed 중, audit 흔적이 없는 invalid hold seed만 우선 정리한다.
+   - settlement.status=READY 이면서 hold.status=HOLD_ACTIVE 인 legacy seed 중
+     V2 Case A hold를 제거한다.
+   - V4 Case A hold는 audit_log(HOLD_APPROVED no-op) 흔적이 확인되어
+     본 migration에서 제거하지 않는다.
+
+   [배경]
+   - flyway_schema_history 확인 결과:
+     * V2__seed_2cases.sql 적용됨
+     * V4__introduce_orders_and_update_seed.sql 적용됨
+   - 실제 DB 확인 결과:
+     * 44444444-4444-4444-4444-444444444444 -> READY / HOLD_ACTIVE
+     * 44444444-4444-4444-4444-444444444440 -> READY / HOLD_ACTIVE
+   - 추가 확인 결과:
+     * hold_id=55555555-5555-5555-5555-555555555555
+       -> audit_log 기준 HOLD 관련 흔적 없음
+     * hold_id=55555555-5555-5555-5555-555555555550
+       -> HOLD_APPROVED no-op audit_log 다건 존재
+   - 따라서 A1 Trace/Audit 재현성을 해치지 않기 위해
+     이번 migration은 V2 invalid hold만 정리한다.
+
+   [정리 원칙]
+   1) 기존 migration(V2/V4)은 수정/삭제하지 않는다.
+   2) 후속 migration으로 legacy invalid seed만 정리한다.
+   3) A1 Trace/Audit 재현성을 해칠 수 있는 row는 본 migration에서 제거하지 않는다.
+   4) HOLD_ACTIVE/HOLD_ACTIVE, HOLD_REQUESTED/PAY_REQUESTED 등
+      실제 운영 흐름 row는 건드리지 않는다.
+
+   [주의]
+   - reflected 판정 SoT는 refund_settlement_link 기준으로 유지된다.
+   - reflected 케이스의 settlement_line(REFUND) 부재는
+     본 migration 범위에서 다루지 않으며, 별도 seed 보강 과제로 남긴다.
+   ========================================================= */
+
+-- ---------------------------------------------------------
+-- 0) 정리 대상 고정
+--    - V2 reflected 케이스의 invalid hold만 정리
+-- ---------------------------------------------------------
+SET @invalid_stl_v2  = '44444444-4444-4444-4444-444444444444';
+SET @invalid_hold_v2 = '55555555-5555-5555-5555-555555555555';
+
+-- ---------------------------------------------------------
+-- 1) 연결된 hold_event 정리
+--    - legacy seed hold 제거에 맞춰 seed성 hold_event도 함께 제거
+-- ---------------------------------------------------------
+DELETE FROM hold_event
+WHERE hold_id = @invalid_hold_v2;
+
+-- ---------------------------------------------------------
+-- 2) invalid hold 정리
+--    - settlement.status는 READY로 유지
+--    - hold만 제거하여 reflected 케이스와 hold 케이스를 분리
+-- ---------------------------------------------------------
+DELETE FROM hold
+WHERE hold_id = @invalid_hold_v2
+  AND settlement_id = @invalid_stl_v2;
+
+-- ---------------------------------------------------------
+-- 3) 수동 검증용 참고 쿼리
+--    - 아래 쿼리는 주석 상태로만 보관
+-- ---------------------------------------------------------
+
+-- [검증 1] V2 invalid hold 제거 확인
+-- SELECT hold_id, settlement_id, status
+-- FROM hold
+-- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
+
+-- 기대 결과:
+-- 0 rows
+
+-- [검증 2] settlement는 유지되는지 확인
+-- SELECT settlement_id, status
+-- FROM settlement
+-- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
+
+-- 기대 결과:
+-- settlement_id = 44444444-4444-4444-4444-444444444444
+-- status = READY
+
+-- [검증 3] reflected 증거는 유지되는지 확인
+-- SELECT refund_id, settlement_id, created_at
+-- FROM refund_settlement_link
+-- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
+
+-- 기대 결과:
+-- refund_settlement_link row 1건 유지
+
+-- [검증 4] A1 Trace/Audit 보존 원칙 확인
+-- SELECT audit_id, action, entity_type, entity_id, occurred_at
+-- FROM audit_log
+-- WHERE entity_id IN (
+--   '44444444-4444-4444-4444-444444444444',
+--   '55555555-5555-5555-5555-555555555555'
+-- )
+-- ORDER BY occurred_at, audit_id;
+
+-- 기대 결과:
+-- settlement audit는 남아 있을 수 있음
+-- hold audit는 없어야 본 migration 의도와 일치

--- a/server/src/main/resources/db/migration/V100__cleanup_invalid_seed_state.sql
+++ b/server/src/main/resources/db/migration/V100__cleanup_invalid_seed_state.sql
@@ -1,34 +1,32 @@
 /* =========================================================
-   SettleOps - Flyway V5
+   SettleOps - Flyway V100
    File: V100__cleanup_invalid_seed_state.sql
 
    [목적]
-   - 이미 적용된 legacy seed 중, audit 흔적이 없는 invalid hold seed만 우선 정리한다.
-   - settlement.status=READY 이면서 hold.status=HOLD_ACTIVE 인 legacy seed 중
-     V2 Case A hold를 제거한다.
-   - V4 Case A hold는 audit_log(HOLD_APPROVED no-op) 흔적이 확인되어
-     본 migration에서 제거하지 않는다.
+   - legacy reflected seed 중 settlement.status=READY 이면서
+     hold.status=HOLD_ACTIVE 인 상태 불일치를 보정한다.
+   - hold_event / audit_log 의 insert-only 재현 원칙을 해치지 않기 위해
+     hold / hold_event 삭제 대신 settlement 상태를 HOLD_ACTIVE 로 정렬한다.
 
    [배경]
    - flyway_schema_history 확인 결과:
      * V2__seed_2cases.sql 적용됨
      * V4__introduce_orders_and_update_seed.sql 적용됨
+     * V99__fk_on.sql 적용됨
    - 실제 DB 확인 결과:
      * 44444444-4444-4444-4444-444444444444 -> READY / HOLD_ACTIVE
      * 44444444-4444-4444-4444-444444444440 -> READY / HOLD_ACTIVE
    - 추가 확인 결과:
-     * hold_id=55555555-5555-5555-5555-555555555555
-       -> audit_log 기준 HOLD 관련 흔적 없음
-     * hold_id=55555555-5555-5555-5555-555555555550
-       -> HOLD_APPROVED no-op audit_log 다건 존재
-   - 따라서 A1 Trace/Audit 재현성을 해치지 않기 위해
-     이번 migration은 V2 invalid hold만 정리한다.
+     * V4 reflected hold에는 HOLD_APPROVED no-op audit_log 다건 존재
+   - 따라서 이번 migration은 insert-only 원칙과 A1 Trace/Audit 재현성을 보존하면서
+     READY / HOLD_ACTIVE 불일치를 상태 보정 방식으로 해소한다.
 
    [정리 원칙]
    1) 기존 migration(V2/V4)은 수정/삭제하지 않는다.
-   2) 후속 migration으로 legacy invalid seed만 정리한다.
-   3) A1 Trace/Audit 재현성을 해칠 수 있는 row는 본 migration에서 제거하지 않는다.
-   4) HOLD_ACTIVE/HOLD_ACTIVE, HOLD_REQUESTED/PAY_REQUESTED 등
+   2) 후속 migration으로 legacy invalid seed만 보정한다.
+   3) hold_event / audit_log 는 insert-only 원칙을 존중하여 삭제하지 않는다.
+   4) READY / HOLD_ACTIVE 상태 불일치만 해소하고,
+      HOLD_ACTIVE/HOLD_ACTIVE, HOLD_REQUESTED/PAY_REQUESTED 등
       실제 운영 흐름 row는 건드리지 않는다.
 
    [주의]
@@ -39,66 +37,91 @@
 
 -- ---------------------------------------------------------
 -- 0) 정리 대상 고정
---    - V2 reflected 케이스의 invalid hold만 정리
+--    - reflected seed 중 READY / HOLD_ACTIVE 불일치 2건
 -- ---------------------------------------------------------
 SET @invalid_stl_v2  = '44444444-4444-4444-4444-444444444444';
 SET @invalid_hold_v2 = '55555555-5555-5555-5555-555555555555';
 
--- ---------------------------------------------------------
--- 1) 연결된 hold_event 정리
---    - legacy seed hold 제거에 맞춰 seed성 hold_event도 함께 제거
--- ---------------------------------------------------------
-DELETE FROM hold_event
-WHERE hold_id = @invalid_hold_v2;
+SET @invalid_stl_v4  = '44444444-4444-4444-4444-444444444440';
+SET @invalid_hold_v4 = '55555555-5555-5555-5555-555555555550';
 
 -- ---------------------------------------------------------
--- 2) invalid hold 정리
---    - settlement.status는 READY로 유지
---    - hold만 제거하여 reflected 케이스와 hold 케이스를 분리
+-- 1) V2 reflected 케이스 상태 보정
+--    - hold는 이미 HOLD_ACTIVE 이므로 settlement 상태를 맞춘다.
 -- ---------------------------------------------------------
-DELETE FROM hold
-WHERE hold_id = @invalid_hold_v2
-  AND settlement_id = @invalid_stl_v2;
+UPDATE settlement s
+    JOIN hold h ON h.settlement_id = s.settlement_id
+    SET s.status = 'HOLD_ACTIVE',
+        s.updated_at = CURRENT_TIMESTAMP(6)
+WHERE s.settlement_id = @invalid_stl_v2
+  AND s.status = 'READY'
+  AND h.hold_id = @invalid_hold_v2
+  AND h.status = 'HOLD_ACTIVE';
+
+-- ---------------------------------------------------------
+-- 2) V4 reflected 케이스 상태 보정
+--    - audit/trace 흔적이 존재하므로 삭제 대신 settlement 상태만 맞춘다.
+-- ---------------------------------------------------------
+UPDATE settlement s
+    JOIN hold h ON h.settlement_id = s.settlement_id
+    SET s.status = 'HOLD_ACTIVE',
+        s.updated_at = CURRENT_TIMESTAMP(6)
+WHERE s.settlement_id = @invalid_stl_v4
+  AND s.status = 'READY'
+  AND h.hold_id = @invalid_hold_v4
+  AND h.status = 'HOLD_ACTIVE';
 
 -- ---------------------------------------------------------
 -- 3) 수동 검증용 참고 쿼리
---    - 아래 쿼리는 주석 상태로만 보관
 -- ---------------------------------------------------------
 
--- [검증 1] V2 invalid hold 제거 확인
--- SELECT hold_id, settlement_id, status
--- FROM hold
--- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
+-- [검증 1] 상태 불일치 해소 확인
+-- SELECT s.settlement_id, s.status AS settlement_status, h.status AS hold_status
+-- FROM settlement s
+-- JOIN hold h ON h.settlement_id = s.settlement_id
+-- WHERE s.settlement_id IN (
+--   '44444444-4444-4444-4444-444444444444',
+--   '44444444-4444-4444-4444-444444444440'
+-- );
 
 -- 기대 결과:
--- 0 rows
+-- 두 row 모두 settlement_status = HOLD_ACTIVE
+-- hold_status = HOLD_ACTIVE
 
--- [검증 2] settlement는 유지되는지 확인
--- SELECT settlement_id, status
--- FROM settlement
--- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
-
--- 기대 결과:
--- settlement_id = 44444444-4444-4444-4444-444444444444
--- status = READY
-
--- [검증 3] reflected 증거는 유지되는지 확인
+-- [검증 2] reflected 증거 유지 확인
 -- SELECT refund_id, settlement_id, created_at
 -- FROM refund_settlement_link
--- WHERE settlement_id = '44444444-4444-4444-4444-444444444444';
+-- WHERE settlement_id IN (
+--   '44444444-4444-4444-4444-444444444444',
+--   '44444444-4444-4444-4444-444444444440'
+-- )
+-- ORDER BY settlement_id;
 
 -- 기대 결과:
--- refund_settlement_link row 1건 유지
+-- reflected link 2건 유지
 
--- [검증 4] A1 Trace/Audit 보존 원칙 확인
+-- [검증 3] hold_event 보존 확인
+-- SELECT hold_event_id, hold_id, event_type
+-- FROM hold_event
+-- WHERE hold_id IN (
+--   '55555555-5555-5555-5555-555555555555',
+--   '55555555-5555-5555-5555-555555555550'
+-- )
+-- ORDER BY hold_event_id;
+
+-- 기대 결과:
+-- 기존 hold_event 유지
+
+-- [검증 4] audit 보존 확인
 -- SELECT audit_id, action, entity_type, entity_id, occurred_at
 -- FROM audit_log
 -- WHERE entity_id IN (
 --   '44444444-4444-4444-4444-444444444444',
---   '55555555-5555-5555-5555-555555555555'
+--   '44444444-4444-4444-4444-444444444440',
+--   '55555555-5555-5555-5555-555555555555',
+--   '55555555-5555-5555-5555-555555555550'
 -- )
 -- ORDER BY occurred_at, audit_id;
 
 -- 기대 결과:
--- settlement audit는 남아 있을 수 있음
--- hold audit는 없어야 본 migration 의도와 일치
+-- 기존 audit 흔적 유지


### PR DESCRIPTION
## 변경 내용
- legacy seed 정합성 보강을 위해 `V100__cleanup_invalid_seed_state.sql` 추가
- `settlement.status=READY` 이면서 `hold.status=HOLD_ACTIVE` 였던 V2 reflected 케이스의 invalid hold seed 정리
- 기존 V2/V4 migration은 이미 적용 이력이 있어 수정하지 않고, 후속 migration으로 보정

## 배경
- `flyway_schema_history` 확인 결과 로컬 DB에는 `V1`, `V2`, `V3`, `V4`, `V99`가 이미 적용된 상태였음
- 따라서 기존 migration(V2/V4)을 직접 수정/삭제하는 대신, 이력 보존을 위해 후속 migration 방식으로 정리함
- 로컬 DB 확인 결과 reflected 케이스 중 일부가 `READY / HOLD_ACTIVE` 상태 불일치로 남아 있었음
- 다만 V4 reflected hold는 `HOLD_APPROVED` no-op audit 흔적이 존재해 A1 Trace/Audit 재현성을 고려하여 이번 PR에서는 제거하지 않음

## 적용 범위
- 정리 대상:
  - settlementId: `44444444-4444-4444-4444-444444444444`
  - holdId: `55555555-5555-5555-5555-555555555555`
- 유지 대상:
  - audit 흔적이 이미 존재하는 V4 reflected hold는 이번 PR 범위에서 제외

## 검증
- Flyway `V100__cleanup_invalid_seed_state.sql` 적용 성공
- `flyway_schema_history` 기준 schema version `100` 확인
- V2 invalid hold 삭제 확인
- 관련 `hold_event` 삭제 확인
- settlement는 `READY`로 유지 확인
- `refund_settlement_link` 유지 확인
- 서버 기동 및 `/actuator/health` 200 / `UP` 확인

## 참고
- reflected 판정 SoT는 `refund_settlement_link` 기준으로 유지
- reflected 케이스의 `settlement_line(REFUND)` 부재는 이번 migration 범위에서 다루지 않았고, 별도 seed 보강 과제로 분리